### PR TITLE
docs: update model lists for recent Go/Python/Dart plugin work

### DIFF
--- a/src/content/docs/docs/integrations/anthropic.mdx
+++ b/src/content/docs/docs/integrations/anthropic.mdx
@@ -641,6 +641,7 @@ You must provide an API key from Anthropic. You can get an API key from the [Ant
 ## Supported Models
 
 - **claude-opus-4-8** - Most capable model for complex reasoning and agentic tasks
+- **claude-opus-4-7** - Previous-generation Opus, highly capable for long-horizon work
 - **claude-sonnet-4-6** - Balanced model with extended thinking support
 - **claude-haiku-4-5** - Fastest and most cost-effective model
 
@@ -931,6 +932,7 @@ ai = Genkit(
 - `claude-haiku-4-5` - Fastest and most cost-effective
 - `claude-sonnet-4-6` - Balanced performance with thinking/reasoning support
 - `claude-opus-4-8` - Most capable for complex reasoning and agentic tasks
+- `claude-opus-4-7` - Previous-generation Opus, highly capable for long-horizon work
 
 ## Basic Usage
 

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1158,7 +1158,7 @@ in conjunction with a service like Cloud Secret Manager or similar.
 
 **Gemini 2.5 Series** - Stable models with advanced reasoning and multimodal capabilities:
 
-- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
 - `gemini-2.5-flash` - Fast and efficient for most use cases
 - `gemini-2.5-flash-lite` - Lightweight version for simple tasks
 
@@ -1618,7 +1618,7 @@ This is useful for multi-tenant apps or routing requests to different keys. Mode
 
 **Gemini 2.5 Series** - Stable models with advanced reasoning:
 
-- `gemini-2.5-pro` - Most capable stable model
+- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
 - `gemini-2.5-flash` - Fast and efficient for most use cases
 - `gemini-2.5-flash-lite` - Lightweight version for simple tasks
 

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1146,6 +1146,31 @@ in conjunction with a service like Cloud Secret Manager or similar.
 
 ### Generative models
 
+#### Available Models
+
+**Gemini 3+ Series** - Latest models with state-of-the-art reasoning:
+
+- `gemini-3.5-flash` - Fast and efficient for most use cases
+- `gemini-3.1-flash-image` - Fast and efficient image generation
+- `gemini-3.1-flash-image-preview` - Preview of the flash image model
+- `gemini-3.1-flash-lite-preview` - Preview of the lightweight model
+- `gemini-3-pro-image` - Supports image generation outputs
+
+**Gemini 2.5 Series** - Stable models with advanced reasoning and multimodal capabilities:
+
+- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-flash` - Fast and efficient for most use cases
+- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
+
+**Gemini 2.0 Series**:
+
+- `gemini-2.0-flash` - Fast and efficient
+- `gemini-2.0-flash-exp` - Experimental Flash model
+
+:::note
+See the [Google Generative AI models documentation](https://ai.google.dev/gemini-api/docs/models) for a complete list of available models and their capabilities.
+:::
+
 To get a reference to a supported model, specify its identifier to `googlegenai.GoogleAIModel`:
 
 ```go
@@ -1177,10 +1202,15 @@ See [Generating content with AI models](/docs/models) for more information.
 
 ### Embedding models
 
+#### Available Models
+
+- `gemini-embedding-2` - Latest embedding model with **3072** dimensions; supports multimodal input (text, images, video).
+- `embedding-001` - Legacy text embedding model with **768** dimensions.
+
 To get a reference to a supported embedding model, specify its identifier to `googlegenai.GoogleAIEmbedder`:
 
 ```go
-embeddingModel := googlegenai.GoogleAIEmbedder(g, "text-embedding-004")
+embeddingModel := googlegenai.GoogleAIEmbedder(g, "gemini-embedding-2")
 ```
 
 Embedder references have an `Embed()` method that calls the Google AI API:
@@ -1578,6 +1608,12 @@ This is useful for multi-tenant apps or routing requests to different keys. Mode
 
 - `gemini-3-pro-preview` - Most capable model for complex tasks
 - `gemini-3-flash-preview` - Fast and intelligent for high-volume tasks
+- `gemini-3.1-pro-preview` - Preview of the most capable model for complex tasks
+- `gemini-3.1-pro-preview-customtools` - Tuned for best custom tools support
+- `gemini-3.1-flash-lite-preview` - Preview of the lightweight model
+- `gemini-3.1-flash-image` - Fast and efficient image generation
+- `gemini-3.1-flash-image-preview` - Preview of the flash image model
+- `gemini-3-pro-image` - Supports image generation outputs
 
 **Gemini 2.5 Series** - Stable models with advanced reasoning:
 

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1205,6 +1205,7 @@ See [Generating content with AI models](/docs/models) for more information.
 #### Available Models
 
 - `gemini-embedding-2` - Latest embedding model with **3072** dimensions; supports multimodal input (text, images, video).
+- `text-embedding-004` - Stable text embedding model with **768** dimensions.
 - `embedding-001` - Legacy text embedding model with **768** dimensions.
 
 To get a reference to a supported embedding model, specify its identifier to `googlegenai.GoogleAIEmbedder`:

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -95,6 +95,30 @@ print(response.text);
 
 See [Generating content with AI models](/docs/models) for more information.
 
+### Embedding models
+
+The following embedding models are supported:
+
+- `text-embedding-005` - English text embeddings (**768** dimensions)
+- `text-multilingual-embedding-002` - Multilingual text embeddings (**768** dimensions)
+- `multimodalembedding@001` - Multimodal embeddings for text, image, and video
+- `gemini-embedding-001` - Gemini embedding model (default **3072** dimensions)
+
+To get a reference to a supported embedding model, specify its identifier to `vertexAI.textEmbedding`:
+
+```dart
+final embeddings = await ai.embedMany(
+  embedder: vertexAI.textEmbedding('gemini-embedding-001'),
+  documents: [
+    DocumentData(content: [TextPart(text: 'Hello world')]),
+  ],
+);
+
+print(embeddings[0].embedding);
+```
+
+See [Retrieval-augmented generation (RAG)](/docs/rag) for more information.
+
 </Lang>
 
 The Vertex AI plugin provides access to Google Cloud's enterprise-grade AI platform, offering advanced features beyond basic model access. Use this for enterprise applications that need grounding, Vector Search, Model Garden, or evaluation capabilities.
@@ -694,7 +718,27 @@ modelRef := googlegenai.VertexAIModelRef("gemini-flash-latest", &genai.GenerateC
 })
 ```
 
-The following models are supported: `gemini-flash-latest`, `gemini-pro-latest`, `gemini-2.5-flash`, `gemini-2.5-pro`, and other models.
+The following models are supported, in addition to the `gemini-flash-latest` and `gemini-pro-latest` aliases:
+
+**Gemini 3+ Series** - Latest models with state-of-the-art reasoning:
+
+- `gemini-3.5-flash` - Fast and efficient for most use cases
+- `gemini-3.1-flash-lite` - Lightweight version for simple tasks
+- `gemini-3.1-flash-lite-preview` - Preview of the lightweight model
+- `gemini-3.1-flash-image` - Fast and efficient image generation
+- `gemini-3.1-flash-image-preview` - Preview of the flash image model
+- `gemini-3-pro-image` - Supports image generation outputs
+
+**Gemini 2.5 Series** - Stable models with advanced reasoning:
+
+- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-flash` - Fast and efficient for most use cases
+- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
+
+**Gemini 2.0 Series**:
+
+- `gemini-2.0-flash` - Fast and efficient
+- `gemini-2.0-flash-lite` - Lightweight version
 
 Model references have a `Generate()` method that calls the Vertex AI API:
 
@@ -802,6 +846,23 @@ ai = Genkit(
 ```
 
 _Note: When using Express Mode, you typically omit `project` and `location` on `VertexAI` (see the [Express Mode docs](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview))._
+
+### Available Models
+
+**Gemini 3+ Series** - Latest models with state-of-the-art reasoning:
+
+- `gemini-3.5-flash` - Fast and efficient for most use cases
+- `gemini-3.1-pro-preview` - Preview of the most capable model for complex tasks
+- `gemini-3.1-flash-lite` - Lightweight version for simple tasks
+- `gemini-3.1-flash-image` - Fast and efficient image generation
+- `gemini-3-pro-image` - Supports image generation outputs
+- `gemini-3-flash-preview` - Fast and intelligent for high-volume tasks
+
+**Gemini 2.5 Series** - Stable models with advanced reasoning:
+
+- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-flash` - Fast and efficient for most use cases
+- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
 
 ### Basic Usage
 

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -731,7 +731,7 @@ The following models are supported, in addition to the `gemini-flash-latest` and
 
 **Gemini 2.5 Series** - Stable models with advanced reasoning:
 
-- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
 - `gemini-2.5-flash` - Fast and efficient for most use cases
 - `gemini-2.5-flash-lite` - Lightweight version for simple tasks
 
@@ -860,7 +860,7 @@ _Note: When using Express Mode, you typically omit `project` and `location` on `
 
 **Gemini 2.5 Series** - Stable models with advanced reasoning:
 
-- `gemini-2.5-pro` - Most capable stable model for complex tasks
+- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
 - `gemini-2.5-flash` - Fast and efficient for most use cases
 - `gemini-2.5-flash-lite` - Lightweight version for simple tasks
 


### PR DESCRIPTION
## What

Brings the per-language **Available Models** lists in the Google AI, Vertex AI, and Anthropic integration docs up to date with models that recently landed in the Go, Python, and Dart plugins.

## Scope / approach

- **Additive only** - no existing entries removed, even where they looked stale. JS sections untouched (they were already current and served as the style template).
- Added enumerated lists where only prose existed (Go GoogleAI/Vertex, Python Vertex, Dart Vertex embedders).
- Every added model identifier was **verified against the plugin source**, not guessed.

## Changes

| File | Section | Change |
|------|---------|--------|
| `anthropic.mdx` | Go, Python | Add `claude-opus-4-7` |
| `google-genai.mdx` | Go | Add `Available Models` lists (Gemini + embedders); embedder example now uses `gemini-embedding-2` |
| `google-genai.mdx` | Python | Add `gemini-3.1` family + image models to the Gemini list |
| `vertex-ai.mdx` | Go, Python | Add `Available Models` lists |
| `vertex-ai.mdx` | Dart | Document Vertex embedders (previously undocumented) |

## Source authority

- **Go** - `googleAIModels` / `vertexAIModels` arrays and `embedderConfig` in `go/plugins/googlegenai/models.go`; Anthropic lists models dynamically from the API.
- **Python** - `GoogleAIGeminiVersion` / `VertexAIGeminiVersion` enums in `py/plugins/google-genai/.../models/gemini.py`; `anthropic/model_info.py`.
- **Dart** - Vertex embedders in `genkit_vertexai`; public API `vertexAI.textEmbedding(...)`.

## Note

`gemini-3.5-flash` is registered for **Vertex** (not GoogleAI) in the Python plugin, so it is documented under the Vertex section rather than GoogleAI.

## Verification

- `pnpm build` passes (360 pages, all internal links valid).
- Every added identifier exact-matched against the source files above.