### PR TITLE
docs(observability): Add documentation for environment variable based initialization

### DIFF
--- a/src/content/docs/docs/observability/getting-started.md
+++ b/src/content/docs/docs/observability/getting-started.md
@@ -49,16 +49,25 @@ npm install @genkit-ai/firebase
 
 ### Environment-based configuration
 
-If you intend to use the default configuration for Firebase Genkit Monitoring, you can enable telemetry by setting the `ENABLE_FIREBASE_MONITORING` environment variable.
+If you intend to use the default configuration for Firebase Genkit
+Monitoring, you can enable telemetry by setting the
+`ENABLE_FIREBASE_MONITORING` environment variable in your deployment
+environment.
 
 ```bash
 export ENABLE_FIREBASE_MONITORING=true
 ```
 
+:::note
+This will use default configuration values. To
+override configuration options, use "Programmatic configuration".
+:::
+
 ### Programmatic configuration
 
 You can also enable Firebase Genkit Monitoring in code. This is useful
-if you want to tweak any configuration settings like metric export interval or setting up your local environment to export telemetry.
+if you want to tweak any configuration settings like the metric export
+interval or to set up your local environment to export telemetry data.
 
 Import `enableFirebaseTelemetry` into your Genkit configuration file (the
 file where `genkit(...)` is initalized), and call it:

--- a/src/content/docs/docs/observability/getting-started.md
+++ b/src/content/docs/docs/observability/getting-started.md
@@ -47,6 +47,19 @@ Install the `@genkit-ai/firebase` plugin in your project:
 npm install @genkit-ai/firebase
 ```
 
+### Environment-based configuration
+
+If you intend to use the default configuration for Firebase Genkit Monitoring, you can enable telemetry by setting the `ENABLE_FIREBASE_MONITORING` environment variable.
+
+```bash
+export ENABLE_FIREBASE_MONITORING=true
+```
+
+### Programmatic configuration
+
+You can also enable Firebase Genkit Monitoring in code. This is useful
+if you want to tweak any configuration settings like metric export interval or setting up your local environment to export telemetry.
+
 Import `enableFirebaseTelemetry` into your Genkit configuration file (the
 file where `genkit(...)` is initalized), and call it:
 


### PR DESCRIPTION
We recently made a change that allows customers to initialize Firebase Genkit Monitoring via an environment variable (https://github.com/firebase/genkit/pull/3043).

This updates our documentation to reflect this new capability. It should not go out until the change makes it into the next release.

Testing:
Ran locally with `pnpm run dev`