### PR TITLE
docs: add Dart language support to Dotprompt guide

### DIFF
--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -1112,7 +1112,7 @@ Within your prompt, provide the name of the registered schema:
 
 ```dotprompt
 ---
-model: googleai/gemini-flash-latest-latest
+model: googleai/gemini-flash-latest
 output:
   schema: MenuItemSchema
 ---

--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -4,6 +4,7 @@ description: Learn how to use Dotprompt to manage prompts, models, and parameter
 supportedLanguages:
   - js
   - go
+  - dart
   - python
 ---
 
@@ -38,7 +39,7 @@ example of what these files look like:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   temperature: 0.9
 input:
@@ -68,10 +69,20 @@ Before reading this page, you should be familiar with the content covered on the
 If you want to run the code examples on this page, first complete the steps in
 the Getting started guide for your language:
 
-<Lang lang="js go python">
+<Lang lang="js go dart python">
 
 Complete the [Get started](/docs/get-started) guide. All examples assume you have already installed Genkit as a
 dependency in your project.
+
+</Lang>
+
+<Lang lang="dart">
+
+:::note
+Genkit Dart uses [`build_runner`](https://dart.dev/tools/build_runner) to generate schema types from your
+[schemantic](https://pub.dev/packages/schemantic) classes. When you define input or output schemas in code,
+remember to run `dart run build_runner build` before running your app.
+:::
 
 </Lang>
 
@@ -84,7 +95,7 @@ section shows you how to create and load prompts using this recommended setup.
 
 ### Creating a prompt directory
 
-<Lang lang="js go python">
+<Lang lang="js go dart python">
 
 The Dotprompt library expects to find your prompts in a directory at your project root and automatically loads any
 prompts it finds there. By default, this directory is named `prompts`. For example, using the default directory name,
@@ -108,7 +119,7 @@ your-project/
 
 </Lang>
 
-<Lang lang="js go python">
+<Lang lang="js go dart python">
 
 If you want to use a different directory, you can specify it when you configure Genkit:
 
@@ -163,6 +174,31 @@ ai = Genkit(
 
 </Lang>
 
+<Lang lang="dart">
+
+```
+your-project/
+├── bin/
+│   └── main.dart
+├── prompts/
+│   └── hello.prompt
+├── pubspec.yaml
+└── pubspec.lock
+```
+
+By default, Genkit looks for prompts in the `./prompts` directory. To use a
+different directory, set the `promptDir` parameter when you create the Genkit
+instance:
+
+```dart
+final ai = Genkit(
+  plugins: [googleAI()],
+  promptDir: './llm_prompts',
+);
+```
+
+</Lang>
+
 ### Creating a prompt file
 
 There are two ways to create a `.prompt` file: using a text editor, or with the
@@ -178,7 +214,7 @@ Here is a minimal example of a prompt file:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 ---
 You are the world's most welcoming AI assistant. Greet the user and offer your assistance.
 ```
@@ -192,7 +228,7 @@ of Dotprompt's features in your prompt files.
 
 #### Using the Developer UI
 
-<Lang lang="js go python">
+<Lang lang="js go dart python">
 
 You can also create a prompt file using the model runner in the developer UI. Start with application code that imports
 the Genkit library and configures it to use the model plugin you're interested in:
@@ -217,9 +253,9 @@ const ai = genkit({
 });
 ```
 
-    It's okay if the file contains other code, but the above is all that's required.
+It's okay if the file contains other code, but the above is all that's required.
 
-    Load the developer UI in the same project:
+Load the developer UI in the same project:
 
 ```bash
 genkit start -- tsx --watch src/your-code.ts
@@ -249,7 +285,7 @@ func main() {
 }
 ```
 
-    Load the developer UI in the same project:
+Load the developer UI in the same project:
 
 ```bash
 genkit start -- go run .
@@ -268,12 +304,34 @@ ai = Genkit(
 )
 ```
 
-    It's okay if the file contains other code, but the above is all that's required.
+It's okay if the file contains other code, but the above is all that's required.
 
-    Load the developer UI in the same project:
+Load the developer UI in the same project:
 
 ```bash
 genkit start -- uv run src/main.py
+```
+
+</Lang>
+
+<Lang lang="dart">
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_genai/genkit_google_genai.dart';
+
+void main() {
+  final ai = Genkit(plugins: [googleAI()]);
+  // Keeps the program running so the developer UI can connect.
+}
+```
+
+It's okay if the file contains other code, but the above is all that's required.
+
+Load the developer UI in the same project:
+
+```bash
+genkit start -- dart run
 ```
 
 </Lang>
@@ -305,7 +363,7 @@ To use a prompt, first load it using the `prompt('file_name')` method:
 const helloPrompt = ai.prompt('hello');
 ```
 
-    Once loaded, you can call the prompt like a function:
+Once loaded, you can call the prompt like a function:
 
 ```ts
 const response = await helloPrompt();
@@ -315,7 +373,7 @@ const response = await helloPrompt();
 const { text } = await helloPrompt();
 ```
 
-    Or you can also run the prompt in streaming mode:
+Or you can also run the prompt in streaming mode:
 
 ```ts
 const { response, stream } = helloPrompt.stream();
@@ -327,9 +385,9 @@ for await (const chunk of stream) {
 console.log((await response).text);
 ```
 
-    A callable prompt takes two optional parameters: the input to the prompt (see
-    the section below on [specifying input schemas](#input-and-output-schemas)), and a configuration
-    object, similar to that of the `generate()` method. For example:
+A callable prompt takes two optional parameters: the input to the prompt (see
+the section below on [specifying input schemas](#input-and-output-schemas)), and a configuration
+object, similar to that of the `generate()` method. For example:
 
 ```ts
 const response2 = await helloPrompt(
@@ -351,11 +409,11 @@ const response2 = await helloPrompt(
 const { stream } = helloPrompt.stream(input, options);
 ```
 
-    Any parameters you pass to the prompt call will override the same parameters
-    specified in the prompt file.
+Any parameters you pass to the prompt call will override the same parameters
+specified in the prompt file.
 
-    See [Generate content with AI models](/docs/models) for descriptions of the available
-    options.
+See [Generate content with AI models](/docs/models) for descriptions of the available
+options.
 
 </Lang>
 
@@ -373,7 +431,7 @@ helloPrompt := genkit.LookupPrompt(g, "hello")
 
 ```go
 resp, err := helloPrompt.Execute(context.Background(),
-	ai.WithModelName("googleai/gemini-2.5-flash"),
+	ai.WithModelName("googleai/gemini-flash-latest"),
 	ai.WithInput(map[string]any{"name": "John"}),
 	ai.WithConfig(&genai.GenerateContentConfig{Temperature: genai.Ptr[float32](0.5)})
 )
@@ -426,11 +484,11 @@ if err != nil {
 log.Printf("Message: %s, Tone: %s\n", greeting.Message, greeting.Tone)
 ```
 
-    The `.prompt` file should define an output schema that matches your Go type:
+The `.prompt` file should define an output schema that matches your Go type:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     name: string
@@ -442,7 +500,7 @@ output:
 Greet {{name}} warmly.
 ```
 
-    For streaming with typed prompts, use `ExecuteStream()` which provides typed chunks:
+For streaming with typed prompts, use `ExecuteStream()` which provides typed chunks:
 
 ```go
 helloPrompt := genkit.LookupDataPrompt[GreetingInput, *Greeting](g, "hello")
@@ -462,11 +520,11 @@ for result, err := range helloPrompt.ExecuteStream(ctx, GreetingInput{Name: "Joh
 }
 ```
 
-    Any parameters you pass to the prompt call will override the same parameters
-    specified in the prompt file.
+Any parameters you pass to the prompt call will override the same parameters
+specified in the prompt file.
 
-    See [Generate content with AI models](/docs/models) for descriptions of the available
-    options.
+See [Generate content with AI models](/docs/models) for descriptions of the available
+options.
 
 </Lang>
 
@@ -530,6 +588,67 @@ result = hello_prompt.stream(
 
 </Lang>
 
+<Lang lang="dart">
+
+To use a prompt, first load it using the `prompt('file_name')` method:
+
+```dart
+final helloPrompt = await ai.prompt('hello');
+```
+
+    Once loaded, you can call the prompt like a function:
+
+```dart
+final response = await helloPrompt();
+
+// Access the text output
+print(response.text);
+```
+
+    Or you can run the prompt in streaming mode:
+
+```dart
+final stream = helloPrompt.stream();
+
+await for (final chunk in stream) {
+  print(chunk.text);
+}
+
+// optional final (aggregated) response
+final response = await stream.onResult;
+print(response.text);
+```
+
+    A callable prompt takes optional parameters: the input to the prompt (see
+    the section below on [specifying input schemas](#input-and-output-schemas)), and a
+    `PromptGenerateOptions` object for generation options. For example:
+
+```dart
+final response = await helloPrompt(
+  // Prompt input:
+  {'name': 'Ted'},
+  // Generation options:
+  PromptGenerateOptions(config: {'temperature': 0.4}),
+);
+```
+
+    Similarly for streaming:
+
+```dart
+final stream = helloPrompt.stream(
+  {'name': 'Ted'},
+  PromptGenerateOptions(config: {'temperature': 0.4}),
+);
+```
+
+    Any parameters you pass to the prompt call will override the same parameters
+    specified in the prompt file.
+
+    See [Generate content with AI models](/docs/models) for descriptions of the available
+    options.
+
+</Lang>
+
 ### Using the Developer UI
 
 As you're refining your app's prompts, you can run them in the Genkit developer
@@ -566,6 +685,16 @@ genkit start -- uv run src/main.py
 
 </Lang>
 
+<Lang lang="dart">
+
+Load the developer UI from your project directory:
+
+```bash
+genkit start -- dart run
+```
+
+</Lang>
+
 Once you've loaded prompts into the developer UI, you can run them with
 different input values, and experiment with how changes to the prompt wording or
 the configuration parameters affect the model output. When you're happy with the
@@ -579,7 +708,7 @@ configuration values for your prompt:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 config:
   temperature: 1.4
   topK: 50
@@ -644,6 +773,25 @@ response = await hello_prompt(
 
 </Lang>
 
+<Lang lang="dart">
+
+```dart
+final response = await helloPrompt(
+  {},
+  PromptGenerateOptions(
+    config: {
+      'temperature': 1.4,
+      'topK': 50,
+      'topP': 0.4,
+      'maxOutputTokens': 400,
+      'stopSequences': ['<end>', '<fin>'],
+    },
+  ),
+);
+```
+
+</Lang>
+
 See [Generate content with AI models](/docs/models) for descriptions of the available
 options.
 
@@ -654,7 +802,7 @@ front matter section:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     theme?: string
@@ -729,6 +877,18 @@ description = response.output["description"]
 - Use `response.output.field` when you pass `output={'schema': YourPydanticModel}`.
 
 :::
+
+</Lang>
+
+<Lang lang="dart">
+
+```dart
+final menuPrompt = await ai.prompt('menu');
+final response = await menuPrompt({'theme': 'medieval'});
+
+final dishName = response.output['dishname'];
+final description = response.output['description'];
+```
 
 </Lang>
 
@@ -850,6 +1010,51 @@ class Article(BaseModel):
 
 </Lang>
 
+<Lang lang="dart">
+
+```dart
+@Schema()
+abstract class $Author {
+  String get name;
+  String? get email;
+}
+
+@Schema()
+abstract class $Metadata {
+  @Field(description: 'ISO timestamp of last update')
+  String? get updatedAt;
+
+  @Field(description: 'id of approver')
+  int? get approvedBy;
+}
+
+@Schema()
+abstract class $Article {
+  String get title;
+  String? get subtitle;
+
+  @Field(description: 'true when in draft state')
+  bool? get draft;
+
+  @Field(description: 'approval status')
+  String? get status;
+
+  @Field(description: "the date of publication e.g. '2024-04-09'")
+  String get date;
+
+  @Field(description: 'relevant tags for article')
+  List<String> get tags;
+
+  List<Author> get authors;
+  Metadata? get metadata;
+
+  @Field(description: 'arbitrary extra data')
+  dynamic get extra;
+}
+```
+
+</Lang>
+
 Picoschema supports scalar types `string`, `integer`, `number`, `boolean`, and
 `any`. Objects, arrays, and enums are denoted by a parenthetical after the field
 name.
@@ -887,7 +1092,7 @@ reference a schema registered with `defineSchema()` by name. If you're using
 TypeScript, this approach will let you take advantage of the language's static
 type checking features when you work with prompts.
 
-    To register a schema using Zod:
+To register a schema using Zod:
 
 ```ts
 import { z } from 'genkit';
@@ -903,19 +1108,19 @@ const MenuItemSchema = ai.defineSchema(
 );
 ```
 
-    Within your prompt, provide the name of the registered schema:
+Within your prompt, provide the name of the registered schema:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash-latest
+model: googleai/gemini-flash-latest-latest
 output:
   schema: MenuItemSchema
 ---
 ```
 
-    The Dotprompt library will automatically resolve the name to the underlying
-    registered schema. You can then utilize the schema to strongly type the
-    output of a Dotprompt:
+The Dotprompt library will automatically resolve the name to the underlying
+registered schema. You can then utilize the schema to strongly type the
+output of a Dotprompt:
 
 ```ts
 const menuPrompt = ai.prompt<
@@ -939,7 +1144,7 @@ reference a schema registered with `genkit.DefineSchemaFor[T]()` by name. This
 approach lets you define your types once in Go and reference them in prompt
 files, giving you compile-time type safety without duplicating schema definitions.
 
-    To register a schema from a Go type:
+To register a schema from a Go type:
 
 ```go
 type MenuItem struct {
@@ -953,11 +1158,11 @@ type MenuItem struct {
 genkit.DefineSchemaFor[MenuItem](g)
 ```
 
-    Within your prompt, reference the registered schema by name:
+Within your prompt, reference the registered schema by name:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 output:
   schema: MenuItem
 ---
@@ -990,7 +1195,7 @@ if err != nil {
 log.Printf("Dish: %s, Calories: %d", item.Dishname, item.Calories)
 ```
 
-    You can also reference registered schemas programmatically using `ai.WithOutputSchemaName()`:
+You can also reference registered schemas programmatically using `ai.WithOutputSchemaName()`:
 
 ```go
 genkit.DefineSchemaFor[MenuItem](g)
@@ -1017,7 +1222,7 @@ reference a Pydantic model using the `output` parameter when defining
 or calling the prompt. This approach lets you take advantage of Python's type
 checking features when you work with prompts.
 
-    Define your schema as a Pydantic model:
+Define your schema as a Pydantic model:
 
 ```python
 from pydantic import BaseModel
@@ -1029,11 +1234,11 @@ class MenuItem(BaseModel):
     allergens: list[str]
 ```
 
-    Within your prompt, you can use Picoschema or JSON Schema as usual:
+Within your prompt, you can use Picoschema or JSON Schema as usual:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 output:
   schema:
     dishname: string
@@ -1044,7 +1249,7 @@ output:
 Invent a menu item for a pirate themed restaurant.
 ```
 
-    Then load and call the prompt, specifying the output schema for type safety:
+Then load and call the prompt, specifying the output schema for type safety:
 
 ```python
 menu_prompt = ai.prompt('menu')
@@ -1058,8 +1263,8 @@ dish_name = response.output.dishname
 description = response.output.description
 ```
 
-    You can also use `ai.define_prompt()` to define prompts programmatically with
-    Pydantic schemas using the `Output` helper:
+You can also use `ai.define_prompt()` to define prompts programmatically with
+Pydantic schemas using the `Output` helper:
 
 ```python
 from pydantic import BaseModel
@@ -1076,7 +1281,7 @@ class MenuItem(BaseModel):
 
 menu_prompt = ai.define_prompt(
     name="menu",
-    model="googleai/gemini-2.5-flash",
+    model="googleai/gemini-flash-latest",
     input_schema=MenuInput,
     output_schema=MenuItem,
     prompt="Invent a menu item for a {{theme}} themed restaurant.",
@@ -1084,6 +1289,54 @@ menu_prompt = ai.define_prompt(
 
 response = await menu_prompt(MenuInput(theme="pirate"))
 # response.output is MenuItem
+```
+
+</Lang>
+
+<Lang lang="dart">
+
+In addition to directly defining schemas in the `.prompt` file, you can
+register a schema by name with `defineSchema()` and reference it from your
+prompts. This lets you define a schema once and reuse it across multiple prompts.
+
+Define your schema as a [schemantic](https://pub.dev/packages/schemantic) class:
+
+```dart
+@Schema()
+abstract class $MenuItem {
+  String get dishname;
+  String get description;
+  int get calories;
+  List<String> get allergens;
+}
+```
+
+Register it with a name, converting the generated schema to JSON Schema:
+
+```dart
+ai.defineSchema('MenuItemSchema', MenuItem.$schema.jsonSchema());
+```
+
+Within your prompt, reference the registered schema by name:
+
+```dotprompt
+---
+model: googleai/gemini-flash-latest
+output:
+  schema: MenuItemSchema
+---
+Invent a menu item for a {{theme}} themed restaurant.
+```
+
+The Dotprompt library will automatically resolve the name to the underlying
+registered schema when the prompt runs:
+
+```dart
+final menuPrompt = await ai.prompt('menu');
+final response = await menuPrompt({'theme': 'medieval'});
+
+final dishName = response.output['dishname'];
+final description = response.output['description'];
 ```
 
 </Lang>
@@ -1144,6 +1397,19 @@ response = await my_prompt({"input_args": "go here"}, tools=["my_tool"])
 
 </Lang>
 
+<Lang lang="dart">
+
+```dart
+final myTool = ai.defineTool(...);
+final myPrompt = await ai.prompt('my_prompt');
+await myPrompt(
+  {'inputArgs': 'go here'},
+  PromptGenerateOptions(tools: [myTool]),
+);
+```
+
+</Lang>
+
 ## Prompt templates
 
 The portion of a `.prompt` file that follows the front matter (if present) is
@@ -1161,7 +1427,7 @@ You already saw this in action in the section on input and output schemas:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     theme?: string
@@ -1211,6 +1477,15 @@ response = await menu_prompt({"theme": "medieval"})
 
 </Lang>
 
+<Lang lang="dart">
+
+```dart
+final menuPrompt = await ai.prompt('menu');
+final response = await menuPrompt({'theme': 'medieval'});
+```
+
+</Lang>
+
 Note that because the input schema declared the `theme` property to be optional
 and provided a default, you could have omitted the property,
 and the prompt would have resolved using the default value.
@@ -1221,7 +1496,7 @@ Handlebars's `#if` helper:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     theme?: string
@@ -1250,7 +1525,7 @@ construct multi-message prompts:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     userQuestion: string
@@ -1271,7 +1546,7 @@ use the `{{media}}` helper:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     photoUrl: string
@@ -1319,6 +1594,18 @@ print(response.text)
 
 </Lang>
 
+<Lang lang="dart">
+
+```dart
+final multimodalPrompt = await ai.prompt('multimodal');
+final response = await multimodalPrompt({
+  'photoUrl': 'https://example.com/photo.jpg',
+});
+print(response.text);
+```
+
+</Lang>
+
 See also [Multimodal input](/docs/models#multimodal-input), on the Generating content
 page, for an example of constructing a `data:` URL.
 
@@ -1338,7 +1625,7 @@ This can then be included in other prompts:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     name: string
@@ -1373,7 +1660,7 @@ members of a list.
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     destinations(array):
@@ -1400,7 +1687,7 @@ ai.definePartial(
 );
 ```
 
-    Code-defined partials are available in all prompts.
+Code-defined partials are available in all prompts.
 
 </Lang>
 
@@ -1410,7 +1697,7 @@ ai.definePartial(
 genkit.DefinePartial(g, "personality", "Talk like a {{#if style}}{{style}}{{else}}helpful assistant{{/if}}.")
 ```
 
-    Code-defined partials are available in all prompts.
+Code-defined partials are available in all prompts.
 
 </Lang>
 
@@ -1421,6 +1708,16 @@ ai.define_partial('personality', 'Talk like a {{#if style}}{{style}}{{else}}help
 ```
 
     Code-defined partials are available in all prompts.
+
+</Lang>
+
+<Lang lang="dart">
+
+```dart
+ai.definePartial('personality', 'Talk like a {{#if style}}{{style}}{{else}}helpful assistant{{/if}}.');
+```
+
+Code-defined partials are available in all prompts.
 
 </Lang>
 
@@ -1435,11 +1732,11 @@ Helpers are registered globally:
 ai.defineHelper('shout', (text: string) => text.toUpperCase());
 ```
 
-    Once a helper is defined you can use it in any prompt:
+Once a helper is defined you can use it in any prompt:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     name: string
@@ -1458,11 +1755,11 @@ genkit.DefineHelper(g, "shout", func(input string) string {
 })
 ```
 
-    Once a helper is defined you can use it in any prompt:
+Once a helper is defined you can use it in any prompt:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
 input:
   schema:
     name: string
@@ -1479,11 +1776,32 @@ HELLO, {{shout name}}!!!
 ai.define_helper('shout', lambda text: text.upper())
 ```
 
-    Once a helper is defined you can use it in any prompt:
+Once a helper is defined you can use it in any prompt:
 
 ```dotprompt
 ---
-model: googleai/gemini-2.5-flash
+model: googleai/gemini-flash-latest
+input:
+  schema:
+    name: string
+---
+
+HELLO, {{shout name}}!!!
+```
+
+</Lang>
+
+<Lang lang="dart">
+
+```dart
+ai.defineHelper('shout', (args, options) => args[0].toString().toUpperCase());
+```
+
+Once a helper is defined you can use it in any prompt:
+
+```dotprompt
+---
+model: googleai/gemini-flash-latest
 input:
   schema:
     name: string
@@ -1541,6 +1859,16 @@ my_prompt = ai.prompt('my_prompt', variant='gemini25pro')
 
 </Lang>
 
+<Lang lang="dart">
+
+Specify the variant option when loading:
+
+```dart
+final myPrompt = await ai.prompt('my_prompt', variant: 'gemini25pro');
+```
+
+</Lang>
+
 The name of the variant is included in the metadata of generation traces, so you
 can compare and contrast actual performance between variants in the Genkit trace
 inspector.
@@ -1564,7 +1892,7 @@ as in a prompt file, or a function that returns a `GenerateRequest`:
 ```ts
 const myPrompt = ai.definePrompt({
   name: 'myPrompt',
-  model: 'googleai/gemini-2.5-flash',
+  model: 'googleai/gemini-flash-latest',
   input: {
     schema: z.object({
       name: z.string(),
@@ -1577,7 +1905,7 @@ const myPrompt = ai.definePrompt({
 ```ts
 const myPrompt = ai.definePrompt({
   name: 'myPrompt',
-  model: 'googleai/gemini-2.5-flash',
+  model: 'googleai/gemini-flash-latest',
   input: {
     schema: z.object({
       name: z.string(),
@@ -1613,7 +1941,7 @@ type CountryList struct {
 
 geographyPrompt := genkit.DefineDataPrompt[GeoQuery, *CountryList](
     g, "GeographyPrompt",
-    ai.WithModel(googlegenai.GoogleAIModelRef("gemini-2.5-flash", nil)),
+    ai.WithModel(googlegenai.GoogleAIModelRef("gemini-flash-latest", nil)),
     ai.WithSystem("You are a geography teacher. Respond only when the user asks about geography."),
     ai.WithPrompt("Give me the {{countryCount}} biggest countries in the world by inhabitants."),
 )
@@ -1627,10 +1955,10 @@ if err != nil {
 log.Printf("Countries: %v", list.Countries)
 ```
 
-    With `DefineDataPrompt`, the input and output schemas are automatically inferred
-    from the Go type parameters, and the output is returned directly as the typed value.
+With `DefineDataPrompt`, the input and output schemas are automatically inferred
+from the Go type parameters, and the output is returned directly as the typed value.
 
-    For streaming with typed prompts, use `ExecuteStream()`:
+For streaming with typed prompts, use `ExecuteStream()`:
 
 ```go
 for result, err := range geographyPrompt.ExecuteStream(ctx, GeoQuery{CountryCount: 15}) {
@@ -1712,7 +2040,7 @@ class GreetingInput(BaseModel):
 
 my_prompt = ai.define_prompt(
     name='myPrompt',
-    model='googleai/gemini-2.5-flash',
+    model='googleai/gemini-flash-latest',
     input_schema=GreetingInput,
     prompt='Hello, {{name}}. How are you today?',
 )
@@ -1721,7 +2049,7 @@ response = await my_prompt(GreetingInput(name='Alice'))
 print(response.text)
 ```
 
-    You can also define prompts with structured output. For array output, use JSON schema via `TypeAdapter`:
+You can also define prompts with structured output. For array output, use JSON schema via `TypeAdapter`:
 
 ```python
 from pydantic import BaseModel, TypeAdapter
@@ -1733,7 +2061,7 @@ class GeoQuery(BaseModel):
 
 geography_prompt = ai.define_prompt(
     name='GeographyPrompt',
-    model='googleai/gemini-2.5-flash',
+    model='googleai/gemini-flash-latest',
     input_schema=GeoQuery,
     output_schema=CountryList,
     output_format='array',
@@ -1758,16 +2086,66 @@ final_response = await result.response
 print(final_response.output)
 ```
 
-    You can also define prompts with a system message and multi-turn setup:
+You can also define prompts with a system message and multi-turn setup:
 
 ```python
 my_prompt = ai.define_prompt(
     name='chatPrompt',
-    model='googleai/gemini-2.5-flash',
+    model='googleai/gemini-flash-latest',
     input_schema=GreetingInput,
     system='You are a helpful assistant.',
     prompt='Hello, {{name}}!',
 )
+```
+
+</Lang>
+
+<Lang lang="dart">
+
+Use the `definePrompt()` method. It accepts the same metadata as the front matter
+block of a `.prompt` file, along with a Handlebars template string for the
+`prompt` (and optional `system`) parameters:
+
+```dart
+@Schema()
+abstract class $GreetingInput {
+  String get name;
+}
+
+final myPrompt = ai.definePrompt(
+  name: 'myPrompt',
+  model: modelRef('googleai/gemini-flash-latest'),
+  inputSchema: GreetingInput.$schema,
+  prompt: 'Hello, {{name}}. How are you today?',
+);
+
+final response = await myPrompt(GreetingInput(name: 'Alice'));
+print(response.text);
+```
+
+If you need to build the messages programmatically instead of using a Handlebars
+template, use `defineCustomPrompt()`. The function you provide returns a
+`GenerateActionOptions` describing the request:
+
+```dart
+final myPrompt = ai.defineCustomPrompt(
+  name: 'myPrompt',
+  inputSchema: GreetingInput.$schema,
+  fn: (input, ctx) async {
+    return GenerateActionOptions(
+      model: 'googleai/gemini-flash-latest',
+      messages: [
+        Message(
+          role: Role.user,
+          content: [TextPart(text: 'Hello, ${input.name}. How are you today?')],
+        ),
+      ],
+    );
+  },
+);
+
+final response = await myPrompt(GreetingInput(name: 'Alice'));
+print(response.text);
 ```
 
 </Lang>


### PR DESCRIPTION
Add Dart-specific examples and instructions throughout the Dotprompt documentation, covering prompt directories, schemas, tools, and templates. Include a note about using build_runner to generate schema types.

Also update model references from gemini-2.5-flash to gemini-flash-latest.