### PR TITLE
docs(dart/models): use new top-level `system` parameter for system prompts

### DIFF
--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1282,15 +1282,14 @@ instructions as to how you want it to respond to messages from the user. You can
 use the system prompt to specify characteristics such as a persona you want the
 model to adopt, the tone of its responses, and the format of its responses.
 
-If the model you're using supports system prompts, you can provide one through the model configuration:
+If the model you're using supports system prompts, you can provide one with the
+`system` parameter:
 
 ```dart
 final response = await ai.generate(
   model: googleAI.gemini('gemini-2.5-flash'),
+  system: 'You are a food industry marketing consultant.',
   prompt: 'Invent a menu item for a pirate themed restaurant.',
-  config: GeminiOptions(
-    systemInstruction: 'You are a food industry marketing consultant.',
-  ),
 );
 ```
 


### PR DESCRIPTION
## Summary

**Bug fix.** The Dart variant of the Models / generating content docs previously showed `config: GeminiOptions(systemInstruction: ...)` as the way to set a system prompt. That is a Gemini-specific config option, not the framework-level way to specify a system prompt — it doesn't work with non-Gemini models and bypasses Genkit's role-based message system. The snippet was incorrect for a section meant to document the cross-model `ai.generate()` API.

This PR replaces it with the new top-level `system` parameter on `ai.generate()`, which matches the JS and Go SDK surface.

## Depends on

genkit-ai/genkit-dart#289 — adds the `system` parameter to `Genkit.generate`, `Genkit.generateStream`, `lite.generate`, `lite.generateStream`, and `generateHelper`. This docs change should land after that PR ships in a release that the docs target.

## Before (incorrect)

```dart
final response = await ai.generate(
  model: googleAI.gemini('gemini-2.5-flash'),
  prompt: 'Invent a menu item for a pirate themed restaurant.',
  config: GeminiOptions(
    systemInstruction: 'You are a food industry marketing consultant.',
  ),
);
```

## After

```dart
final response = await ai.generate(
  model: googleAI.gemini('gemini-2.5-flash'),
  system: 'You are a food industry marketing consultant.',
  prompt: 'Invent a menu item for a pirate themed restaurant.',
);
```

## Test plan

- [x] `pnpm generate-language-pages` regenerates `src/content/docs/docs/dart/models.mdx` with the new snippet (verified locally; that path is gitignored).
- [ ] Reviewer checks the rendered Dart Models page looks right.