### PR TITLE
docs: fix incorrect googleAI import paths in examples

### DIFF
--- a/src/content/docs/docs/interrupts.mdx
+++ b/src/content/docs/docs/interrupts.mdx
@@ -507,7 +507,7 @@ For this use case, use the Genkit instance's `defineInterrupt()` method:
 
 ```ts
 import { genkit, z } from 'genkit';
-import { googleAI } from '@genkitai/google-ai';
+import { googleAI } from '@genkit-ai/google-genai';
 
 const ai = genkit({
   plugins: [googleAI()],

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -117,7 +117,7 @@ Use the Genkit instance's `defineTool()` function to write tool definitions:
 
 ```ts
 import { genkit, z } from 'genkit';
-import { googleAI } from '@genkitai/google-ai';
+import { googleAI } from '@genkit-ai/google-genai';
 
 const ai = genkit({
   plugins: [googleAI()],


### PR DESCRIPTION
Fixed two incorrect import statements in docs examples.

Changed:
```ts
import { googleAI } from '@genkitai/google-ai';
````
to:
```ts
import { googleAI } from '@genkit-ai/google-genai';
```

in:

* `src/content/docs/docs/interrupts.mdx`
* `src/content/docs/docs/tool-calling.mdx`
