### PR TITLE
Fix incorrect field name in express authentication example

### DIFF
--- a/src/content/docs/docs/frameworks/express.mdx
+++ b/src/content/docs/docs/frameworks/express.mdx
@@ -144,7 +144,7 @@ app.use(express.json());
 app.post(
   '/simpleFlow',
   authMiddleware, // Optional: Express middleware for early auth checks
-  expressHandler(simpleFlow, { context: authContext }),
+  expressHandler(simpleFlow, { contextProvider: authContext }),
 );
 
 app.listen(8080, () => {


### PR DESCRIPTION
Thank you for maintaining Genkit always!
Genkit provides us high productivity and flexibility. :+1:

## Problem I encountered

I got a following error when I tried [this example]( https://genkit.dev/docs/frameworks/express/#authentication)

```
• Object literal may only specify known properties, and 'context' does not exist in type '{ contextProvider?: ContextProvider<ActionContext, ZodObject<{ input: ZodString; }, "strip", ZodTypeAny, { input: string; }, { input: string; }>>; }'. 
```

## Solution

As of `@genkit-ai/express@v1.20.0`, it works if I specify `contextProvider` instead of `context`.

So I replaced `context` with `contextProvider`.

## Testing

I have confirmed it looks fine as below locally by running `pnpm dev`.

<img width="3598" height="2082" alt="CleanShot 2025-10-01 at 21 02 25@2x" src="https://github.com/user-attachments/assets/1b58d165-abc4-43ca-8c5d-e771e2854957" />
