### PR TITLE
Add step to install Genkit Agent Skills to get-started.mdx

### DIFF
--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -200,6 +200,16 @@ This installs:
 
 </Lang>
 
+### Install Genkit Agent Skills
+
+To provide your AI assistant with structured knowledge about Genkit, you can install the Genkit Agent Skills using the skills CLI:
+
+```bash
+npx skills add genkit-ai/skills
+```
+
+For more details on AI-assisted development, see [AI-assisted development](/docs/develop-with-ai).
+
 ## Configure your model API key
 
 Genkit can work with multiple model providers. This guide uses the **Gemini API**, which offers a generous free tier and doesn't require a credit card to get started.


### PR DESCRIPTION
This PR adds a step to install Genkit Agent Skills using the skills CLI to the Get started guide.