### PR TITLE
fix: update Firestore RAG docs and code samples

### DIFF
--- a/src/content/docs/docs/integrations/cloud-firestore.mdx
+++ b/src/content/docs/docs/integrations/cloud-firestore.mdx
@@ -165,7 +165,9 @@ const indexConfig = {
   collection: "menuInfo",
   contentField: "text",
   vectorField: "embedding",
-  embedder: vertexAI.embedder('gemini-embedding-001'),
+  embedder: vertexAI.embedder('gemini-embedding-001', {
+    outputDimensionality: 2048
+  }),
 };
 
 const ai = genkit({
@@ -218,9 +220,9 @@ The prior example requires the `embedding` field to be indexed to work. To creat
   The command looks like the following:
 
   ```bash
-  gcloud alpha firestore indexes composite create --project=your-project-id \
-    --collection-group=yourCollectionName --query-scope=COLLECTION \
-    --field-config=vector-config='{"dimension":"768","flat": "{}"}',field-path=yourEmbeddingField
+  gcloud firestore indexes composite create --project=your-project-id \
+    --collection-group=yourCollectionName --query-scope=COLLECTION \ 
+    --field-config=vector-config='{"dimension":"2048","flat": "{}"}',field-path=yourEmbeddingField
   ```
 
   However, the correct indexing configuration depends on the queries you make and the embedding model you're using.
@@ -229,11 +231,13 @@ The prior example requires the `embedding` field to be indexed to work. To creat
 
 ### Deploy flows as Cloud Functions
 
-To deploy a flow with Cloud Functions, use the Firebase Functions library's built-in support for genkit. The `onCallGenkit` method lets you create a [callable function](https://firebase.google.com/docs/functions/callable?gen=2nd) from a flow. It automatically supports streaming and JSON requests. You can use the [Cloud Functions client SDKs](https://firebase.google.com/docs/functions/callable?gen=2nd#call_the_function) to call them.
+To deploy a flow with Cloud Functions, use the Firebase Functions library's built-in support for Genkit. The `onCallGenkit` method lets you create a [callable function](https://firebase.google.com/docs/functions/callable?gen=2nd) from a flow. It automatically supports streaming and JSON requests. You can use the [Cloud Functions client SDKs](https://firebase.google.com/docs/functions/callable?gen=2nd#call_the_function) to call them.
 
 ```js
 import { onCallGenkit } from 'firebase-functions/https';
 import { defineSecret } from 'firebase-functions/params';
+
+const apiKey = defineSecret("apiKey");
 
 export const exampleFlow = ai.defineFlow(
   {


### PR DESCRIPTION
I found several issues in the samples for Firestore, main one being different embedding dimensions, as the gemini-embedding-001 generates larger dimension by default than [Firestore supports](https://firebase.google.com/docs/firestore/manage-data/data-types). I also updated the command to remove the alpha and match the generated dimension. 