### PR TITLE
Update messaging to be agentic-forward and app-first

### DIFF
--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -10,20 +10,20 @@ import Icon from './Icon.astro';
       <div class="flex flex-col items-center gap-4 sm:hidden">
         <Icon name="genkit-logo" size="md" class="w-12 h-12" />
         <h1 class="text-5xl leading-tight tracking-tight hero-title font-sans text-center">
-          The AI Framework for<br>
-          Full-Stack Apps
+          Build Powerful<br>
+          Agentic Apps
         </h1>
       </div>
       
       <!-- Desktop: Logo inline -->
       <h1 class="hidden sm:block text-5xl lg:text-7xl leading-tight tracking-tight hero-title font-sans text-center">
-        The AI Framework for<br>
-        Full-Stack Apps
+        Build Powerful<br>
+        Agentic Apps
       </h1>
     </div>
     
     <p class="subtitle text-muted mb-12 max-w-2xl mx-auto text-sm">
-      Built and used in production by Google, Genkit is an open-source library with tools to help you build AI-powered experiences
+      Genkit is Google's open-source framework for building full-stack, AI-powered and agentic applications for any platform
     </p>
     
     <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">

--- a/src/content/docs/docs/overview.mdx
+++ b/src/content/docs/docs/overview.mdx
@@ -1,8 +1,8 @@
 ---
-title: Genkit | Open-source AI development framework by Google
-description: Build high-quality GenAI features for your app with intuitive Genkit SDKs.
+title: Genkit | Open-source framework for AI-powered and agentic apps by Google
+description: Build full-stack, AI-powered and agentic applications with intuitive Genkit SDKs.
 hero:
-  tagline: An open-source framework for building AI-powered apps, built and used in production by Google
+  tagline: An open-source framework for building full-stack, AI-powered and agentic applications, built and used in production by Google
   image:
     dark: ../../../assets/genkit-darkmode.svg
     light: ../../../assets/genkit-lightmode.svg
@@ -29,9 +29,9 @@ supportedLanguages:
 import Lang from '../../../components/Lang.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Genkit is an open-source framework for building full-stack AI-powered applications, built and used in production by Google.
+Genkit is Google's open-source framework for building full-stack, AI-powered and agentic applications.
 
-It offers a unified interface for integrating AI models from many model providers, so you can use the best models for your needs. Rapidly build and deploy production-ready chatbots, automations, and recommendation systems using streamlined APIs for multimodal content, structured outputs, tool calling, and agentic workflows.
+It offers a unified interface for integrating AI models from many model providers, so you can use the best models for your needs. Rapidly build and deploy production-ready AI-powered and agentic applications—chatbots, automations, recommendation systems, and more—using streamlined APIs for multimodal content, structured outputs, tool calling, and agentic workflows.
 
 Get started with just a few lines of code:
 
@@ -545,8 +545,8 @@ Create your own AI-powered feature in minutes with our guides.
 
 ## How does it work?
 
-Genkit simplifies AI integration with an open-source SDK and unified APIs that
-work across various model providers and programming languages. It abstracts away complexity so you can focus on delivering great user experiences.
+Genkit simplifies building AI-powered and agentic applications with an open-source SDK and unified APIs that
+work across various model providers and programming languages. It abstracts away complexity so you can focus on delivering great app experiences.
 
 Some key features offered by Genkit include:
 
@@ -566,7 +566,7 @@ Genkit is designed for server-side deployment in multiple language environments,
 | :---- | :-------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **1** | Choose your language and model provider | Select the Genkit SDK for your preferred language (JavaScript/TypeScript, Go, Python, or Dart). Choose a model provider like [Google Gemini](/docs/integrations/google-genai) or Anthropic, and get an API key. Some providers, like [Vertex AI](/docs/integrations/vertex-ai), may rely on a different means of authentication. |
 | **2** | Install the SDK and initialize          | Install the Genkit SDK, model-provider package of your choice, and the Genkit CLI. Import the Genkit and provider packages and initialize Genkit with the provider API key.                                                                                                                                                      |
-| **3** | Write and test AI features              | Use the Genkit SDK to build AI features for your use case, from basic text generation to complex multi-step workflows and agents. Use the CLI and Developer UI to help you rapidly test and iterate.                                                                                                                             |
+| **3** | Write and test AI features              | Use the Genkit SDK to build AI features for your use case, from basic text generation to complex multi-step agentic applications. Use the CLI and Developer UI to help you rapidly test and iterate.                                                                                                                             |
 | **4** | Deploy and monitor                      | Deploy your AI features to Firebase, Google Cloud Run, or any environment that supports your chosen programming language. Integrate them into your app, and monitor them in production in the Firebase console.                                                                                                                  |
 
 ## Connect with us


### PR DESCRIPTION
## Summary

Updates landing page and overview doc messaging to be consistently agentic-forward and app-first.

### Changes

**Landing page (Hero.astro):**
- Title: "Build Powerful Agentic Apps"
- Subtext: "Genkit is Google's open-source framework for building full-stack, AI-powered and agentic applications"

**Overview doc (overview.mdx):**
- Page title, description, and hero tagline updated
- Opening paragraph reframed as app-first
- How does it work section updated
- Implementation path step 3 updated
- All references consistently use AI-powered and agentic applications instead of building agents

### Motivation

Align messaging to frame Genkit as a framework for building AI-powered and agentic applications, keeping the focus app-first throughout.