### PR TITLE
fix(docs): dereference MenuItem pointer in example code

### DIFF
--- a/src/content/docs/docs/flows.mdx
+++ b/src/content/docs/docs/flows.mdx
@@ -621,24 +621,27 @@ Streaming flows can be run like non-streaming flows with
 `menuSuggestionFlow.Run(ctx, MenuSuggestionInput{Theme: "bistro"})` or they can be streamed:
 
 ```go
-streamCh, err := menuSuggestionFlow.Stream(context.Background(), MenuSuggestionInput{Theme: "bistro"})
-if err != nil {
-	log.Fatal(err)
-}
+streamCh := menuSuggestionFlow.Stream(
+    context.Background(),
+    MenuSuggestionInput{Theme: "bistro"},
+)
 
-for result := range streamCh {
-	if result.Err != nil {
-		log.Fatalf("Stream error: %v", result.Err)
-	}
-	if result.Done {
-		log.Printf("Menu with %s theme:\n", result.Output.Theme)
-		for _, item := range result.Output.Items {
-			log.Printf(" - %s: %s", item.Name, item.Description)
-		}
-	} else {
-		log.Println("Stream chunk:", result.Stream)
-	}
-}
+streamCh(func(result *core.StreamingFlowValue[Menu, string], err error) bool {
+    if err != nil {
+        log.Fatalf("Stream error: %v", err)
+    }
+
+    if result.Done {
+        log.Printf("Menu with %s theme:\n", result.Output.Theme)
+        for _, item := range result.Output.Items {
+            log.Printf(" - %s: %s", item.Name, item.Description)
+        }
+    } else {
+        log.Println("Stream chunk:", result.Stream)
+    }
+
+    return true
+})
 ```
 
 </LanguageContent>


### PR DESCRIPTION
The documentation example used `[]MenuItem{item}`, but the `GenerateData` function
returns a pointer (`*MenuItem`). This caused a mismatch because `Menu.Items` expects
a slice of values (`[]MenuItem`), not pointers.

This commit updates the example to use `[]MenuItem{*item}` to correctly
dereference the pointer before adding it to the slice.
