### PR TITLE
Update JS get started guide to use ESM

### DIFF
--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -49,17 +49,21 @@ The Genkit libraries for Python are currently in **Alpha**. You might see API an
 Create a new Node.js project and configure TypeScript:
 
 ```sh
+# Create and navigate to a new directory
 mkdir my-genkit-app
 cd my-genkit-app
-npm init -y
 
-# Set up your source directory
-mkdir src
-touch src/index.ts
+# Initialize a new Node.js project
+npm init -y
+npm pkg set type=module
 
 # Install and configure TypeScript
 npm install -D typescript tsx
 npx tsc --init
+
+# Set up your source directory
+mkdir src
+touch src/index.ts
 ```
 
 This sets up your project structure and a TypeScript entry point at `src/index.ts`.


### PR DESCRIPTION
Currently the Get Started guide will cause errors because `npm init -y` defaults to CommonJS instead of ESM. Added a line to the set up to use ESM instead.