### PR TITLE
Update start script path and curl command in docs

### DIFF
--- a/src/content/docs/docs/deployment/cloud-run.mdx
+++ b/src/content/docs/docs/deployment/cloud-run.mdx
@@ -57,7 +57,7 @@ typical TypeScript project, the following scripts are usually adequate:
 
 ```json
 "scripts": {
-  "start": "node lib/index.js",
+  "start": "node src/index.js",
   "build": "tsc"
 },
 ```
@@ -220,7 +220,7 @@ After deployment finishes, the tool will print the service URL. You can test
 it with `curl`:
 
 ```bash
-curl -X POST https://<service-url>/menuSuggestionFlow \
+curl -X POST https://<service-url>/menuSuggestion \
   -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
   -H "Content-Type: application/json" -d '{"data": "banana"}'
 ```


### PR DESCRIPTION
The reason I made the change was when I tried to call the endpoint it only worked without having the word flow at the end.

The src/index.js change was based on how the default installation is created and where it puts things.