### PR TITLE
fix(go/cloud-run): correct port binding and curl command format

### DIFF
--- a/src/content/docs/go/docs/cloud-run.md
+++ b/src/content/docs/go/docs/cloud-run.md
@@ -86,7 +86,7 @@ flow.
 
         mux := http.NewServeMux()
         mux.HandleFunc("POST /jokesFlow", genkit.Handler(flow))
-        log.Fatal(server.Start(ctx, "127.0.0.1:"+os.Getenv("PORT"), mux))
+        log.Fatal(server.Start(ctx, "0.0.0.0:"+os.Getenv("PORT"), mux))
     }
     ```
 
@@ -216,7 +216,7 @@ After deployment finishes, the tool will print the service URL. You can test
 it with `curl`:
 
 ```bash
-curl -X POST https://<service-url>/menuSuggestionFlow \
+curl -X POST https://<service-url>/jokesFlow \
   -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
-  -H "Content-Type: application/json" -d '"bananas"'
+  -H "Content-Type: application/json" -d '{"data": "bananas"}'
 ```


### PR DESCRIPTION
## Summary

This PR fixe issues in the Cloud Run deployment documentation for Genkit Go that prevent successful deployment and testing.

## Changes

- Change port binding from `127.0.0.1:PORT` to `0.0.0.0:PORT` for Cloud Run compatibility
- Fix curl endpoint URL from `menuSuggestionFlow` to `jokesFlow` to match the actual flow name
- Update request body format to include `data` wrapper for Genkit handler

## Background

### Port Binding Issue
According to the official [Cloud Run container runtime contract](https://cloud.google.com/run/docs/container-contract#port):
> The ingress container within an instance must listen for requests on 0.0.0.0 on the port to which requests are sent. Notably, the ingress container should not listen on 127.0.0.1.

### Request Format Issue

The Genkit HTTP handler expects requests to be wrapped with a `data` key, consistent with the JavaScript implementation. As shown in the [Genkit JS Cloud Run documentation](https://genkit.dev/docs/cloud-run/#optional-try-the-deployed-flow), the request format should be:
```json
{"data": "input_value"}
```