### PR TITLE
docs: add Firestore session store and schemantic_builder guidance

### DIFF
--- a/src/content/docs/docs/agents/session-stores.mdx
+++ b/src/content/docs/docs/agents/session-stores.mdx
@@ -255,6 +255,29 @@ final weatherAgent = ai.defineAgent(
 
 Snapshots will be saved to files inside the `.sessions` folder.
 
+## Use a Firestore store
+
+`FirestoreSessionStore` (from `package:genkit_google_cloud/genkit_google_cloud.dart`) persists snapshots in Cloud Firestore. It is a managed, multi-instance store, so it is the built-in option for production apps where several server instances share sessions.
+
+```dart
+import 'package:genkit/genkit.dart';
+import 'package:genkit_google_cloud/genkit_google_cloud.dart';
+
+final store = FirestoreSessionStore(
+  collection: 'genkit-sessions',
+);
+
+final supportAgent = ai.defineAgent(
+  name: 'supportAgent',
+  system: 'Help customers with their orders.',
+  store: store,
+);
+```
+
+By default the store creates a new `Firestore()` client that uses Application Default Credentials (ADC). ADC alone does not always carry a project ID, so if writes fail with an error like "Project ID has not been discovered yet", set the `GOOGLE_CLOUD_PROJECT` environment variable to your project ID (or pass an explicit `Firestore` instance via the `db` parameter). The store also picks up `FIRESTORE_EMULATOR_HOST`, so the same code runs against the Firestore emulator for local testing.
+
+The `collection` option defaults to `genkit-sessions`. Two companion collections, `<collection>-shards` and `<collection>-pointers`, are derived from it for sharded checkpoint state and per-session pointers. Snapshot documents are nested under a per-tenant prefix (`global` by default), so a flat listing of the root collection can look empty even though `loadChat()` restores full state.
+
 ## Implement a production store
 
 To store snapshots in a shared production database (such as PostgreSQL, Spanner, or Redis), implement a custom `SessionStore`:

--- a/src/content/docs/docs/agents/state.mdx
+++ b/src/content/docs/docs/agents/state.mdx
@@ -446,6 +446,13 @@ session.updateCustom((state) {
 
 Keep custom state serializable, and provide the matching `stateSchema` when defining your agent (e.g. `stateSchema: TaskState.$schema`) so the typed state is validated at load time. When state is a loose JSON map rather than a typed class, use a map schema such as `SchemanticType.map(SchemanticType.string(), SchemanticType.dynamicSchema())`; the updater then receives a typed `Map<String, dynamic>?`.
 
+:::tip[Prefer whole-collection tools over incremental ones]
+
+When a tool mutates a collection in session state, prefer a tool that replaces the whole collection in a single call (for example `setTasks(tasks: [...])`) over one that appends a single item (for example `addTask(...)`). A model may emit several tool calls in one parallel batch, and each `updateCustom` reads the same base snapshot before writing back its own result, so parallel appends race and only the last write survives. A single whole-collection tool is idempotent and immune to this last-writer-wins problem.
+:::
+
+Make optional or computed fields nullable (or give them a `defaultValue`) in your `@Schema`. Generated getters are non-nullable casts, so reading a field that was never written on a partially populated state blob throws (for example `Null is not a subtype of num`) instead of returning a default.
+
 ## Server-managed stores
 
 Add a store when defining your agent to enable server-managed persistence:

--- a/src/content/docs/docs/backend-frameworks/shelf.mdx
+++ b/src/content/docs/docs/backend-frameworks/shelf.mdx
@@ -45,7 +45,7 @@ curl -sL cli.genkit.dev | bash
 Add the Genkit packages your app needs:
 
 ```bash
-dart pub add genkit genkit_google_genai genkit_shelf schemantic shelf shelf_cors_headers shelf_router dev:build_runner
+dart pub add genkit genkit_google_genai genkit_shelf schemantic shelf shelf_cors_headers shelf_router dev:build_runner dev:schemantic_builder
 ```
 
 These packages include:
@@ -56,7 +56,8 @@ These packages include:
 - **`schemantic`**: Generates JSON schemas from Dart classes for typed flow inputs and outputs.
 - **`shelf`** and **`shelf_router`**: Shelf server and routing.
 - **`shelf_cors_headers`**: CORS middleware. Lets browser frontends served from a different origin call the Genkit endpoint.
-- **`build_runner`**: Generates the schema code from your annotated classes.
+- **`build_runner`**: Runs Dart code generation.
+- **`schemantic_builder`**: The `build_runner` generator for `schemantic`. As of `schemantic` 0.2.x this lives in a separate package, and it must be a dev dependency; without it `dart run build_runner build` reports "wrote 0 outputs" and generates no `.g.dart` files.
 
 ### Configure a model API key
 
@@ -78,9 +79,9 @@ export GEMINI_API_KEY=<your API key>
 ```
 
 <Aside type="note" title="Prefer a different model?">
-  This tutorial uses Gemini, but Genkit also supports [Anthropic (Claude)](/docs/integrations/anthropic),
-  [OpenAI](/docs/integrations/openai), and
-  many [other model providers](/docs/integrations/model-providers).
+  This tutorial uses Gemini, but Genkit also supports [Anthropic
+  (Claude)](/docs/integrations/anthropic), [OpenAI](/docs/integrations/openai),
+  and many [other model providers](/docs/integrations/model-providers).
 </Aside>
 
 ## Create the backend

--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -81,7 +81,10 @@ dependency in your project.
 :::note
 Genkit Dart uses [`build_runner`](https://dart.dev/tools/build_runner) to generate schema types from your
 [schemantic](https://pub.dev/packages/schemantic) classes. When you define input or output schemas in code,
-remember to run `dart run build_runner build` before running your app.
+remember to run `dart run build_runner build` before running your app. As of `schemantic` 0.2.x the code
+generator lives in a separate `schemantic_builder` package, so add both dependencies (`dart pub add schemantic`
+and `dart pub add dev:schemantic_builder`). Without `schemantic_builder`, `build_runner` reports "wrote 0
+outputs" and generates no `.g.dart` files.
 :::
 
 </Lang>


### PR DESCRIPTION
Document FirestoreSessionStore as the built-in production session store, including ADC/project ID setup and derived collection behavior.

Add state guidance to prefer whole-collection tools over incremental ones to avoid parallel update races, and to make optional fields nullable.

Update shelf backend setup to include the separate `schemantic_builder` package required as of schemantic 0.2.x.