### PR TITLE
feat(go/docsite): Add docs for vectorsearch using Bigquery and Firestore

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -266,6 +266,26 @@
         "type": 301
       },
       {
+        "source": "/docs/plugins/vectorsearch-bigquery/",
+        "destination": "/docs/integrations/vectorsearch-bigquery/?lang=js",
+        "type": 301
+      },
+      {
+        "source": "/docs/plugins/vectorsearch-bigquery",
+        "destination": "/docs/integrations/vectorsearch-bigquery/?lang=js",
+        "type": 301
+      },
+      {
+        "source": "/docs/plugins/vectorsearch-firestore/",
+        "destination": "/docs/integrations/vectorsearch-firestore/?lang=js",
+        "type": 301
+      },
+      {
+        "source": "/docs/plugins/vectorsearch-firestore",
+        "destination": "/docs/integrations/vectorsearch-firestore/?lang=js",
+        "type": 301
+      },
+      {
         "source": "/docs/plugins/third-party-plugins/",
         "destination": "/",
         "type": 301

--- a/firebase.json
+++ b/firebase.json
@@ -546,6 +546,26 @@
         "type": 301
       },
       {
+        "source": "/go/docs/plugins/vectorsearch-bigquery/",
+        "destination": "/docs/integrations/vectorsearch-bigquery/?lang=go",
+        "type": 301
+      },
+      {
+        "source": "/go/docs/plugins/vectorsearch-bigquery",
+        "destination": "/docs/integrations/vectorsearch-bigquery/?lang=go",
+        "type": 301
+      },
+      {
+        "source": "/go/docs/plugins/vectorsearch-firestore/",
+        "destination": "/docs/integrations/vectorsearch-firestore/?lang=go",
+        "type": 301
+      },
+      {
+        "source": "/go/docs/plugins/vectorsearch-firestore",
+        "destination": "/docs/integrations/vectorsearch-firestore/?lang=go",
+        "type": 301
+      },
+      {
         "source": "/go/docs/plugins/third-party-plugins/",
         "destination": "/?lang=go",
         "type": 301

--- a/src/content/docs/docs/integrations/alloydb.mdx
+++ b/src/content/docs/docs/integrations/alloydb.mdx
@@ -33,8 +33,6 @@ The AlloyDB plugin provides provides the retriever implementation to search a [A
 
 ## Configuration
 
-## Configuration
-
 To use this plugin, follow these steps:
 
 1. Import the plugin

--- a/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
@@ -1,0 +1,159 @@
+---
+title: Vector Search using Bigquery
+description: Learn how to use the GCP Vector search using Bigquery with Genkit.
+---
+
+import LanguageSelector from '../../../../components/LanguageSelector.astro';
+import CopyMarkdownButton from '../../../../components/CopyMarkdownButton.astro';
+import LanguageContent from '../../../../components/LanguageContent.astro';
+
+<div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin: 1rem 0 1rem 0;">
+  <LanguageSelector />
+  <CopyMarkdownButton />
+</div>
+
+<LanguageContent lang="go">
+
+Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Bigquery and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.
+
+## Installation
+
+The vector search functionality is built into Genkit Go. You need to import the [`vectorsearch`](https://pkg.go.dev/github.com/firebase/genkit/go/plugins/vertexai/vectorsearch) package:
+
+```go
+import "github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
+```
+
+## Configuration
+
+1. Create a vector search index in GCP. Details on creating vector search index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
+2. Create a Bigquery Dataset and a Table within that dataset to store the documents that will be indexed. More information to create Bigquery datasets is available [here](https://cloud.google.com/bigquery/docs/datasets)
+
+To use the GCP vector search with Bigquery, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Bigquery dataset:
+
+```go
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
+)
+
+ctx := context.Background()
+
+g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
+
+bqClient, err := bigquery.NewClient(ctx, "your-project-id")
+if err != nil {
+    log.Fatalf("Failed to create BigQuery client: %v", err)
+}
+
+documentIndexer := vectorsearch.GetBigQueryDocumentIndexer(bqClient, "your-dataset-id", "your-table-id")
+documentRetriever := vectorsearch.GetBigQueryDocumentRetriever(bqClient, "your-dataset-id", "your-table-id")
+
+vectorsearchParams := &VectorsearchConfig{
+    ProjectID:         vectorsearchPlugin.ProjectID,
+    Location:          vectorsearchPlugin.Location,
+    IndexID:           "${VECTOR_SEARCH_INDEX_ID}",                           // Replace with your index ID
+    IndexEndpointID:   "${VECTOR_SEARCH_INDEX_ENDPOINT_ID}",                  // Replace with your index endpoint ID
+    DeployedIndexID:   "${VECTOR_SEARCH_DEPLOYED_INDEX_ID}",                  // Replace with your deployed index ID
+    ProjectNumber:     "${GOOGLE_CLOUD_PROJECT_NUMBER}",                      // Replace with your Google Cloud project number
+    PublicDomainName:  "${VECTOR_SEARCH_PUBLIC_DOMAIN_NAME}",                 // Replace with your public domain name
+    Embedder:          googlegenai.VertexAIEmbedder(g, "text-embedding-004"), // Replace with your desired embedder
+    NeighborsCount:    10,                                                    // Number of neighbors to retrieve
+    DocumentIndexer:   documentIndexer,
+    DocumentRetriever: documentRetriever,
+}
+```
+
+### Configuration Options
+
+- **ProjectID** (string): GCP Project ID
+- **Location** (string): GCP Project location
+- **IndexID** (string): Vector search index id
+- **IndexEndpointID** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
+- **DeployedIndexID** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
+- **ProjectNumber** (string): GCP Project Number
+- **PublicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **Embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
+- **NeighborsCount** (int): Number of neighbors to set in the vector search
+- **DocumentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Bigquery. This can be a custom document indexer as well depending on the user's requirement.
+- **DocumentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Bigquery. This can be a custom document retriever as well depending on the user's requirement.
+## Usage
+
+### Indexing Documents
+
+To populate with data, you need to implement your own indexing logic using the [`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document) format. Genkit provides a sample indexing function as well:
+
+```go
+import (
+    "github.com/firebase/genkit/go/ai"
+)
+
+// Create documents from text
+data := []string{
+    "This is the first document.",
+    "This is the second document.",
+    "This is the third document.",
+    "This is the fourth document.",
+}
+
+var docs []*ai.Document
+for _, text := range data {
+	docs = append(docs, ai.DocumentFromText(text, nil))
+}
+
+// Index the docs.
+// Custom Index function can be used which should internally refer the indexer function for Bigquery
+if err := vectorsearch.Index(ctx, g, vectorsearch.IndexParams{
+    IndexID:         vectorsearchParams.IndexID,
+    Embedder:        vectorsearchParams.Embedder,
+    EmbedderOptions: nil,
+    Docs:            docs,
+    ProjectID:       vectorsearchParams.ProjectID,
+    Location:        vectorsearchParams.Location,
+}, vectorsearchParams.DocumentIndexer); err != nil {
+    return nil, err
+}
+```
+
+### Retrieving Documents
+
+Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+
+```go
+// Define the retriever for vector search.
+retriever, err := vectorsearch.DefineRetriever(ctx, g, vectorsearch.Config{
+    IndexID: vectorsearchParams.IndexID, // Replace with your index ID
+}, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+// The retriever defined above has built in function called Retrieve() which 
+// corresponds to vector search retriever function defined in vector search plugin.
+// The DocumentRetriever passed as argument corresponds to the documentretriever 
+// for Bigquery. This function retrieves the docs corresponding to the Neighbor IDs
+// found using vector search index.
+
+resp, err := retriever.Retrieve(ctx, &ai.RetrieverRequest{
+    Query: ai.DocumentFromText(input.Question, nil),
+    Options: &vectorsearch.RetrieveParams{
+        Embedder:          vectorsearchParams.Embedder,
+        NeighborCount:     vectorsearchParams.NeighborsCount,
+        IndexEndpointID:   vectorsearchParams.IndexEndpointID,
+        DeployedIndexID:   vectorsearchParams.DeployedIndexID,
+        PublicDomainName:  vectorsearchParams.PublicDomainName,
+        ProjectNumber:     vectorsearchParams.ProjectNumber,
+        DocumentRetriever: vectorsearchParams.DocumentRetriever,
+    }})
+if err != nil {
+    return nil, err
+}
+```
+
+</LanguageContent>

--- a/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
@@ -12,6 +12,139 @@ import LanguageContent from '../../../../components/LanguageContent.astro';
   <CopyMarkdownButton />
 </div>
 
+<LanguageContent lang="python">
+
+:::note[Feature unavailable for Python]
+Vertex AI Vectorsearch with Bigquery database integration is not currently available for Python. Please use Go for Vertex AI Vectorsearch with Bigquery database functionality.
+:::
+
+</LanguageContent>
+
+<LanguageContent lang="js">
+
+Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Bigquery and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.
+
+## Installation
+
+```bash
+npm install @genkit-ai/vertexai
+```
+
+## Configuration
+
+1. Create a vector search index in GCP. Details on creating vector search index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
+2. Create a Bigquery Dataset and a Table within that dataset to store the documents that will be indexed. More information to create Bigquery datasets is available [here](https://cloud.google.com/bigquery/docs/datasets)
+
+To use the GCP vector search with Bigquery, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Bigquery dataset:
+
+```ts
+import { BigQuery } from '@google-cloud/bigquery';
+
+const bq = new BigQuery({
+  projectId: PROJECT_ID,
+});
+
+const bigQueryDocumentRetriever: DocumentRetriever =
+  getBigQueryDocumentRetriever(bq, BIGQUERY_TABLE, BIGQUERY_DATASET);
+
+const bigQueryDocumentIndexer: DocumentIndexer = getBigQueryDocumentIndexer(
+  bq,
+  BIGQUERY_TABLE,
+  BIGQUERY_DATASET
+);
+
+// Configure Genkit with Vertex AI plugin
+const ai = genkit({
+  plugins: [
+    vertexAI({
+      projectId: PROJECT_ID,
+      location: LOCATION,
+      googleAuth: {
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      },
+    }),
+    vertexAIVectorSearch({
+      location: LOCATION,
+      projectId: PROJECT_ID,
+      embedder: textEmbedding004,
+      vectorSearchOptions: [
+        {
+          publicDomainName: VECTOR_SEARCH_PUBLIC_DOMAIN_NAME,
+          indexEndpointId: VECTOR_SEARCH_INDEX_ENDPOINT_ID,
+          indexId: VECTOR_SEARCH_INDEX_ID,
+          deployedIndexId: VECTOR_SEARCH_DEPLOYED_INDEX_ID,
+          documentRetriever: bigQueryDocumentRetriever,
+          documentIndexer: bigQueryDocumentIndexer,
+        },
+      ],
+    }),
+  ],
+});
+```
+
+### Configuration Options
+
+- **projectId** (string): GCP Project ID
+- **location** (string): GCP Project location
+- **indexId** (string): Vector search index id
+- **indexEndpointId** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
+- **deployedIndexId** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
+- **publicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
+- **documentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Bigquery. This can be a custom document indexer as well depending on the user's requirement.
+- **documentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Bigquery. This can be a custom document retriever as well depending on the user's requirement.
+## Usage
+
+### Indexing Documents
+
+To populate with data, you need to implement your own indexing logic using the [`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document) format. Genkit provides a sample indexing function as well:
+
+```ts
+async ({ texts }) => {
+const documents = texts.map((text) => Document.fromText(text));
+await ai.index({
+    indexer: vertexAiIndexerRef({
+    indexId: VECTOR_SEARCH_INDEX_ID,
+    displayName: 'bigquery_index',
+    }),
+    documents,
+});
+return { result: 'success' };
+}
+```
+
+### Retrieving Documents
+
+Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+
+```ts
+async ({ query, k }) => {
+    const startTime = performance.now();
+    const queryDocument = Document.fromText(query);
+    const res = await ai.retrieve({
+        retriever: vertexAiRetrieverRef({
+        indexId: VECTOR_SEARCH_INDEX_ID,
+        displayName: 'bigquery_index',
+        }),
+        query: queryDocument,
+        options: { k },
+    });
+    const endTime = performance.now();
+    return {
+        result: res
+        .map((doc) => ({
+            text: doc.content[0].text!,
+            distance: doc.metadata?.distance,
+        }))
+        .sort((a, b) => b.distance - a.distance),
+        length: res.length,
+        time: endTime - startTime,
+    };
+}
+```
+
+</LanguageContent>
+
 <LanguageContent lang="go">
 
 Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Bigquery and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.

--- a/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
@@ -12,6 +12,168 @@ import LanguageContent from '../../../../components/LanguageContent.astro';
   <CopyMarkdownButton />
 </div>
 
+<LanguageContent lang="python">
+
+:::note[Feature unavailable for Python]
+Vertex AI Vectorsearch with Firestore database integration is not currently available for Python. Please use Go for Vertex AI Vectorsearch with Firestore database functionality.
+:::
+
+</LanguageContent>
+
+<LanguageContent lang="js">
+
+Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Firestore and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.
+
+## Installation
+
+The vector search functionality is built into Genkit Go. You need to import the [`vectorsearch`](https://pkg.go.dev/github.com/firebase/genkit/go/plugins/vertexai/vectorsearch) package:
+
+```bash
+npm install @genkit-ai/vertexai
+```
+
+## Configuration
+
+1. Create a vector search index in GCP. Details on creating vector search index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
+2. Create a Firestore Dataset and a Collection within that dataset to store the documents that will be indexed. More information to create Firestore datasets is available [here](https://firebase.google.com/docs/firestore/quickstart#create)
+
+To use the GCP vector search with Firestore, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Firestore dataset:
+
+```ts
+import { initializeApp } from 'firebase-admin/app';
+import { Document, genkit, z } from 'genkit';
+
+import { textEmbedding004, vertexAI } from '@genkit-ai/vertexai';
+
+import {
+  getFirestoreDocumentIndexer,
+  getFirestoreDocumentRetriever,
+  vertexAIVectorSearch,
+  vertexAiIndexerRef,
+  vertexAiRetrieverRef,
+  type DocumentIndexer,
+  type DocumentRetriever,
+} from '@genkit-ai/vertexai/vectorsearch';
+
+// // Initialize Firebase app
+initializeApp({ projectId: PROJECT_ID });
+
+const db = getFirestore();
+
+// Use our helper functions here, or define your own document retriever and document indexer
+const firestoreDocumentRetriever: DocumentRetriever =
+  getFirestoreDocumentRetriever(db, FIRESTORE_COLLECTION);
+
+const firestoreDocumentIndexer: DocumentIndexer = getFirestoreDocumentIndexer(
+  db,
+  FIRESTORE_COLLECTION
+);
+
+
+// Configure Genkit with Vertex AI plugin
+const ai = genkit({
+  plugins: [
+    vertexAI({
+      projectId: PROJECT_ID,
+      location: LOCATION,
+      googleAuth: {
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      },
+    }),
+    vertexAIVectorSearch({
+      projectId: PROJECT_ID,
+      location: LOCATION,
+      vectorSearchOptions: [
+        {
+          publicDomainName: VECTOR_SEARCH_PUBLIC_DOMAIN_NAME,
+          indexEndpointId: VECTOR_SEARCH_INDEX_ENDPOINT_ID,
+          indexId: VECTOR_SEARCH_INDEX_ID,
+          deployedIndexId: VECTOR_SEARCH_DEPLOYED_INDEX_ID,
+          documentRetriever: firestoreDocumentRetriever,
+          documentIndexer: firestoreDocumentIndexer,
+          embedder: textEmbedding004,
+        },
+      ],
+    }),
+  ],
+});
+```
+
+### Configuration Options
+
+- **projectId** (string): GCP Project ID
+- **location** (string): GCP Project location
+- **indexId** (string): Vector search index id
+- **indexEndpointId** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
+- **deployedIndexId** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
+- **publicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
+- **documentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Firestore. This can be a custom document indexer as well depending on the user's requirement.
+- **documentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Firestore. This can be a custom document retriever as well depending on the user's requirement.
+
+## Usage
+
+### Indexing Documents
+
+To populate with data, you need to implement your own indexing logic using the [`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document) format. Genkit provides a sample indexing function as well:
+
+```ts
+async ({ datapoints }) => {
+    const documents: Document[] = datapoints.map((dp) => {
+        const metadata = {
+        restricts: structuredClone(dp.restricts),
+        numericRestricts: structuredClone(dp.numericRestricts),
+        };
+        return Document.fromText(dp.text, metadata);
+    });
+    await ai.index({
+        indexer: vertexAiIndexerRef({
+        indexId: VECTOR_SEARCH_INDEX_ID,
+        displayName: 'firestore_index',
+        }),
+        documents,
+    });
+    return { result: 'success' };
+}
+```
+
+### Retrieving Documents
+
+Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+
+```ts
+async ({ query, k, restricts, numericRestricts }) => {
+    const startTime = performance.now();
+    const metadata = {
+        restricts: structuredClone(restricts),
+        numericRestricts: structuredClone(numericRestricts),
+    };
+    const queryDocument = Document.fromText(query, metadata);
+    const res = await ai.retrieve({
+        retriever: vertexAiRetrieverRef({
+        indexId: VECTOR_SEARCH_INDEX_ID,
+        displayName: 'firestore_index',
+        }),
+        query: queryDocument,
+        options: { k },
+    });
+    const endTime = performance.now();
+    return {
+        result: res
+        .map((doc) => ({
+            text: doc.content[0].text!,
+            metadata: JSON.stringify(doc.metadata),
+            distance: doc.metadata?.distance,
+        }))
+        .sort((a, b) => b.distance - a.distance),
+        length: res.length,
+        time: endTime - startTime,
+    };
+}
+```
+
+</LanguageContent>
+
 <LanguageContent lang="go">
 
 Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Firestore and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.

--- a/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
@@ -1,0 +1,157 @@
+---
+title: Vector Search using Firestore
+description: Learn how to use the GCP Vector search using Firestore with Genkit.
+---
+
+import LanguageSelector from '../../../../components/LanguageSelector.astro';
+import CopyMarkdownButton from '../../../../components/CopyMarkdownButton.astro';
+import LanguageContent from '../../../../components/LanguageContent.astro';
+
+<div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin: 1rem 0 1rem 0;">
+  <LanguageSelector />
+  <CopyMarkdownButton />
+</div>
+
+<LanguageContent lang="go">
+
+Vector search provided by Google Cloud services allows you to index and retrieve documents. The documents are stored in Firestore and the corresponding document IDs are indexed using the vector search index provided by GCP. These are suitable for production use cases.
+
+## Installation
+
+The vector search functionality is built into Genkit Go. You need to import the [`vectorsearch`](https://pkg.go.dev/github.com/firebase/genkit/go/plugins/vertexai/vectorsearch) package:
+
+```go
+import "github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
+```
+
+## Configuration
+
+1. Create a vector search index in GCP. Details on creating vector search index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
+2. Create a Firestore Dataset and a Collection within that dataset to store the documents that will be indexed. More information to create Firestore datasets is available [here](https://firebase.google.com/docs/firestore/quickstart#create)
+
+To use the GCP vector search with Firestore, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Firestore dataset:
+
+```go
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/firestore"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
+)
+
+ctx := context.Background()
+
+g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
+
+databaseId := "${FIRESTORE_DATABASE_ID}"         // Replace with your Firestore database ID
+collectionName := "${FIRESTORE_COLLECTION_NAME}" // Replace with your Firestore collection name
+firestoreClient, err := firestore.NewClientWithDatabase(ctx, vectorsearchPlugin.ProjectID, databaseId)
+documentIndexer := vectorsearch.GetFirestoreDocumentIndexer(firestoreClient, collectionName)
+documentRetriever := vectorsearch.GetFirestoreDocumentRetriever(firestoreClient, collectionName)
+
+vectorsearchParams := &VectorsearchConfig{
+    ProjectID:         vectorsearchPlugin.ProjectID,
+    Location:          vectorsearchPlugin.Location,
+    IndexID:           "${VECTOR_SEARCH_INDEX_ID}",                           // Replace with your index ID
+    IndexEndpointID:   "${VECTOR_SEARCH_INDEX_ENDPOINT_ID}",                  // Replace with your index endpoint ID
+    DeployedIndexID:   "${VECTOR_SEARCH_DEPLOYED_INDEX_ID}",                  // Replace with your deployed index ID
+    ProjectNumber:     "${GOOGLE_CLOUD_PROJECT_NUMBER}",                      // Replace with your Google Cloud project number
+    PublicDomainName:  "${VECTOR_SEARCH_PUBLIC_DOMAIN_NAME}",                 // Replace with your public domain name
+    Embedder:          googlegenai.VertexAIEmbedder(g, "text-embedding-004"), // Replace with your desired embedder
+    NeighborsCount:    10,                                                    // Number of neighbors to retrieve
+    DocumentIndexer:   documentIndexer,
+    DocumentRetriever: documentRetriever,
+}
+```
+
+### Configuration Options
+
+- **ProjectID** (string): GCP Project ID
+- **Location** (string): GCP Project location
+- **IndexID** (string): Vector search index id
+- **IndexEndpointID** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
+- **DeployedIndexID** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
+- **ProjectNumber** (string): GCP Project Number
+- **PublicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **Embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
+- **NeighborsCount** (int): Number of neighbors to set in the vector search
+- **DocumentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Firestore. This can be a custom document indexer as well depending on the user's requirement.
+- **DocumentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Firestore. This can be a custom document retriever as well depending on the user's requirement.
+## Usage
+
+### Indexing Documents
+
+To populate with data, you need to implement your own indexing logic using the [`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document) format. Genkit provides a sample indexing function as well:
+
+```go
+import (
+    "github.com/firebase/genkit/go/ai"
+)
+
+// Create documents from text
+data := []string{
+    "This is the first document.",
+    "This is the second document.",
+    "This is the third document.",
+    "This is the fourth document.",
+}
+
+var docs []*ai.Document
+for _, text := range data {
+	docs = append(docs, ai.DocumentFromText(text, nil))
+}
+
+// Index the docs.
+// Custom Index function can be used which should internally refer the indexer function for Firestore
+if err := vectorsearch.Index(ctx, g, vectorsearch.IndexParams{
+    IndexID:         vectorsearchParams.IndexID,
+    Embedder:        vectorsearchParams.Embedder,
+    EmbedderOptions: nil,
+    Docs:            docs,
+    ProjectID:       vectorsearchParams.ProjectID,
+    Location:        vectorsearchParams.Location,
+}, vectorsearchParams.DocumentIndexer); err != nil {
+    return nil, err
+}
+```
+
+### Retrieving Documents
+
+Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+
+```go
+// Define the retriever for vector search.
+retriever, err := vectorsearch.DefineRetriever(ctx, g, vectorsearch.Config{
+    IndexID: vectorsearchParams.IndexID, // Replace with your index ID
+}, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+// The retriever defined above has built in function called Retrieve() which 
+// corresponds to vector search retriever function defined in vector search plugin.
+// The DocumentRetriever passed as argument corresponds to the documentretriever 
+// for Firestore. This function retrieves the docs corresponding to the Neighbor IDs
+// found using vector search index.
+
+resp, err := retriever.Retrieve(ctx, &ai.RetrieverRequest{
+    Query: ai.DocumentFromText(input.Question, nil),
+    Options: &vectorsearch.RetrieveParams{
+        Embedder:          vectorsearchParams.Embedder,
+        NeighborCount:     vectorsearchParams.NeighborsCount,
+        IndexEndpointID:   vectorsearchParams.IndexEndpointID,
+        DeployedIndexID:   vectorsearchParams.DeployedIndexID,
+        PublicDomainName:  vectorsearchParams.PublicDomainName,
+        ProjectNumber:     vectorsearchParams.ProjectNumber,
+        DocumentRetriever: vectorsearchParams.DocumentRetriever,
+    }})
+if err != nil {
+    return nil, err
+}
+```
+
+</LanguageContent>

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -65,6 +65,8 @@ const DOCS_SIDEBAR = [
       { label: "AlloyDB for PostgreSQL", slug: "docs/integrations/alloydb" },
       { label: "Cloud SQL PostgreSQL", slug: "docs/integrations/cloud-sql-postgresql" },
       { label: "Cloud Firestore", slug: "docs/integrations/cloud-firestore" },
+      { label: "Vertex AI Vectosearch with Bigquery", slug: "docs/integrations/vectorsearch-bigquery" },
+      { label: "Vertex AI Vectosearch with Firestore", slug: "docs/integrations/vectorsearch-firestore" },
     ],
   },
   {


### PR DESCRIPTION
- Add documentation for vertex ai vectorsearch using Bigquery and Firestore as the document storage databases.
- Corresponding PR : https://github.com/firebase/genkit/pull/3230