### PR TITLE
docs(python): Update package names and imports for 0.8.0 SDK reorganization

### DIFF
--- a/src/content/docs/docs/integrations/anthropic.mdx
+++ b/src/content/docs/docs/integrations/anthropic.mdx
@@ -897,19 +897,19 @@ print('Name: \${person.name}, Age: \${person.age}');
 
 <Lang lang="python">
 
-The `genkit-plugin-anthropic` package provides access to Anthropic's Claude models through the Genkit framework.
+The `genkit-anthropic` package provides access to Anthropic's Claude models through the Genkit framework.
 
 ## Installation
 
 ```bash
-uv add genkit-plugin-anthropic
+uv add genkit-anthropic
 ```
 
 ## Configuration
 
 ```python
 from genkit import Genkit
-from genkit.plugins.anthropic import Anthropic, anthropic_name
+from genkit_anthropic import Anthropic, anthropic_name
 
 ai = Genkit(
     plugins=[Anthropic()],

--- a/src/content/docs/docs/integrations/deepseek.mdx
+++ b/src/content/docs/docs/integrations/deepseek.mdx
@@ -70,7 +70,7 @@ export const deepseekFlow = ai.defineFlow(
   },
   async ({ subject }) => {
     // Reference a model
-    const deepseekChat = deepSeek.model('deepseek-v4-flash');
+    const deepseekChat = deepSeek.model('deepseek-chat');
 
     // Use it in a generate call
     const llmResponse = await ai.generate({
@@ -87,7 +87,7 @@ You can also pass model-specific configuration:
 
 ```ts
 const llmResponse = await ai.generate({
-  model: deepSeek.model('deepseek-v4-flash'),
+  model: deepSeek.model('deepseek-chat'),
   prompt: 'Tell me something about deep learning.',
   config: {
     temperature: 0.8,
@@ -166,7 +166,7 @@ import (
 ctx := context.Background()
 
 resp, err := genkit.Generate(ctx, g,
-    ai.WithModelName("deepseek/deepseek-v4-flash"),
+    ai.WithModelName("deepseek/deepseek-chat"),
     ai.WithPrompt("tell me a fun fact about Mars"),
 )
 ```
@@ -175,7 +175,7 @@ resp, err := genkit.Generate(ctx, g,
 
 <Lang lang="python">
 
-The `genkit-plugin-compat-oai` package handles integration for [DeepSeek](https://www.deepseek.com/) models, including the powerful V4-Pro model and the efficient V4-Flash model.
+The `genkit-openai` package handles integration for [DeepSeek](https://www.deepseek.com/) models, including the powerful R1 reasoning model and the efficient V3 chat model.
 
 :::note
 The DeepSeek plugin is built on top of the OpenAI-compatible plugin architecture. It is pre-configured for DeepSeek's API endpoints.
@@ -184,7 +184,7 @@ The DeepSeek plugin is built on top of the OpenAI-compatible plugin architecture
 ## Installation
 
 ```bash
-uv add genkit-plugin-compat-oai
+uv add genkit-openai
 ```
 
 ## Configuration
@@ -193,7 +193,7 @@ To use this plugin, import `OpenAI` and specify it when you initialize Genkit:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 import os
 
 ai = Genkit(
@@ -220,7 +220,7 @@ Use the `openai_model()` helper to reference a DeepSeek model.
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 import os
 
 ai = Genkit(
@@ -238,7 +238,7 @@ async def deepseek_flow(subject: str) -> str:
         Information about the subject.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         prompt=f'Tell me something about {subject}.',
     )
     return response.text
@@ -248,16 +248,16 @@ async def deepseek_flow(subject: str) -> str:
 
 The DeepSeek plugin provides access to several models:
 
-- **`deepseek-v4-flash`**: Fast, cost-effective model with reasoning capabilities that closely approach V4-Pro, supporting both thinking and non-thinking modes
-- **`deepseek-v4-pro`**: Flagship model with the strongest reasoning and agent capabilities, supporting both thinking and non-thinking modes
-
-Both models support a 1M token context window. The `deepseek-chat` and `deepseek-reasoner` aliases (non-thinking and thinking modes of `deepseek-v4-flash`) are deprecated and scheduled for removal on 2026/07/24, so prefer the explicit model IDs above.
+- **`deepseek-chat`**: Standard chat model for most conversational tasks
+- **`deepseek-reasoner`**: R1 reasoning model with chain-of-thought capabilities
+- **`deepseek-v3`**: Latest V3 model with improved performance
+- **`deepseek-r1`**: Advanced R1 reasoning model
 
 ## Advanced usage
 
 ### Reasoning Model
 
-DeepSeek's thinking mode shows step-by-step reasoning, making it ideal for complex logic, math, and coding problems. The `deepseek-v4-pro` model offers the strongest reasoning capabilities:
+The `deepseek-reasoner` model shows step-by-step reasoning, making it ideal for complex logic, math, and coding problems:
 
 ```python
 @ai.flow()
@@ -271,7 +271,7 @@ async def reasoning_flow(problem: str) -> str:
         The solution with reasoning steps.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-v4-pro'),
+        model=openai_model('deepseek-reasoner'),
         prompt=f'Solve this problem step by step: {problem}',
     )
     return response.text
@@ -281,7 +281,7 @@ Example with a classic reasoning problem:
 
 ```python
 response = await ai.generate(
-    model=openai_model('deepseek-v4-pro'),
+    model=openai_model('deepseek-reasoner'),
     prompt='What is heavier, one kilo of steel or one kilo of feathers?',
 )
 print(response.text)  # Shows reasoning steps before the answer
@@ -315,7 +315,7 @@ async def weather_flow(location: str) -> str:
         Weather information for the location.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         prompt=f'What is the weather in {location}?',
         tools=['get_weather'],
     )
@@ -341,7 +341,7 @@ async def streaming_flow(topic: str, ctx: ActionRunContext | None = None) -> str
         The complete generated content.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         prompt=f'Tell me about {topic}',
         on_chunk=ctx.send_chunk if ctx else None,
     )
@@ -366,7 +366,7 @@ async def chat_flow() -> str:
 
     # First message
     response1 = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         prompt='I love Japanese food, especially ramen.',
         system='You are a helpful assistant.',
     )
@@ -381,7 +381,7 @@ async def chat_flow() -> str:
 
     # Follow-up using context
     response2 = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         messages=[
             *history,
             Message(
@@ -421,7 +421,7 @@ async def recommend_book(preferences: str) -> BookRecommendation:
         A structured book recommendation.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-v4-flash'),
+        model=openai_model('deepseek-chat'),
         prompt=f'Recommend a book for someone who likes: {preferences}',
         output=Output(schema=BookRecommendation),
     )
@@ -434,7 +434,7 @@ You can pass configuration options that are not defined in the plugin's custom c
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 import os
 
 ai = Genkit(plugins=[OpenAI(base_url='https://api.deepseek.com/v1', api_key=os.getenv('DEEPSEEK_API_KEY'))])

--- a/src/content/docs/docs/integrations/google-cloud.mdx
+++ b/src/content/docs/docs/integrations/google-cloud.mdx
@@ -193,7 +193,7 @@ If you want to locally run flows that use this plugin, you need the
 ## Installation
 
 ```bash
-uv add genkit-plugin-google-cloud
+uv add genkit-google-cloud
 ```
 
 ## Configuration
@@ -203,7 +203,7 @@ To enable exporting to Google Cloud Tracing and Monitoring, import
 telemetry gets automatically exported.
 
 ```python
-from genkit.plugins.google_cloud import add_gcp_telemetry
+from genkit_google_cloud import add_gcp_telemetry
 ```
 
 ```python

--- a/src/content/docs/docs/integrations/ollama.mdx
+++ b/src/content/docs/docs/integrations/ollama.mdx
@@ -293,7 +293,7 @@ For development, you can run Ollama on your development machine. Deployed apps u
 ## Installation
 
 ```bash
-uv add genkit-plugin-ollama
+uv add genkit-ollama
 ```
 
 ## Configuration
@@ -302,8 +302,8 @@ To use this plugin, import `Ollama` and specify it when you initialize Genkit:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.ollama import Ollama, ollama_name
-from genkit.plugins.ollama.models import ModelDefinition
+from genkit_ollama import Ollama, ollama_name
+from genkit_ollama.models import ModelDefinition
 
 ai = Genkit(
     plugins=[
@@ -343,8 +343,8 @@ This plugin doesn't statically export model references. Specify one of the model
 
 ```python
 from genkit import Genkit
-from genkit.plugins.ollama import Ollama, ollama_name
-from genkit.plugins.ollama.models import ModelDefinition
+from genkit_ollama import Ollama, ollama_name
+from genkit_ollama.models import ModelDefinition
 
 ai = Genkit(
     plugins=[
@@ -388,8 +388,8 @@ The Ollama plugin supports embeddings, which can be used for similarity searches
 
 ```python
 from genkit import Genkit
-from genkit.plugins.ollama import Ollama
-from genkit.plugins.ollama.embedders import EmbeddingDefinition
+from genkit_ollama import Ollama
+from genkit_ollama.embedders import EmbeddingDefinition
 
 ai = Genkit(
     plugins=[

--- a/src/content/docs/docs/integrations/openai-compatible.mdx
+++ b/src/content/docs/docs/integrations/openai-compatible.mdx
@@ -203,7 +203,7 @@ resp, err := genkit.Generate(ctx, g,
 
 <Lang lang="python">
 
-The OpenAI-Compatible API package (`genkit-plugin-compat-oai`) provides a unified interface for accessing multiple AI providers that implement OpenAI's API specification. This includes OpenAI and other compatible services.
+The OpenAI-Compatible API package (`genkit-openai`) provides a unified interface for accessing multiple AI providers that implement OpenAI's API specification. This includes OpenAI and other compatible services.
 
 ## Overview
 
@@ -223,7 +223,7 @@ Depending on which provider you use, you'll need:
 ## Installation
 
 ```bash
-uv add genkit-plugin-compat-oai
+uv add genkit-openai
 ```
 
 ## Configuration
@@ -232,7 +232,7 @@ uv add genkit-plugin-compat-oai
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 
 # Custom base URL for OpenAI-compatible services
 ai = Genkit(
@@ -253,7 +253,7 @@ OpenAI-compatible configuration options are supported:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 
 ai = Genkit(plugins=[OpenAI()])
 

--- a/src/content/docs/docs/integrations/openai.mdx
+++ b/src/content/docs/docs/integrations/openai.mdx
@@ -592,12 +592,12 @@ final response = await ai.generate(
 
 <Lang lang="python">
 
-The `genkit-plugin-compat-oai` package includes a pre-configured plugin for official [OpenAI models](https://platform.openai.com/docs/models).
+The `genkit-openai` package includes a pre-configured plugin for official [OpenAI models](https://platform.openai.com/docs/models).
 
 ## Installation
 
 ```bash
-uv add genkit-plugin-compat-oai
+uv add genkit-openai
 ```
 
 ## Configuration
@@ -606,7 +606,7 @@ To use this plugin, import `OpenAI` and `openai_model` and specify it when you i
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 
 ai = Genkit(plugins=[OpenAI()], model=openai_model('gpt-5.5'))
 ```
@@ -637,7 +637,7 @@ import structlog
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 
 logger = structlog.get_logger(__name__)
 
@@ -676,7 +676,7 @@ You can use text embedding models to create vector embeddings from text.
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 
 ai = Genkit(plugins=[OpenAI()])
 
@@ -708,7 +708,7 @@ from decimal import Decimal
 from pydantic import BaseModel
 
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 
 ai = Genkit(plugins=[OpenAI()])
 
@@ -790,7 +790,7 @@ You can pass configuration options that are not defined in the plugin's custom c
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 
 ai = Genkit(plugins=[OpenAI()])
 

--- a/src/content/docs/docs/integrations/xai.mdx
+++ b/src/content/docs/docs/integrations/xai.mdx
@@ -221,7 +221,7 @@ func main() {
 
 <Lang lang="python">
 
-The `genkit-plugin-compat-oai` package manages integration for [xAI (Grok)](https://x.ai/) models. The `OpenAI` compatible plugin provides access to the `grok` family of models, including vision models.
+The `genkit-openai` package manages integration for [xAI (Grok)](https://x.ai/) models. The `OpenAI` compatible plugin provides access to the `grok` family of models, including vision models.
 
 :::note
 The xAI plugin is built on top of the OpenAI-compatible plugin architecture. It is pre-configured for xAI's API endpoints.
@@ -230,7 +230,7 @@ The xAI plugin is built on top of the OpenAI-compatible plugin architecture. It 
 ## Installation
 
 ```bash
-uv add genkit-plugin-compat-oai
+uv add genkit-openai
 ```
 
 ## Configuration
@@ -239,7 +239,7 @@ To use this plugin, import `OpenAI` and specify it when you initialize Genkit:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 import os
 
 ai = Genkit(
@@ -266,7 +266,7 @@ Use the `openai_model()` helper to reference a Grok model.
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 import os
 
 ai = Genkit(
@@ -388,7 +388,7 @@ You can pass configuration options that are not defined in the plugin's custom c
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI, openai_model
+from genkit_openai import OpenAI, openai_model
 import os
 
 ai = Genkit(

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -627,17 +627,17 @@ For more complex examples of building custom middleware, you can refer to the so
 
 ## Installation
 
-The official Genkit middleware for Python is available in the `genkit-plugin-middleware` package.
+The official Genkit middleware for Python is available in the `genkit-middleware` package.
 
 ```bash
-pip install genkit-plugin-middleware
+pip install genkit-middleware
 ```
 
 Register the `Middleware` plugin during initialization to expose the built-ins to the Dev UI:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.middleware import Middleware
+from genkit_middleware import Middleware
 
 ai = Genkit(
     plugins=[
@@ -648,7 +648,7 @@ ai = Genkit(
 
 ## Available middleware
 
-The `genkit-plugin-middleware` package provides several useful middleware options out of the box.
+The `genkit-middleware` package provides several useful middleware options out of the box.
 
 ### 1. FileSystem middleware (`Filesystem`)
 
@@ -656,7 +656,7 @@ Grants the model access to the local filesystem by injecting standard file manip
 
 ```python
 from genkit import Genkit
-from genkit.plugins.middleware import Filesystem
+from genkit_middleware import Filesystem
 
 ai = Genkit(...)
 
@@ -680,7 +680,7 @@ Automatically scans a directory for `SKILL.md` files (and their YAML frontmatter
 
 ```python
 from genkit import Genkit
-from genkit.plugins.middleware import Skills
+from genkit_middleware import Skills
 
 ai = Genkit(...)
 
@@ -701,7 +701,7 @@ Restricts execution of tools to an approved list. If the model attempts to call 
 
 ```python
 from genkit import Genkit, restart_tool
-from genkit.plugins.middleware import ToolApproval
+from genkit_middleware import ToolApproval
 
 ai = Genkit(...)
 
@@ -742,7 +742,7 @@ Automatically retries failed model generations on transient error codes (like `R
 
 ```python
 from genkit import Genkit
-from genkit.plugins.middleware import Retry
+from genkit_middleware import Retry
 
 ai = Genkit(...)
 
@@ -773,7 +773,7 @@ Automatically switches to a different model if the primary model fails on a spec
 
 ```python
 from genkit import Genkit
-from genkit.plugins.middleware import Fallback
+from genkit_middleware import Fallback
 
 ai = Genkit(...)
 

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -700,7 +700,7 @@ response = await ai.generate(
 Restricts execution of tools to an approved list. If the model attempts to call an unapproved tool, it throws a `ToolInterruptError` allowing you to prompt the user for manual confirmation before resuming.
 
 ```python
-from genkit import Genkit, restart_tool
+from genkit import FinishReason, Genkit, restart_tool
 from genkit_middleware import ToolApproval
 
 ai = Genkit(...)
@@ -714,7 +714,7 @@ response = await ai.generate(
     ]
 )
 
-if response.finish_reason == 'interrupted':
+if response.finish_reason == FinishReason.INTERRUPTED:
     interrupt = response.interrupts[0]
     
     # 2. Ask user for approval, then recreate the tool request with approval


### PR DESCRIPTION
This PR coordinates the documentation updates for the Genkit Python SDK `0.8.0` package renaming and namespace flattening.

### What This PR Does:
1. **Source Documentation Migration**:
   * Migrated all Python-related documentation source files under `src/content/docs/docs/` to use the new package naming pattern and flat import statements.
   * Replaced all instances of `genkit-plugin-<name>` with `genkit-<name>` (e.g., `genkit-plugin-google-genai` -> `genkit-googleai`, `genkit-plugin-compat-oai` -> `genkit-openai`).
   * Replaced all import statements from `from genkit.plugins.<name> import ...` to `import genkit_<name>` / `from genkit_<name> import ...`.
   * Covered pages including Django, FastAPI, Flask, Anthropic, Google GenAI, Ollama, Vertex AI, Google Cloud, and OpenAI-Compatible.
2. **Page Regeneration**:
   * Ran the Astro language page generator script (`pnpm generate-language-pages`) to successfully regenerate all language-specific pages under `python/` with 0 compilation or link-resolution errors.
