### PR TITLE
fix: remove import trace logs in nextjs

### DIFF
--- a/src/content/docs/docs/frameworks/nextjs.mdx
+++ b/src/content/docs/docs/frameworks/nextjs.mdx
@@ -85,6 +85,18 @@ npm install @genkit-ai/google-genai
     npm install --save-dev tsx
     ```
 
+ 4.  Update your `next.config.ts` and explicitly mark `genkit` as an external server package to prevent the import trace logs.
+
+    ```bash
+    import type { NextConfig } from "next";
+
+    const nextConfig: NextConfig = {
+    serverExternalPackages: ["genkit"],
+    };
+
+    export default nextConfig;
+    ```   
+
 ## Define Genkit flows
 
 Create a new directory in your Next.js project to contain your Genkit flows. Create `src/genkit/` and add your flow definitions there:


### PR DESCRIPTION
Removes the import trace logs by adding genkit as an external server package

<img width="777" height="125" alt="Screenshot 2025-11-18 at 17 20 18" src="https://github.com/user-attachments/assets/b58a2b3b-030a-4583-b7af-c5a64abcf66e" />
