### PR TITLE
fix: Update landing page Anthropic example to use @genkit-ai/anthropic

### DIFF
--- a/src/components/landing/LanguageSelector.astro
+++ b/src/components/landing/LanguageSelector.astro
@@ -86,13 +86,13 @@ const { text } = await ai.generate({
         name: "Anthropic",
         id: "anthropic",
         code: `import { genkit } from 'genkit';
-import { anthropic, claude35Sonnet } from 'genkitx-anthropic';
+import { anthropic } from '@genkit-ai/anthropic';
 
 const ai = genkit({ plugins: [anthropic()] });
 
 const { text } = await ai.generate({
-	model: claude35Sonnet,
-	prompt: 'Why is Genkit awesome?'
+ model: anthropic.model('claude-sonnet-4-5'),
+ prompt: 'Why is Genkit awesome?'
 });`
       },
       {


### PR DESCRIPTION
## Summary

Replaces the deprecated `genkitx-anthropic` community package reference with the official `@genkit-ai/anthropic` package on the landing page and in the docs bundle.

## Changes

- **`src/components/landing/LanguageSelector.astro`**: Updated the Anthropic code example to:
  - Import from `@genkit-ai/anthropic` instead of `genkitx-anthropic`
  - Use `anthropic.model('claude-sonnet-4-5')` instead of the non-existent `claude35Sonnet` named export, matching the pattern documented in the [Anthropic integration docs](https://genkit.dev/docs/integrations/anthropic/)
- **`public/docs-bundle.json`**: Replaced `genkitx-anthropic` with `@genkit-ai/anthropic` in the pre-built bundle

## Context

The `@genkit-ai/anthropic` package is the official Anthropic plugin for Genkit (as noted in the integration docs). All documentation pages already use `@genkit-ai/anthropic` — the landing page was the only remaining reference to the old `genkitx-anthropic` community package.