### PR TITLE
fix: correct behavior when maxTurns is hit

### DIFF
--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -311,7 +311,7 @@ const response = await ai.generate({
 
 **What happens when maxTurns is reached?**
 
-When the limit is reached, Genkit stops the tool-calling loop and throws a `GenerationResponseError`. You can handle this error in your application to define specific behavior for this scenario.
+When the limit is reached, Genkit stops the tool-calling loop and throws a [`GenkitError`](/docs/error-types). You can handle this error in your application to define specific behavior for this scenario.
 
 ### Dynamically defining tools at runtime
 


### PR DESCRIPTION
Preview: https://genkit-dev-astro--pr-193-w5rg92sg.web.app/docs/tool-calling/#limiting-tool-call-iterations-with-maxturns