### PR TITLE
docs(py): modernize core genkit and google-genai plugin usage

### DIFF
--- a/src/components/landing/LanguageSelector.astro
+++ b/src/components/landing/LanguageSelector.astro
@@ -306,8 +306,8 @@ func main() {
         name: "Gemini",
         id: "gemini",
         active: true,
-        code: `from genkit.ai import Genkit
-from genkit.plugins.google_genai import GoogleAI
+        code: `from genkit import Genkit
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
 	plugins=[GoogleAI()],
@@ -322,8 +322,8 @@ print(response.text)`
       {
         name: "Nano Banana",
         id: "nano-banana",
-        code: `from genkit.ai import Genkit
-from genkit.plugins.google_genai import GoogleAI
+        code: `from genkit import Genkit
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
 	plugins=[GoogleAI()],
@@ -343,7 +343,7 @@ print(f"Generated text: {response.text}")`
       {
         name: "OpenAI",
         id: "openai",
-        code: `from genkit.ai import Genkit
+        code: `from genkit import Genkit
 from genkit.plugins.compat_oai import OpenAI
 
 ai = Genkit(
@@ -359,7 +359,7 @@ print(response.text)`
       {
         name: "Ollama",
         id: "ollama",
-        code: `from genkit.ai import Genkit
+        code: `from genkit import Genkit
 from genkit.plugins.ollama import Ollama
 from genkit.plugins.ollama.models import ModelDefinition
 

--- a/src/content/docs/docs/backend-frameworks/django.mdx
+++ b/src/content/docs/docs/backend-frameworks/django.mdx
@@ -41,7 +41,7 @@ uv run python manage.py startapp recipes
 ### Install packages
 
 ```bash
-uv add django django-cors-headers uvicorn genkit genkit-plugin-django genkit-plugin-google-genai
+uv add django django-cors-headers uvicorn genkit genkit-plugin-django genkit-google-genai
 ```
 
 These packages include:
@@ -51,7 +51,7 @@ These packages include:
 - **`uvicorn`**: ASGI server that runs Django with async support.
 - **`genkit`**: Core Genkit SDK.
 - **`genkit-plugin-django`**: Helper that exposes Genkit flows as Django views, including server-sent events for streaming.
-- **`genkit-plugin-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
+- **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
 
 Install the Genkit CLI, which enables Genkit testing and observability:
 
@@ -133,7 +133,7 @@ from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
 from genkit.plugins.django import genkit_django_handler
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/backend-frameworks/fastapi.mdx
+++ b/src/content/docs/docs/backend-frameworks/fastapi.mdx
@@ -43,7 +43,7 @@ curl -sL cli.genkit.dev | bash
 Then install the packages you need in your project:
 
 ```bash
-uv add fastapi uvicorn genkit genkit-plugin-google-genai genkit-plugin-fastapi
+uv add fastapi uvicorn genkit genkit-google-genai genkit-plugin-fastapi
 ```
 
 These packages include:
@@ -51,7 +51,7 @@ These packages include:
 - **`fastapi`**: The async Python web framework that serves your endpoint.
 - **`uvicorn`**: The ASGI server that runs your FastAPI app.
 - **`genkit`**: Core Genkit SDK.
-- **`genkit-plugin-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
+- **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
 - **`genkit-plugin-fastapi`**: Serves Genkit flows as FastAPI endpoints, including streaming.
 
 ### Configure a model API key
@@ -101,7 +101,7 @@ from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
 from genkit.plugins.fastapi import genkit_fastapi_handler
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/backend-frameworks/flask.mdx
+++ b/src/content/docs/docs/backend-frameworks/flask.mdx
@@ -45,14 +45,14 @@ curl -sL cli.genkit.dev | bash
 Then install the packages you need in your project:
 
 ```bash
-uv add "flask[async]" flask-cors genkit genkit-plugin-google-genai genkit-plugin-flask
+uv add "flask[async]" flask-cors genkit genkit-google-genai genkit-plugin-flask
 ```
 
 These packages include:
 
 - **`flask`**: The Flask web framework.
 - **`genkit`**: Core Genkit SDK for Python.
-- **`genkit-plugin-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
+- **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
 - **`genkit-plugin-flask`**: Helper that exposes Genkit flows as Flask routes, including server-sent events for streaming.
 
 ### Configure a model API key
@@ -92,7 +92,7 @@ from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
 from genkit.plugins.flask import genkit_flask_handler
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/deployment/any-platform.mdx
+++ b/src/content/docs/docs/deployment/any-platform.mdx
@@ -555,7 +555,7 @@ mkdir -p ~/tmp/genkit-fastapi-project
 cd ~/tmp/genkit-fastapi-project
 
 uv init
-uv add genkit genkit-plugin-google-genai fastapi uvicorn
+uv add genkit genkit-google-genai fastapi uvicorn
 ```
 
 ## 2. Define a flow
@@ -564,7 +564,7 @@ Create `flows.py`:
 
 ```python title="flows.py"
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/deployment/cloud-run.mdx
+++ b/src/content/docs/docs/deployment/cloud-run.mdx
@@ -599,7 +599,7 @@ cd genkit-cloudrun
 uv init
 
 # Add dependencies
-uv add genkit genkit-plugin-google-genai fastapi uvicorn slowapi
+uv add genkit genkit-google-genai fastapi uvicorn slowapi
 ```
 
 ### Create your FastAPI application with Genkit
@@ -616,7 +616,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 # Initialize Genkit
 ai = Genkit(

--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -297,7 +297,7 @@ genkit start -- go run .
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -1147,7 +1147,7 @@ UI, located at `localhost:4000/evaluate`.
 
 ```python
 from genkit import Genkit, Document
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel
 
 # Initialize Genkit
@@ -1315,7 +1315,7 @@ Here's an example of a custom evaluator that uses an LLM to check for "delicious
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from genkit.evaluator import (
     BaseEvalDataPoint,
     EvalFnResponse,
@@ -1380,7 +1380,7 @@ You can also run evaluations directly in your code using `ai.evaluate()`:
 ```python
 import asyncio
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from genkit.evaluator import BaseEvalDataPoint, EvalResponse
 
 ai = Genkit(plugins=[GoogleAI()])
@@ -1643,7 +1643,7 @@ questions.
 ```python
 from pathlib import Path
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 import pypdf  # uv add pypdf
 

--- a/src/content/docs/docs/flows.mdx
+++ b/src/content/docs/docs/flows.mdx
@@ -172,7 +172,7 @@ void main() {
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 ai = Genkit(
@@ -1320,7 +1320,7 @@ call.
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 ai = Genkit(
@@ -1562,7 +1562,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 # Initialize Genkit
 ai = Genkit(

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1515,7 +1515,7 @@ The following features documented in other languages are not yet fully supported
 
 <Lang lang="python">
 
-The `genkit-plugin-google-genai` package provides the `GoogleAI` plugin for accessing Google's generative AI models via the Google Gemini API using API key authentication.
+The `genkit-google-genai` package provides the `GoogleAI` plugin for accessing Google's generative AI models via the Google Gemini API using API key authentication.
 
 The plugin supports a wide range of capabilities:
 
@@ -1528,14 +1528,14 @@ The plugin supports a wide range of capabilities:
 ## Installation
 
 ```bash
-uv add genkit-plugin-google-genai
+uv add genkit-google-genai
 ```
 
 ## Configuration
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],
@@ -1589,7 +1589,7 @@ This is useful for multi-tenant apps or routing requests to different keys. Mode
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],
@@ -1787,7 +1787,7 @@ Veo models generate videos from text prompts using the background model pattern
 
 ```python
 import asyncio
-from genkit.plugins.google_genai import VeoVersion
+from genkit_google_genai import VeoVersion
 
 # Start video generation (returns an Operation)
 response = await ai.generate(

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -764,14 +764,14 @@ The unified Google GenAI plugin provides access to models via Vertex AI using th
 ### Installation
 
 ```bash
-uv add genkit-plugin-google-genai
+uv add genkit-google-genai
 ```
 
 ### Configuration
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 ai = Genkit(
     plugins=[
@@ -792,7 +792,7 @@ ai = Genkit(
 import os
 
 from genkit import Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 ai = Genkit(
     plugins=[
@@ -807,7 +807,7 @@ _Note: When using Express Mode, you typically omit `project` and `location` on `
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 ai = Genkit(
     plugins=[VertexAI(location='us-central1')],
@@ -894,10 +894,10 @@ The following advanced features are available in Python. Note that some features
 
 ### Installation for Advanced Features
 
-**Core Vertex AI features** (included in `genkit-plugin-google-genai`):
+**Core Vertex AI features** (included in `genkit-google-genai`):
 
 ```bash
-uv add genkit-plugin-google-genai
+uv add genkit-google-genai
 ```
 
 **Model Garden and Vector Search** (requires separate plugin):
@@ -912,7 +912,7 @@ If you want to locally run flows that use these plugins, you also need the [Goog
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 ai = Genkit(
     plugins=[VertexAI(location='us-central1')],
@@ -1110,7 +1110,7 @@ Genkit provides evaluation metrics through the Vertex AI plugin automatically wh
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 # Evaluators are automatically registered when a project ID is provided
 ai = Genkit(

--- a/src/content/docs/docs/interrupts.mdx
+++ b/src/content/docs/docs/interrupts.mdx
@@ -929,7 +929,7 @@ For this use case, use the Genkit instance's `tool()` decorator with `ctx.interr
 
 ```python
 from genkit import FinishReason, Genkit, tool_response, ToolRunContext
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 ai = Genkit(
@@ -1066,7 +1066,7 @@ You can also use interrupts within flows for more structured applications:
 
 ```python
 from genkit import Genkit, ToolRunContext
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 ai = Genkit(plugins=[GoogleAI()])

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1439,7 +1439,7 @@ prompt:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/overview.mdx
+++ b/src/content/docs/docs/overview.mdx
@@ -440,7 +440,7 @@ void main() async {
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
 plugins=[GoogleAI()],
@@ -459,7 +459,7 @@ print(response.text)
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
 	plugins=[GoogleAI()],

--- a/src/content/docs/docs/plugin-authoring/overview.mdx
+++ b/src/content/docs/docs/plugin-authoring/overview.mdx
@@ -1049,7 +1049,7 @@ evaluators, and more (the exact action kinds vary by language SDK). You've alrea
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 
 ai = Genkit(
     plugins=[GoogleAI()],

--- a/src/content/docs/docs/rag.mdx
+++ b/src/content/docs/docs/rag.mdx
@@ -849,7 +849,7 @@ Implement search with your datastore (vector search, hybrid search, etc.), produ
 
 ```python
 from genkit import Document, Genkit
-from genkit.plugins.google_genai import VertexAI
+from genkit_google_genai import VertexAI
 
 ai = Genkit(
     plugins=[VertexAI(location='us-central1')],

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -879,7 +879,7 @@ Use the Genkit instance's `tool()` decorator to write tool definitions:
 
 ```python
 from genkit import Genkit
-from genkit.plugins.google_genai import GoogleAI
+from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
 ai = Genkit(


### PR DESCRIPTION
### Python SDK Documentation Update (Core & Google GenAI)

This PR updates Python code samples and installation commands for core `genkit` (v0.8.0+) and the released `genkit-google-genai` plugin. Other optional plugins remain documented at their active v0.7.0 syntax until their next scheduled PyPI releases.

#### Key Updates:
- **Package Names:** Updated `genkit-plugin-google-genai` to canonical `genkit-google-genai` across `uv add` and installation examples.
- **Plugin Imports:** Migrated `from genkit.plugins.google_genai import ...` to direct module imports (`from genkit_google_genai import ...`).
- **Core Imports:** Updated legacy `from genkit.ai import Genkit` examples to root imports (`from genkit import Genkit`).