### PR TITLE
Add language-aware table of contents component

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
         Header: "./src/content/custom/header.astro",
         Hero: "./src/content/custom/hero.astro",
         Head: './src/content/custom/head.astro',
+        TableOfContents: './src/components/LanguageAwareTableOfContents.astro',
       },
       head: [
         {

--- a/src/components/LanguageAwareTableOfContents.astro
+++ b/src/components/LanguageAwareTableOfContents.astro
@@ -1,0 +1,147 @@
+---
+// Simple language-aware ToC that filters based on visible content
+const { toc } = Astro.locals.starlightRoute;
+---
+
+{
+	toc && (
+		<starlight-toc data-min-h={toc.minHeadingLevel} data-max-h={toc.maxHeadingLevel}>
+			<nav aria-labelledby="starlight__on-this-page">
+				<h2 id="starlight__on-this-page">{Astro.locals.t('tableOfContents.onThisPage')}</h2>
+				
+				<!-- Inline ToC list with same styling as Starlight -->
+				<ul>
+					{toc.items.map((heading) => (
+						<li>
+							<a href={'#' + heading.slug}>
+								<span>{heading.text}</span>
+							</a>
+							{heading.children.length > 0 && (
+								<ul>
+									{heading.children.map((child) => (
+										<li>
+											<a href={'#' + child.slug}>
+												<span>{child.text}</span>
+											</a>
+										</li>
+									))}
+								</ul>
+							)}
+						</li>
+					))}
+				</ul>
+			</nav>
+		</starlight-toc>
+	)
+}
+
+<script>
+/**
+ * Simple Language-aware ToC Filter
+ * Hides ToC entries when their corresponding headings are hidden by language CSS
+ */
+class LanguageAwareToC {
+	constructor() {
+		// Initialize when DOM is ready
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', () => this.init());
+		} else {
+			this.init();
+		}
+	}
+
+	init() {
+		const tocContainer = document.querySelector('starlight-toc nav');
+		if (!tocContainer) return;
+
+		// Filter ToC immediately and on language changes
+		this.filterToC();
+		this.setupLanguageObserver();
+	}
+
+	filterToC() {
+		// Get all currently visible headings
+		const visibleHeadingIds = new Set();
+		document.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(heading => {
+			if (this.isHeadingVisible(heading) && heading.id) {
+				visibleHeadingIds.add(heading.id);
+			}
+		});
+
+		// Show/hide ToC links based on heading visibility
+		document.querySelectorAll('starlight-toc a[href^="#"]').forEach(link => {
+			const headingId = link.getAttribute('href')?.slice(1);
+			const tocItem = link.closest('li');
+			
+			if (tocItem && headingId) {
+				tocItem.style.display = visibleHeadingIds.has(headingId) ? '' : 'none';
+			}
+		});
+	}
+
+	isHeadingVisible(heading: Element): boolean {
+		const style = window.getComputedStyle(heading);
+		if (style.display === 'none' || style.visibility === 'hidden') {
+			return false;
+		}
+
+		// Check if heading is in a hidden language content block
+		const langContent = heading.closest('.lang-content');
+		if (langContent) {
+			const langStyle = window.getComputedStyle(langContent);
+			return langStyle.display !== 'none' && langStyle.visibility !== 'hidden';
+		}
+
+		return true;
+	}
+
+	setupLanguageObserver() {
+		// Watch for language changes and update ToC
+		const observer = new MutationObserver(() => {
+			setTimeout(() => this.filterToC(), 10);
+		});
+
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-genkit-lang']
+		});
+	}
+}
+
+new LanguageAwareToC();
+</script>
+
+<style>
+/* Use Starlight's existing ToC styles */
+@layer starlight.core {
+	ul {
+		padding: 0;
+		list-style: none;
+	}
+	a {
+		--pad-inline: 0.5rem;
+		display: block;
+		border-radius: 0.25rem;
+		padding-block: 0.25rem;
+		padding-inline: var(--pad-inline);
+		line-height: 1.25;
+	}
+	a[aria-current='true'] {
+		color: var(--sl-color-text-accent);
+	}
+	
+	/* Nested items */
+	ul ul {
+		margin-left: 1rem;
+	}
+	
+	/* Smooth transitions */
+	li {
+		transition: opacity 0.2s ease-out;
+	}
+	li[style*="display: none"] {
+		margin: 0;
+		padding: 0;
+	}
+}
+</style>


### PR DESCRIPTION
Create LanguageAwareTableOfContents.astro component that filters ToC entries based on visible content, hiding links to headings that are hidden by language-specific CSS. Configure component in astro.config.mjs to replace default Starlight ToC.