### PR TITLE
Revise Genkit installation instructions for Next.js

### DIFF
--- a/src/content/docs/docs/frameworks/nextjs.mdx
+++ b/src/content/docs/docs/frameworks/nextjs.mdx
@@ -52,33 +52,13 @@ The `--src-dir` flag creates a `src/` directory to keep your project organized b
 
 Install the Genkit dependencies into your Next.js app:
 
-1.  Install the core Genkit library and the Next.js plugin:
+1.  Install the core Genkit library, the Next.js plugin, and at least one model plugin:
 
     ```bash
-    npm install genkit @genkit-ai/next
+    npm install genkit @genkit-ai/next @genkit-ai/google-genai
     ```
 
-2.  Install at least one model plugin.
-
-<Tabs syncKey="model-provider">
-<TabItem label="Gemini (Google AI)">
-
-```bash
-npm install @genkit-ai/google-genai
-```
-
-</TabItem>
-<TabItem label="Gemini (Vertex AI)">
-
-    ```bash
-    npm install @genkit-ai/vertexai
-    ```
-
-         </TabItem>
-
-    </Tabs>
-
-3.  Install the Genkit CLI globally. The tsx tool is also recommended as a development dependency, as it makes testing your code more convenient. Both of these dependencies are optional, however.
+2.  Install the Genkit CLI globally. The tsx tool is also recommended as a development dependency, as it makes testing your code more convenient. Both of these dependencies are optional, however.
 
     ```bash
     npm install -g genkit-cli
@@ -127,7 +107,7 @@ For example, create `src/genkit/menuSuggestionFlow.ts`:
   </TabItem>
   <TabItem label="Gemini (Vertex AI)">
     ```ts
-    import { vertexAI } from '@genkit-ai/vertexai';
+    import { vertexAI } from '@genkit-ai/google-genai';
     import { genkit, z } from 'genkit';
 
     const ai = genkit({


### PR DESCRIPTION
I think the previous import is now deprecated?

Updated installation instructions for Genkit dependencies in Next.js documentation, including the addition of a model plugin and clarification on optional dependencies.