### PR TITLE
docs: update error-types

### DIFF
--- a/src/content/docs/docs/error-types.mdx
+++ b/src/content/docs/docs/error-types.mdx
@@ -45,6 +45,18 @@ where your error is coming from.
 
 Using `PublicError` allows a web framework handler (e.g. FastAPI, Flask) to know it is safe to return the message in a request. Other kinds of errors will result in a generic 500 message to avoid the possibility of internal exceptions being leaked to attackers.
 
+```python
+from genkit import PublicError
+
+def require_signed_in(auth: dict | None) -> dict:
+    if not auth or 'uid' not in auth:
+        raise PublicError(
+            status='UNAUTHENTICATED',
+            message='Please log in',
+        )
+    return auth
+```
+
 </Lang>
 
 <Lang lang="dart">


### PR DESCRIPTION
The `error-types` page already had a `python` section but no runnable code example. This PR adds one (+12/−0, additive only).

## Code proof

1 ```python fences on the page. Each ran without import/name errors.

| Fence | What it shows | Result |
|---|---|---|
| Fence 1 | 247 chars | ✓ |

### Fence runs (reconstructed + output)

<details>
<summary>Fence 1 — Fence 1 — PASS</summary>

**Doc fence**

```python
from genkit import PublicError

def require_signed_in(auth: dict | None) -> dict:
    if not auth or 'uid' not in auth:
        raise PublicError(
            status='UNAUTHENTICATED',
            message='Please log in',
        )
    return auth
```

**Minimal runnable program** — harness, auto stubs for unresolved names (none), and the earlier chunks this fence needs (prior fence(s): none). Doc lines are unchanged, grouped by imports / classes / defs / run:

```python
# --- harness ---
from genkit import Genkit

ai = Genkit()

# --- imports (fence 1) ---
from genkit import PublicError

# --- flows, tools, and functions (fence 1) ---
def require_signed_in(auth: dict | None) -> dict:
    if not auth or 'uid' not in auth:
        raise PublicError(
            status='UNAUTHENTICATED',
            message='Please log in',
        )
    return auth
```

**Sandbox output**

```
OK — ran end to end against the live model
exit_code: 0
--- stdout ---
2026-06-17 17:08:35 [warning  ] No plugins provided to Genkit

--- stderr ---
/Users/jeffhuang/Desktop/genkit-middleware/py/.venv/lib/python3.12/site-packages/dotpromptz/typing.py:241: UserWarning: Field name "schema" in "PromptInputConfig" shadows an attribute in parent "BaseModel"
  class PromptInputConfig(BaseModel):
/Users/jeffhuang/Desktop/genkit-middleware/py/.venv/lib/python3.12/site-packages/dotpromptz/typing.py:256: UserWarning: Field name "schema" in "PromptOutputConfig" shadows an attribute in parent "BaseModel"
  class PromptOutputConfig(BaseModel):
```
</details>

Structural: docsite validator pass (`pnpm generate-language-pages` rules / Python mirror).

## Diff

```
src/content/docs/docs/error-types.mdx | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```
