### PR TITLE
docs: Updated the documentation for express deployment

### DIFF
--- a/src/content/docs/docs/auth.md
+++ b/src/content/docs/docs/auth.md
@@ -266,18 +266,18 @@ export const selfSummaryFlow = ai.defineFlow(
 You could secure a simple "flow server" express app by writing:
 
 ```ts
-import { apiKey } from 'genkit';
-import { startFlowServer, withContext } from '@genkit-ai/express';
+import { apiKey } from 'genkit/context';
+import { startFlowServer, withContextProvider } from '@genkit-ai/express';
 
 startFlowServer({
-  flows: [withContext(selfSummaryFlow, apiKey(process.env.REQUIRED_API_KEY))],
+  flows: [withContextProvider(selfSummaryFlow, apiKey(process.env.REQUIRED_API_KEY))],
 });
 ```
 
 Or you could build a custom express application using the same tools:
 
 ```ts
-import { apiKey } from "genkit";
+import { apiKey } from "genkit/context";
 import * as express from "express";
 import { expressHandler } from "@genkit-ai/express;
 


### PR DESCRIPTION
Now the apiKey is exported from genkit/context and withContext is now withContextProvider

The sample code:

```ts
import { ai } from "./model";
import { z } from "genkit";
import { startFlowServer, withContextProvider } from "@genkit-ai/express";
import { apiKey } from "genkit/context";

const prompt = `You are an expert in summarizing YouTube videos.
Your task is to watch the provided YouTube video and generate a concise summary of its content. The summary should capture the main points, key themes, and any important details discussed in the video.`;

const summariseYoutubeVideoFlow = ai.defineFlow(
  {
    name: "summarise-youtube-video",
    inputSchema: z.object({ videoURL: z.string().url() }),
    outputSchema: z.object({ summary: z.string() }),
  },
  async ({ videoURL }) => {
    const { output } = await ai.generate({
      prompt: [
        { text: prompt },
        { media: { url: videoURL, contentType: "video/mp4" } },
      ],
    });
    return output;
  }
);

startFlowServer({
  flows: [
    withContextProvider(
      summariseYoutubeVideoFlow,
      apiKey(process.env.REQUIRED_API_KEY)
    ),
  ],
  port: Number(process.env.PORT) || 8080,
  cors: {
    origin: "*",
    methods: ["GET", "POST"],
    allowedHeaders: ["Content-Type", "Authorization"],
    credentials: true,
  },
});
```