### PR TITLE
docs: update Python SDK status from preview to beta

### DIFF
--- a/src/components/landing/LanguageSelector.astro
+++ b/src/components/landing/LanguageSelector.astro
@@ -294,7 +294,7 @@ func main() {
   { 
     name: "Python", 
     id: "python",
-    status: "(Preview)",
+    status: "(Beta)",
     active: false,
     icon: "python",
     href: "/docs/python/get-started/",

--- a/src/components/sidebar.astro
+++ b/src/components/sidebar.astro
@@ -15,7 +15,7 @@ const currentLang = pathLangMatch?.[1] || Astro.url.searchParams.get('lang') || 
 const languageMeta: Record<string, { name: string; preview?: boolean }> = {
 	js: { name: 'TypeScript' },
 	go: { name: 'Go' },
-	python: { name: 'Python', preview: true },
+	python: { name: 'Python', preview: false },
 	dart: { name: 'Dart', preview: true },
 };
 const iconComponents: Record<string, any> = {
@@ -186,7 +186,7 @@ const docsLanguageAgnosticByPath = Object.fromEntries(
 	const LANGUAGE_META: Record<string, { name: string; preview?: boolean }> = {
 		js: { name: 'TypeScript' },
 		go: { name: 'Go' },
-		python: { name: 'Python', preview: true },
+		python: { name: 'Python', preview: false },
 		dart: { name: 'Dart', preview: true },
 	};
 

--- a/src/content/docs/docs/api-stability.mdx
+++ b/src/content/docs/docs/api-stability.mdx
@@ -83,7 +83,7 @@ so bug fixes and new features happen in patch releases and breaking changes in m
 
 <Lang lang="python">
 
-Genkit follows [semantic versioning](https://semver.org/). Genkit Python is currently in preview (`0.*`),
+Genkit follows [semantic versioning](https://semver.org/). Genkit Python is currently in beta (`0.*`),
 so bug fixes and new features happen in patch releases and breaking changes in minor releases.
 
 </Lang>

--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -55,7 +55,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-:::note[Preview release]
+:::note[Beta release]
 The Genkit libraries for Python are currently in **beta**. You might see API and functional changes as development progresses. We recommend using it only for prototyping and exploration.
 :::
 

--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -56,7 +56,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 ```
 
 :::note[Preview release]
-The Genkit libraries for Python are currently in **preview**. You might see API and functional changes as development progresses. We recommend using it only for prototyping and exploration.
+The Genkit libraries for Python are currently in **beta**. You might see API and functional changes as development progresses. We recommend using it only for prototyping and exploration.
 :::
 
 </Lang>


### PR DESCRIPTION
The Python SDK has been promoted to Beta (as reflected in the GitHub README and release notes), but the docs still referenced preview in several places. This updates:
- get-started.mdx: preview -> beta label and note title
- api-stability.mdx: preview -> beta
- sidebar.astro: remove preview flag for Python
- LanguageSelector.astro: Preview -> Beta status badge