### PR TITLE
fix(go/docsite): Update go documentation to remove indexers

### DIFF
--- a/src/content/docs/go/docs/plugin-authoring.md
+++ b/src/content/docs/go/docs/plugin-authoring.md
@@ -1,10 +1,10 @@
 ---
 title: Writing Genkit plugins
-description: Learn the fundamentals of creating Genkit plugins in Go to extend its capabilities with new models, retrievers, indexers, and more.
+description: Learn the fundamentals of creating Genkit plugins in Go to extend its capabilities with new models, retrievers, and more.
 ---
 
 Genkit's capabilities are designed to be extended by plugins. Genkit plugins are
-configurable modules that can provide models, retrievers, indexers, trace
+configurable modules that can provide models, retrievers, trace
 stores, and more. You've already seen plugins in action just by using Genkit:
 
 ```go

--- a/src/content/docs/go/docs/plugins/alloydb.md
+++ b/src/content/docs/go/docs/plugins/alloydb.md
@@ -156,4 +156,4 @@ if err != nil {
 
 
 See the [Retrieval-augmented generation](/go/docs/rag) page for a general
-discussion on using indexers and retrievers for RAG.
+discussion on using retrievers for RAG.

--- a/src/content/docs/go/docs/plugins/cloud-sql-pg.md
+++ b/src/content/docs/go/docs/plugins/cloud-sql-pg.md
@@ -150,4 +150,4 @@ if err != nil {
 
 
 See the [Retrieval-augmented generation](/go/docs/rag) page for a general
-discussion on using indexers and retrievers for RAG.
+discussion on using retrievers for RAG.

--- a/src/content/docs/go/docs/plugins/firebase.md
+++ b/src/content/docs/go/docs/plugins/firebase.md
@@ -3,7 +3,7 @@ title: Firebase plugin
 description: Learn how to configure and use the Genkit Firebase plugin for Go to integrate with Firebase services including Firestore for RAG applications.
 ---
 
-The Firebase plugin provides integration with Firebase services for Genkit applications. It enables you to use Firebase Firestore as a vector database for retrieval-augmented generation (RAG) applications by defining retrievers and indexers.
+The Firebase plugin provides integration with Firebase services for Genkit applications. It enables you to use Firebase Firestore as a vector database for retrieval-augmented generation (RAG) applications by defining retrievers.
 
 ## Prerequisites
 

--- a/src/content/docs/go/docs/plugins/google-genai.md
+++ b/src/content/docs/go/docs/plugins/google-genai.md
@@ -164,7 +164,7 @@ if err != nil {
 }
 ```
 
-You can also pass an Embedder to a retriever's `Retrieve()` method:
+You can retrieve docs by passing in an input to a Retriever's `Retrieve()` method:
 
 ```go
 resp, err := ai.Retrieve(ctx, myRetriever, ai.WithDocs(userInput))

--- a/src/content/docs/go/docs/plugins/google-genai.md
+++ b/src/content/docs/go/docs/plugins/google-genai.md
@@ -164,14 +164,7 @@ if err != nil {
 }
 ```
 
-You can also pass an Embedder to an indexer's `Index()` method and a retriever's
-`Retrieve()` method:
-
-```go
-if err := ai.Index(ctx, myIndexer, ai.WithDocs(docsToIndex...)); err != nil {
-      return err
-}
-```
+You can also pass an Embedder to a retriever's `Retrieve()` method:
 
 ```go
 resp, err := ai.Retrieve(ctx, myRetriever, ai.WithDocs(userInput))

--- a/src/content/docs/go/docs/plugins/pinecone.md
+++ b/src/content/docs/go/docs/plugins/pinecone.md
@@ -38,7 +38,7 @@ Configure the plugin to use your API key by doing one of the following:
 
 ## Usage
 
-Index your documents in pinecone. An example of indexing is provided within the pinecone plugin as shown below. This functionality should be customized by the users according to their use cases.
+Index your documents in pinecone. An example of indexing is provided within the Pinecone plugin as shown below. This functionality should be customized by the user according to their use case.
 ```go
 err = pinecone.Index(ctx, docChunks, ds, "")
 if err != nil {

--- a/src/content/docs/go/docs/plugins/pinecone.md
+++ b/src/content/docs/go/docs/plugins/pinecone.md
@@ -3,7 +3,7 @@ title: Pinecone plugin
 description: Learn how to configure and use the Genkit Pinecone plugin for Go to integrate with the Pinecone cloud vector database.
 ---
 
-The Pinecone plugin provides indexer and retriever implementatons that use the
+The Pinecone plugin provides retriever implementatons that use the
 [Pinecone](https://www.pinecone.io/) cloud vector database.
 
 ## Configuration
@@ -38,35 +38,15 @@ Configure the plugin to use your API key by doing one of the following:
 
 ## Usage
 
-To add documents to a Pinecone index, first create an index definition that
-specifies the name of the index and the embedding model you're using:
-
+Index your documents in pinecone. An example of indexing is provided within the pinecone plugin as shown below. This functionality should be customized by the users according to their use cases.
 ```go
-menuIndexer, err := pinecone.DefineIndexer(ctx, g, pinecone.Config{
-	IndexID:  "menu_data",                                           // Your Pinecone index
-	Embedder: googlegenai.GoogleAIEmbedder(g, "text-embedding-004"), // Embedding model of your choice
-})
+err = pinecone.Index(ctx, docChunks, ds, "")
 if err != nil {
 	return err
 }
 ```
 
-You can also optionally specify the key that Pinecone uses for document data
-(`_content`, by default).
-
-Then, call the index's `Index()` method, passing it a list of the documents you
-want to add:
-
-```go
-if err := ai.Index(
-	ctx,
-	menuIndexer,
-	ai.WithDocs(docChunks...)); err != nil {
-	return err
-}
-```
-
-Similarly, to retrieve documents from an index, first create a retriever
+To retrieve documents from an index, first create a retriever
 definition:
 
 ```go
@@ -93,4 +73,4 @@ menuInfo := resp.Documents
 ```
 
 See the [Retrieval-augmented generation](/go/docs/rag) page for a general
-discussion on using indexers and retrievers for RAG.
+discussion on using retrievers for RAG.

--- a/src/content/docs/go/docs/plugins/third-party-plugins/index.mdx
+++ b/src/content/docs/go/docs/plugins/third-party-plugins/index.mdx
@@ -11,7 +11,7 @@ our partners.
 
 <CardGrid stagger>
   <Card title="Pinecone">
-    The Pinecone plugin provides indexer and retriever implementations that use the{' '}
+    The Pinecone plugin provides retriever implementations that use the{' '}
     <a class="inline-flex no-underline not-content items-center" href="https://www.pinecone.io/product/" target="_blank">
       Pinecone
       <Icon name="external" />
@@ -37,7 +37,7 @@ our partners.
     <a href="/go/docs/plugins/pgvector">View template</a>
   </Card>
   <Card title="AlloyDB for PostgreSQL">
-    The AlloyDB plugin provides indexer and retriever implementations that use the{' '}
+    The AlloyDB plugin provides retriever implementations that use the{' '}
     <a class="inline-flex no-underline" href="https://cloud.google.com/alloydb/docs" target="_blank">
       AlloyDB for PostgreSQL
       <Icon name="external" />
@@ -47,7 +47,7 @@ our partners.
     <a href="/go/docs/plugins/alloydb">View plugin info</a>
   </Card>
   <Card title="Cloud SQL for PostgreSQL">
-    The Cloud SQL for PostgreSQL plugin provides indexer and retriever implementations that use the{' '}
+    The Cloud SQL for PostgreSQL plugin provides retriever implementations that use the{' '}
     <a class="inline-flex no-underline" href="https://cloud.google.com/sql/docs/postgres" target="_blank">
       Cloud SQL for PostgreSQL
       <Icon name="external" />

--- a/src/content/docs/go/docs/rag.md
+++ b/src/content/docs/go/docs/rag.md
@@ -41,7 +41,6 @@ RAG is a very broad area and there are many different techniques used to achieve
 the best quality RAG. The core Genkit framework offers two main abstractions to
 help you do RAG:
 
-- Indexers: add documents to an "index".
 - Embedders: transforms documents into a vector representation
 - Retrievers: retrieve documents from an "index", given a query.
 
@@ -49,40 +48,6 @@ These definitions are broad on purpose because Genkit is un-opinionated about
 what an "index" is or how exactly documents are retrieved from it. Genkit only
 provides a `Document` format and everything else is defined by the retriever or
 indexer implementation provider.
-
-### Indexers
-
-The index is responsible for keeping track of your documents in such a way that
-you can quickly retrieve relevant documents given a specific query. This is most
-often accomplished using a vector database, which indexes your documents using
-multidimensional vectors called embeddings. A text embedding (opaquely)
-represents the concepts expressed by a passage of text; these are generated
-using special-purpose ML models. By indexing text using its embedding, a vector
-database is able to cluster conceptually related text and retrieve documents
-related to a novel string of text (the query).
-
-Before you can retrieve documents for the purpose of generation, you need to
-ingest them into your document index. A typical ingestion flow does the
-following:
-
-1.  Split up large documents into smaller documents so that only relevant
-    portions are used to augment your prompts – "chunking". This is necessary
-    because many LLMs have a limited context window, making it impractical to
-    include entire documents with a prompt.
-
-    Genkit doesn't provide built-in chunking libraries; however, there are open
-    source libraries available that are compatible with Genkit.
-
-2.  Generate embeddings for each chunk. Depending on the database you're using,
-    you might explicitly do this with an embedding generation model, or you
-    might use the embedding generator provided by the database.
-
-3.  Add the text chunk and its index to the database.
-
-You might run your ingestion flow infrequently or only once if you are working
-with a stable source of data. On the other hand, if you are working with data
-that frequently changes, you might continuously run the ingestion flow (for
-example, in a Cloud Firestore trigger, whenever a document is updated).
 
 ### Embedders
 
@@ -102,9 +67,9 @@ data.
 To create a retriever, you can use one of the provided implementations or
 create your own.
 
-## Supported indexers, retrievers, and embedders
+## Supported retrievers, and embedders
 
-Genkit provides indexer and retriever support through its plugin system. The
+Genkit provides retriever support through its plugin system. The
 following plugins are officially supported:
 
 - [Pinecone](/go/docs/plugins/pinecone) cloud vector database
@@ -126,6 +91,7 @@ Embedding model support is provided through the following plugins:
 The following examples show how you could ingest a collection of restaurant menu
 PDF documents into a vector database and retrieve them for use in a flow that
 determines what food items are available.
+*Note*: Although retriever functions are defined by genkit, Users are expected to add their own functionality to index the documents.
 
 ### Install dependencies
 
@@ -135,44 +101,6 @@ the `ledongthuc/pdf` PDF parsing Library:
 ```bash
 go get github.com/tmc/langchaingo/textsplitter
 go get github.com/ledongthuc/pdf
-```
-
-### Define an Indexer
-
-The following example shows how to create an indexer to ingest a collection of
-PDF documents and store them in a local vector database.
-
-It uses the local file-based vector similarity retriever that Genkit provides
-out-of-the box for simple testing and prototyping. _Do not use this
-in production._
-
-#### Create the indexer
-
-```go
-// Import Genkit's file-based vector retriever, (Don't use in production.)
-import "github.com/firebase/genkit/go/plugins/localvec"
-
-// Vertex AI provides the text-embedding-004 embedder model.
-import "github.com/firebase/genkit/go/plugins/vertexai"
-```
-
-```go
-ctx := context.Background()
-
-g, err := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
-if err != nil {
-	log.Fatal(err)
-}
-
-if err = localvec.Init(); err != nil {
-	log.Fatal(err)
-}
-
-menuPDFIndexer, _, err := localvec.DefineIndexerAndRetriever(g, "menuQA",
-	  localvec.Config{Embedder: googlegenai.VertexAIEmbedder(g, "text-embedding-004")})
-if err != nil {
-	log.Fatal(err)
-}
 ```
 
 #### Create chunking config
@@ -226,9 +154,7 @@ genkit.DefineFlow(
             return nil, err
         }
 
-        // Add chunks to the index.
-        err = ai.Index(ctx, menuPDFIndexer, ai.WithDocs(docs...))
-        return nil, err
+        // Add chunks to the index using custom index function
     },
 )
 ```
@@ -270,9 +196,8 @@ documents and ready to be used in Genkit flows with retrieval steps.
 
 ### Define a flow with retrieval
 
-The following example shows how you might use a retriever in a RAG flow. Like
-the indexer example, this example uses Genkit's file-based vector retriever,
-which you should not use in production.
+The following example shows how you might use a retriever in a RAG flow. This 
+example uses Genkit's file-based vector retriever, which you should not use in production.
 
 ```go
 ctx := context.Background()
@@ -288,7 +213,7 @@ if err = localvec.Init(); err != nil {
 
 model := googlegenai.VertexAIModel(g, "gemini-1.5-flash")
 
-_, menuPdfRetriever, err := localvec.DefineIndexerAndRetriever(
+_, menuPdfRetriever, err := localvec.DefineRetriever(
     g, "menuQA", localvec.Config{Embedder: googlegenai.VertexAIEmbedder(g, "text-embedding-004")},
 )
 if err != nil {
@@ -315,11 +240,11 @@ You are acting as a helpful AI assistant that can answer questions about the
 food available on the menu at Genkit Grub Pub.
 Use only the context provided to answer the question. If you don't know, do not
 make up an answer. Do not add or change items on the menu.`)
-        ai.WithPrompt(question),
+        ai.WithPrompt(question))
   })
 ```
 
-## Write your own indexers and retrievers
+## Write your own retrievers
 
 It's also possible to create your own retriever. This is useful if your
 documents are managed in a document store that is not supported in Genkit (eg:

--- a/src/content/docs/go/docs/rag.md
+++ b/src/content/docs/go/docs/rag.md
@@ -91,7 +91,7 @@ Embedding model support is provided through the following plugins:
 The following examples show how you could ingest a collection of restaurant menu
 PDF documents into a vector database and retrieve them for use in a flow that
 determines what food items are available.
-*Note*: Although retriever functions are defined by genkit, Users are expected to add their own functionality to index the documents.
+*Note*: Although retriever functions are defined using Genkit, users are expected to add their own functionality to index the documents.
 
 ### Install dependencies
 


### PR DESCRIPTION
- Update go docs to remove references to indexers.
- Added note and examples to ask users to use their custom index functions.