### PR TITLE
fix(py): Docs fixes and updated FastAPI guidance

### DIFF
--- a/src/components/landing/LanguageSelector.astro
+++ b/src/components/landing/LanguageSelector.astro
@@ -337,14 +337,14 @@ response = await ai.generate(
 
 # Access generated media and text
 if response.media:
-	print(f"Generated image: {response.media.url}")
+	print(f"Generated image: {response.media[0].url}")
 print(f"Generated text: {response.text}")`
       },
       {
         name: "OpenAI",
         id: "openai",
         code: `from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 
 ai = Genkit(
 	plugins=[OpenAI()],
@@ -360,8 +360,7 @@ print(response.text)`
         name: "Ollama",
         id: "ollama",
         code: `from genkit import Genkit
-from genkit.plugins.ollama import Ollama
-from genkit.plugins.ollama.models import ModelDefinition
+from genkit_ollama import Ollama, ModelDefinition
 
 ai = Genkit(
 	plugins=[

--- a/src/content/docs/blog/announcing-genkit-middleware.mdx
+++ b/src/content/docs/blog/announcing-genkit-middleware.mdx
@@ -18,7 +18,7 @@ import middlewareVideo from './_assets/announcing-genkit-middleware/middleware.m
 
 [Genkit](https://genkit.dev) is an open-source framework for **building full-stack, AI-powered and agentic applications for any platform** with support for TypeScript, Go, Dart, and Python. Building a production-ready agentic applications and AI features requires more than powerful models and careful prompting. You might need retries and fallbacks for maximum reliability, human approval before destructive tool calls, and observability across every layer.
 
-Genkit solves this with **middleware**: composable hooks that intercept generation calls, including the tool execution loop, and inject custom behaviors. The middleware system is available today in TypeScript, Go, and Dart, with Python support coming soon.
+Genkit solves this with **middleware**: composable hooks that intercept generation calls, including the tool execution loop, and inject custom behaviors. The middleware system is available today in TypeScript, Go, Dart, and Python (`genkit-middleware` — see the [middleware docs](/docs/middleware)).
 
 ## How Genkit middleware works
 

--- a/src/content/docs/docs/agents/custom-orchestration.mdx
+++ b/src/content/docs/docs/agents/custom-orchestration.mdx
@@ -434,7 +434,7 @@ async def custom_coder_fn(sess: SessionRunner, ctx: ActionRunContext) -> AgentRe
 
         res = await stream_resp.response
         if res.message:
-            await sess.add_messages(res.message)
+            await sess.add_messages([res.message])
 
         finish = (
             AgentFinishReason.STOP

--- a/src/content/docs/docs/agents/errors.mdx
+++ b/src/content/docs/docs/agents/errors.mdx
@@ -303,9 +303,11 @@ except AgentError as err:
         await agent.load_chat(snapshot_id=err.snapshot_id)
         if err.snapshot_id
         else agent.chat(
-            messages=err.response.messages,
+            messages=err.response.messages if err.response else [],
             state=err.state,
-            artifacts=err.response.raw.state.artifacts if err.response.raw.state else None,
+            artifacts=err.response.raw.state.artifacts
+            if (err.response and err.response.raw and err.response.raw.state)
+            else None,
         )
     )
     await recovery_chat.send('Try again with order 456.')

--- a/src/content/docs/docs/agents/errors.mdx
+++ b/src/content/docs/docs/agents/errors.mdx
@@ -303,9 +303,9 @@ except AgentError as err:
         await agent.load_chat(snapshot_id=err.snapshot_id)
         if err.snapshot_id
         else agent.chat(
-            messages=err.response.messages if err.response else None,
+            messages=err.response.messages,
             state=err.state,
-            artifacts=err.response.artifacts if err.response else None,
+            artifacts=err.response.raw.state.artifacts if err.response.raw.state else None,
         )
     )
     await recovery_chat.send('Try again with order 456.')

--- a/src/content/docs/docs/agents/errors.mdx
+++ b/src/content/docs/docs/agents/errors.mdx
@@ -302,7 +302,11 @@ except AgentError as err:
     recovery_chat = (
         await agent.load_chat(snapshot_id=err.snapshot_id)
         if err.snapshot_id
-        else agent.chat(state=err.state)
+        else agent.chat(
+            messages=err.response.messages if err.response else None,
+            state=err.state,
+            artifacts=err.response.artifacts if err.response else None,
+        )
     )
     await recovery_chat.send('Try again with order 456.')
 ```

--- a/src/content/docs/docs/agents/http.mdx
+++ b/src/content/docs/docs/agents/http.mdx
@@ -170,20 +170,38 @@ The turn endpoint processes both streaming and non-streaming requests. The snaps
 
 ## FastAPI routes
 
-Serve agents over HTTP with `serve_agent()` from `genkit_fastapi`. One `include_router` call mounts the turn route plus `/getSnapshot` and `/abort` companions when the agent has a store.
+Serve agents over HTTP with `serve_agent()` from `genkit_fastapi`. The turn route is always mounted. `/getSnapshot` and `/abort` are mounted only when the agent has a session store—without one, those paths are not registered and return 404.
 
 ```python
-from fastapi import FastAPI
+from fastapi import FastAPI, Header
 from genkit_fastapi import serve_agent
+from genkit_google_cloud import FirestoreSessionStore
 
 app = FastAPI()
-app.include_router(serve_agent(weather_agent), prefix='/api')
+
+async def user_context(authorization: str = Header(...)) -> dict[str, object]:
+    # Validate the token and load the user in a real app.
+    return {'uid': authorization.removeprefix('Bearer ').strip()}
+
+weather_agent = ai.define_agent(
+    name='weatherAgent',
+    model='googleai/gemini-flash-latest',
+    system='You help with weather questions.',
+    store=FirestoreSessionStore(),
+)
+
+app.include_router(
+    serve_agent(weather_agent, context_dependency=user_context),
+    prefix='/api',
+)
 # Routes: /api/weatherAgent, /api/weatherAgent/getSnapshot, /api/weatherAgent/abort
 ```
 
 The turn endpoint handles both streaming and non-streaming requests. The snapshot endpoint reads by `snapshotId` or returns the latest leaf by `sessionId`. The abort endpoint takes a `snapshotId` and cancels running background work.
 
-Pass `context_dependency` to reuse FastAPI `Depends` for auth or request-scoped resources on the turn, snapshot, and abort routes.
+### Request context
+
+`context_dependency` is a FastAPI dependency that returns a dict. Genkit threads that dict into the action as context on the turn, snapshot, and abort routes, so auth and other request-scoped values resolve once through FastAPI's `Depends` graph. Tools and custom orchestration read the same map from turn context.
 
 </Lang>
 

--- a/src/content/docs/docs/agents/interrupts.mdx
+++ b/src/content/docs/docs/agents/interrupts.mdx
@@ -398,6 +398,17 @@ user_approval = ai.define_interrupt(
     input_schema=UserApprovalInput,
 )
 
+
+class TransferMoneyInput(BaseModel):
+    amount: float
+    to_account: str
+
+
+@ai.tool(name='transferMoney', description='Transfer money after approval.')
+async def transfer_money(input: TransferMoneyInput) -> str:
+    return f'Transferred ${input.amount} to {input.to_account}.'
+
+
 banking_agent = ai.define_agent(
     name='bankingAgent',
     model='googleai/gemini-flash-latest',

--- a/src/content/docs/docs/agents/interrupts.mdx
+++ b/src/content/docs/docs/agents/interrupts.mdx
@@ -378,6 +378,8 @@ To prevent client-side spoofing, the runtime validates that every `respond` and 
 - **`raise Interrupt(metadata)`** inside a normal tool that can either finish immediately or pause based on runtime conditions.
 
 ```python
+from decimal import Decimal
+
 from pydantic import BaseModel
 
 from genkit import Genkit
@@ -400,7 +402,7 @@ user_approval = ai.define_interrupt(
 
 
 class TransferMoneyInput(BaseModel):
-    amount: float
+    amount: Decimal
     to_account: str
 
 

--- a/src/content/docs/docs/agents/session-stores.mdx
+++ b/src/content/docs/docs/agents/session-stores.mdx
@@ -459,9 +459,10 @@ Plan retention before launch. Snapshots are full conversation checkpoints, so lo
 
 - **In-memory store** (`InMemorySessionStore`) for tests, local examples, command-line interfaces, and single-process experiments.
 - **File store** (`FileSessionStore`) for local development, prototypes, and single-host applications where snapshots must persist across process restarts.
-- **Custom store** (implementing `SessionStore`) for production apps using a shared database such as Cloud SQL, Spanner, Postgres, or Redis.
+- **Firestore store** (`FirestoreSessionStore` from `genkit-google-cloud`) for production apps where several server instances share sessions.
+- **Custom store** (implementing `SessionStore`) when you need a different shared database such as Cloud SQL, Spanner, Postgres, or Redis.
 
-Configure the store on the agent. The runtime handles reads and writes.
+Configure the store on the agent. The runtime handles reads and writes. With [HTTP serving](/docs/agents/http), `/getSnapshot` and `/abort` are mounted only when a store is configured.
 
 ## Use an in-memory store
 
@@ -501,9 +502,46 @@ weather_agent = ai.define_agent(
 
 Snapshots are saved as files inside the `.sessions` folder.
 
-## Implement a production store
+## Use a Firestore store
 
-To store snapshots in a shared production database, implement a custom `SessionStore`:
+`FirestoreSessionStore` in `genkit-google-cloud` persists snapshots in Cloud Firestore. It is the built-in option for production apps where several server instances share sessions, and it supports snapshot watching for background execution and abort.
+
+```python
+from genkit_google_cloud import FirestoreSessionStore
+
+
+def by_user(context: dict | None = None) -> str:
+    if isinstance(context, dict) and isinstance(context.get('uid'), str):
+        return context['uid']
+    return 'global'
+
+
+store = FirestoreSessionStore(
+    collection='genkit-sessions',
+    snapshot_path_prefix=by_user,
+)
+
+support_agent = ai.define_agent(
+    name='supportAgent',
+    model='googleai/gemini-flash-latest',
+    system='Help customers understand their order status.',
+    store=store,
+)
+```
+
+All options are optional:
+
+- **`client`** is an explicit Firestore `AsyncClient`. It defaults to a new client that picks up Application Default Credentials and `FIRESTORE_EMULATOR_HOST`.
+- **`collection`** is the collection that holds snapshot documents. It defaults to `genkit-sessions`. Two companion collections, `<collection>-pointers` and `<collection>-shards`, are derived from it.
+- **`snapshot_path_prefix`** returns a per-tenant prefix from the call context (for example an authenticated user id). When set, snapshots are nested under that prefix so one tenant cannot read another's data even with a `snapshotId`. It defaults to `global`.
+- **`checkpoint_interval`** is the number of turns between full-state checkpoints. Between checkpoints the store writes diffs. It defaults to `25`.
+- **`shard_size`** is the maximum size in bytes of a single shard or diff document. It defaults to 512 KiB.
+
+The Firestore store watches snapshot documents to observe status changes, so background execution and aborts work across instances without polling. It does not prune snapshots, so plan retention for long-running or artifact-heavy conversations as described in [Production guidance](#production-guidance).
+
+## Implement a custom store
+
+When the built-in Firestore store does not fit, implement a custom `SessionStore`:
 
 ```python
 from genkit.agent import SessionSnapshot, SessionStore

--- a/src/content/docs/docs/agents/state.mdx
+++ b/src/content/docs/docs/agents/state.mdx
@@ -719,13 +719,14 @@ from genkit.agent import Artifact
 sess = ai.current_session()
 assert sess is not None
 
-await sess.add_artifacts(
+await sess.add_artifacts([
     Artifact(
         name='report.md',
-        parts=[Part(TextPart(text='# Research Report\nThis is the content.'))],
+        parts=[Part(root=TextPart(text='# Research Report\nThis is the content.'))],
     )
-)
+])
 ```
+
 
 Artifacts with identical names overwrite earlier ones, while unnamed artifacts are appended to the session.
 

--- a/src/content/docs/docs/backend-frameworks/django.mdx
+++ b/src/content/docs/docs/backend-frameworks/django.mdx
@@ -28,20 +28,15 @@ This tutorial assumes you're already familiar with building Django applications.
 
 ### Create the project
 
-Create a new project with uv and bootstrap Django:
+Create a new project with uv, install packages, then bootstrap Django:
 
 ```bash
 mkdir my-genkit-django
 cd my-genkit-django
 uv init --no-readme --python 3.11
+uv add django django-cors-headers uvicorn genkit genkit-django genkit-google-genai
 uv run django-admin startproject myproject .
 uv run python manage.py startapp recipes
-```
-
-### Install packages
-
-```bash
-uv add django django-cors-headers uvicorn genkit genkit-django genkit-google-genai
 ```
 
 These packages include:

--- a/src/content/docs/docs/backend-frameworks/django.mdx
+++ b/src/content/docs/docs/backend-frameworks/django.mdx
@@ -9,7 +9,7 @@ import { Aside, FileTree, LinkButton } from '@astrojs/starlight/components';
 
 In this tutorial, you'll build **Bargain Chef**, a standalone Genkit backend on Django that exposes a recipe-generating flow over HTTP. It uses two AI patterns Genkit simplifies: streaming structured output and tool calling.
 
-The `genkit-plugin-django` package wires the flow into Django's async (ASGI) stack with a single decorator, exposing both a JSON endpoint and a Server-Sent Events stream so any client can consume the partial recipe as it arrives, no manual request parsing or streaming code required.
+The `genkit-django` package wires the flow into Django's async (ASGI) stack with a single decorator, exposing both a JSON endpoint and a Server-Sent Events stream so any client can consume the partial recipe as it arrives, no manual request parsing or streaming code required.
 
 ## What you'll build
 
@@ -41,7 +41,7 @@ uv run python manage.py startapp recipes
 ### Install packages
 
 ```bash
-uv add django django-cors-headers uvicorn genkit genkit-plugin-django genkit-google-genai
+uv add django django-cors-headers uvicorn genkit genkit-django genkit-google-genai
 ```
 
 These packages include:
@@ -50,7 +50,7 @@ These packages include:
 - **`django-cors-headers`**: CORS middleware. Lets browser frontends served from a different origin call the Genkit endpoint.
 - **`uvicorn`**: ASGI server that runs Django with async support.
 - **`genkit`**: Core Genkit SDK.
-- **`genkit-plugin-django`**: Helper that exposes Genkit flows as Django views, including server-sent events for streaming.
+- **`genkit-django`**: Helper that exposes Genkit flows as Django views, including server-sent events for streaming.
 - **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
 
 Install the Genkit CLI, which enables Genkit testing and observability:
@@ -89,6 +89,10 @@ export GEMINI_API_KEY=<your API key>
 Update `myproject/settings.py` so Django loads the `recipes` app and runs without the default database and admin middleware that Bargain Chef doesn't need:
 
 ```python title="myproject/settings.py"
+SECRET_KEY = 'dev-only-change-me'
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+
 INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.auth',
@@ -132,7 +136,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
-from genkit.plugins.django import genkit_django_handler
+from genkit_django import genkit_django_handler
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(

--- a/src/content/docs/docs/backend-frameworks/fastapi.mdx
+++ b/src/content/docs/docs/backend-frameworks/fastapi.mdx
@@ -43,7 +43,7 @@ curl -sL cli.genkit.dev | bash
 Then install the packages you need in your project:
 
 ```bash
-uv add fastapi uvicorn genkit genkit-google-genai genkit-plugin-fastapi
+uv add fastapi uvicorn genkit genkit-google-genai genkit-fastapi
 ```
 
 These packages include:
@@ -52,7 +52,7 @@ These packages include:
 - **`uvicorn`**: The ASGI server that runs your FastAPI app.
 - **`genkit`**: Core Genkit SDK.
 - **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
-- **`genkit-plugin-fastapi`**: Serves Genkit flows as FastAPI endpoints, including streaming.
+- **`genkit-fastapi`**: Serves Genkit flows as FastAPI endpoints, including streaming.
 
 ### Configure a model API key
 
@@ -100,7 +100,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
-from genkit.plugins.fastapi import genkit_fastapi_handler
+from genkit_fastapi import genkit_fastapi_handler
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(

--- a/src/content/docs/docs/backend-frameworks/fastapi.mdx
+++ b/src/content/docs/docs/backend-frameworks/fastapi.mdx
@@ -52,7 +52,7 @@ These packages include:
 - **`uvicorn`**: The ASGI server that runs your FastAPI app.
 - **`genkit`**: Core Genkit SDK.
 - **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
-- **`genkit-fastapi`**: Serves Genkit flows as FastAPI endpoints, including streaming.
+- **`genkit-fastapi`**: Mounts Genkit flows and agents on FastAPI with `serve_flow` / `serve_agent`, including streaming.
 
 ### Configure a model API key
 
@@ -100,7 +100,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
-from genkit_fastapi import genkit_fastapi_handler
+from genkit_fastapi import serve_flow
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(
@@ -204,11 +204,8 @@ app.add_middleware(
     allow_headers=['*'],
 )
 
-
-@app.post('/bargainChefFlow', response_model=None)
-@genkit_fastapi_handler(ai)
-async def bargain_chef_endpoint():
-    return bargain_chef_flow
+# POST /bargainChefFlow — path defaults to the flow's name
+app.include_router(serve_flow(bargain_chef_flow))
 ```
 
 A few details are worth noting before you run the backend:
@@ -220,7 +217,65 @@ A few details are worth noting before you run the backend:
 
 ### Expose the flow over HTTP
 
-The `@genkit_fastapi_handler(ai)` decorator wraps the flow as a FastAPI route. The handler inspects the incoming request: when the client sends `Accept: text/event-stream`, it streams partial chunks as Server-Sent Events; otherwise it returns the final recipe as JSON.
+`serve_flow` returns a FastAPI `APIRouter` you mount with `app.include_router`. By default the route is `POST /<flow name>` (here `/bargainChefFlow`). When the client sends `Accept: text/event-stream`, the endpoint streams partial chunks as Server-Sent Events; otherwise it returns the final recipe as JSON. Pass `base_path=` or a router `prefix=` if you want a different URL.
+
+### Attach request context
+
+Use `context_dependency` to wire FastAPI dependency injection into Genkit. The dependency returns a dict; Genkit makes that dict available on the flow as `ctx.context`—the same `ActionRunContext` you already use for `send_chunk`. Typical uses are auth, tenancy, and other values you already resolve with `Depends`:
+
+```python
+from fastapi import Header
+
+async def user_context(authorization: str = Header(...)) -> dict[str, object]:
+    # Validate the token and load the user in a real app.
+    return {'uid': authorization.removeprefix('Bearer ').strip()}
+
+app.include_router(
+    serve_flow(bargain_chef_flow, context_dependency=user_context),
+)
+```
+
+Inside the flow:
+
+```python
+uid = (ctx.context or {}).get('uid')
+```
+
+### Serve an agent over HTTP
+
+For [agents](/docs/agents/overview), use `serve_agent` the same way. One `include_router` call mounts the turn route. Configure a [session store](/docs/agents/session-stores) on the agent when you want server-managed sessions—only then does `serve_agent` also mount `/getSnapshot` and `/abort`. Without a store, those paths are not registered and return 404.
+
+Pass the same `context_dependency` and Genkit applies it on every mounted route. Install `genkit-google-cloud` for the Firestore-backed store:
+
+```bash
+uv add genkit-google-cloud
+```
+
+```python
+from genkit_fastapi import serve_agent
+from genkit_google_cloud import FirestoreSessionStore
+
+bargain_chef_agent = ai.define_agent(
+    name='bargainChefAgent',
+    model='googleai/gemini-flash-latest',
+    system='You help users cook from grocery sale ingredients.',
+    tools=[get_ingredients_on_sale],
+    store=FirestoreSessionStore(),
+)
+
+app.include_router(
+    serve_agent(
+        bargain_chef_agent,
+        context_dependency=user_context,
+    ),
+    prefix='/api',
+)
+# POST /api/bargainChefAgent
+# POST /api/bargainChefAgent/getSnapshot
+# POST /api/bargainChefAgent/abort
+```
+
+`FirestoreSessionStore` uses Application Default Credentials (or `FIRESTORE_EMULATOR_HOST` locally). See [Session stores](/docs/agents/session-stores) for options such as tenant prefixes, and [Serve agents over HTTP](/docs/agents/http) for the turn envelope (`data` / `init`), streaming, and client connection details.
 
 ### Check the project layout
 
@@ -325,6 +380,7 @@ You now have a standalone Genkit backend on FastAPI that streams structured outp
 - [Connect an app framework](/docs/app-frameworks/overview)
 - [Deploy your app](/docs/deployment/overview)
 - [Creating flows](/docs/flows)
+- [Agents](/docs/agents/overview) and [serve agents over HTTP](/docs/agents/http)
 - [Generating content](/docs/models)
 - [Connect a web frontend](/docs/client)
 - [Developer tools](/docs/devtools)

--- a/src/content/docs/docs/backend-frameworks/flask.mdx
+++ b/src/content/docs/docs/backend-frameworks/flask.mdx
@@ -45,7 +45,7 @@ curl -sL cli.genkit.dev | bash
 Then install the packages you need in your project:
 
 ```bash
-uv add "flask[async]" flask-cors genkit genkit-google-genai genkit-plugin-flask
+uv add "flask[async]" flask-cors genkit genkit-google-genai genkit-flask
 ```
 
 These packages include:
@@ -53,7 +53,7 @@ These packages include:
 - **`flask`**: The Flask web framework.
 - **`genkit`**: Core Genkit SDK for Python.
 - **`genkit-google-genai`**: Plugin that connects Genkit to Google's Gemini models.
-- **`genkit-plugin-flask`**: Helper that exposes Genkit flows as Flask routes, including server-sent events for streaming.
+- **`genkit-flask`**: Helper that exposes Genkit flows as Flask routes, including server-sent events for streaming.
 
 ### Configure a model API key
 
@@ -91,7 +91,7 @@ from flask_cors import CORS
 from pydantic import BaseModel, Field
 
 from genkit import ActionRunContext, Genkit
-from genkit.plugins.flask import genkit_flask_handler
+from genkit_flask import genkit_flask_handler
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(

--- a/src/content/docs/docs/backend-frameworks/overview.mdx
+++ b/src/content/docs/docs/backend-frameworks/overview.mdx
@@ -107,7 +107,7 @@ Pick the server framework that matches your backend. Each guide is self-containe
   <FrameworkCard
     framework="django"
     title="Django"
-    description="Add Genkit flows to Django projects using Django Ninja or REST framework."
+    description="Add Genkit flows to Django projects as async views with streaming support."
     href="/docs/python/backend-frameworks/django/"
   />
 </CardGrid>

--- a/src/content/docs/docs/client.mdx
+++ b/src/content/docs/docs/client.mdx
@@ -5,7 +5,6 @@ supportedLanguages:
   - js
   - go
   - dart
-  - python
 isLanguageAgnostic: true
 ---
 

--- a/src/content/docs/docs/deployment/any-platform.mdx
+++ b/src/content/docs/docs/deployment/any-platform.mdx
@@ -548,11 +548,17 @@ This page shows one way to deploy a Python Genkit app to _any_ platform: run a
 FastAPI server that calls your flows. (FastAPI is ASGI and works well on most
 Python hosting providers.)
 
+:::tip[Prefer `serve_flow`?]
+Start from the [FastAPI tutorial](/docs/backend-frameworks/fastapi)
+(`serve_flow` / `serve_agent`) when you want the Genkit HTTP envelope and SSE.
+The sample below is a plain FastAPI REST wrapper with custom request bodies.
+:::
+
 ## 1. Set up your project (uv)
 
 ```bash
-mkdir -p ~/tmp/genkit-fastapi-project
-cd ~/tmp/genkit-fastapi-project
+mkdir -p ~/tmp/genkit-plain-fastapi
+cd ~/tmp/genkit-plain-fastapi
 
 uv init
 uv add genkit genkit-google-genai fastapi uvicorn

--- a/src/content/docs/docs/deployment/cloud-run.mdx
+++ b/src/content/docs/docs/deployment/cloud-run.mdx
@@ -561,6 +561,13 @@ You can deploy Genkit flows as HTTPS endpoints using Cloud Run. This page walks
 you through deploying a FastAPI-based Genkit application to Cloud Run with automatic
 scaling and containerization.
 
+:::tip[Prefer the Genkit FastAPI handler?]
+For the idiomatic Genkit HTTP envelope (`{"data": ...}` / SSE) and
+`genkit_fastapi_handler`, start from the [FastAPI tutorial](/docs/backend-frameworks/fastapi)
+and deploy that app to Cloud Run. The sample below is a minimal hand-rolled
+FastAPI wrapper if you want plain Pydantic request bodies instead.
+:::
+
 ## Before you begin
 
 - Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install).
@@ -618,7 +625,9 @@ from pydantic import BaseModel, Field
 from genkit import Genkit
 from genkit_google_genai import GoogleAI
 
-# Initialize Genkit
+# Gemini API (API key). For Vertex AI instead:
+#   from genkit_google_genai import VertexAI
+#   ai = Genkit(plugins=[VertexAI(location='us-central1')], model='vertexai/gemini-flash-latest')
 ai = Genkit(
     plugins=[GoogleAI()],
     model='googleai/gemini-flash-latest',
@@ -885,6 +894,9 @@ gcloud run deploy genkit-service \
 ```
 
 **Gemini (Vertex AI)**
+
+Switch the sample above to `VertexAI` + `vertexai/…` model IDs before deploying
+with these flags (ADC / the Cloud Run service account replaces `GEMINI_API_KEY`):
 
 ```bash
 gcloud run deploy genkit-service \

--- a/src/content/docs/docs/deployment/cloud-run.mdx
+++ b/src/content/docs/docs/deployment/cloud-run.mdx
@@ -561,11 +561,11 @@ You can deploy Genkit flows as HTTPS endpoints using Cloud Run. This page walks
 you through deploying a FastAPI-based Genkit application to Cloud Run with automatic
 scaling and containerization.
 
-:::tip[Prefer the Genkit FastAPI handler?]
-For the idiomatic Genkit HTTP envelope (`{"data": ...}` / SSE) and
-`genkit_fastapi_handler`, start from the [FastAPI tutorial](/docs/backend-frameworks/fastapi)
-and deploy that app to Cloud Run. The sample below is a minimal hand-rolled
-FastAPI wrapper if you want plain Pydantic request bodies instead.
+:::tip[Prefer `serve_flow`?]
+Build the HTTP app with the [FastAPI tutorial](/docs/backend-frameworks/fastapi)
+(`serve_flow` / `serve_agent`, `{"data": ...}` envelope, SSE), then deploy that
+app here. The sample below is a plain FastAPI REST wrapper if you want custom
+request bodies instead.
 :::
 
 ## Before you begin
@@ -606,7 +606,7 @@ cd genkit-cloudrun
 uv init
 
 # Add dependencies
-uv add genkit genkit-google-genai fastapi uvicorn slowapi
+uv add genkit genkit-google-genai fastapi uvicorn slowapi PyJWT
 ```
 
 ### Create your FastAPI application with Genkit

--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -1488,7 +1488,7 @@ def my_tool(...):
     ...
 
 my_prompt = ai.prompt('my_prompt')
-response = await my_prompt({"input_args": "go here"}, tools=["my_tool"])
+response = await my_prompt({"input_args": "go here"}, tools=[my_tool])
 ```
 
 </Lang>

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -1419,9 +1419,9 @@ async def run_evaluation() -> EvalResponse:
         eval_run_id='my-eval-run',
     )
 
-    for item in result.root:
-        print(f'Test case: {item.test_case_id}')
-        print(f'Score: {item.evaluation}')
+    for item in result.model_dump(exclude_none=True):
+        print(f'Test case: {item["test_case_id"]}')
+        print(f'Score: {item["evaluation"]}')
 
     return result
 

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -1288,18 +1288,17 @@ If variants have different input schemas, schema validation will be performed ag
 
 ### Genkit evaluators
 
-Genkit includes a number of built-in evaluators, inspired by [RAGAS](https://docs.ragas.io/en/stable/), to help you get started:
+Install `genkit-evaluators` and call `register_genkit_evaluators(ai)` to register
+these built-in heuristic metrics:
 
-- **Faithfulness** -- Measures the factual consistency of the generated answer against the given context
-- **Answer Relevancy** -- Assesses how pertinent the generated answer is to the given prompt
-- **Maliciousness** -- Measures whether the generated output intends to deceive, harm, or exploit
-- **Regex** -- Checks if the generated output matches a regular expression pattern provided in the reference field
-- **Deep Equal** -- Checks if the generated output is deep-equal to the reference output
-- **JSONata** -- Checks if the generated output matches a JSONata expression provided in the reference field
+- **Regex** (`genkitEval/regex`) -- Checks if the generated output matches a regular expression pattern provided in the reference field
+- **Deep Equal** (`genkitEval/deep_equal`) -- Checks if the generated output is deep-equal to the reference output
+- **JSONata** (`genkitEval/jsonata`) -- Checks if the generated output matches a JSONata expression provided in the reference field
 
-#### Python
-
-Use **`ai.define_evaluator()`** (see [Custom evaluators](#custom-evaluators)) for project-specific metrics, or install plugins that register evaluators with your `Genkit` instance—for example [Vertex AI evaluation metrics](/docs/integrations/vertex-ai#evaluation-metrics) via the Google GenAI plugin. Third-party packages may ship additional evaluators; follow each package’s install and registration instructions.
+For LLM-as-judge metrics, define your own with
+**`ai.define_evaluator()`** (see [Custom evaluators](#custom-evaluators)) or use
+[Vertex AI evaluation metrics](/docs/integrations/vertex-ai#evaluation-metrics)
+via the Google GenAI plugin.
 
 ### Evaluator plugins
 
@@ -1349,7 +1348,7 @@ async def food_evaluator(
     # )
 
     return EvalFnResponse(
-        test_case_id=datapoint.test_case_id or '',
+        test_case_id=datapoint.test_case_id,
         evaluation=Score(
             score=response.text,
             status=EvalStatusEnum.PASS,
@@ -1542,7 +1541,7 @@ for evaluation. To run on a subset of the configured evaluators, use the
 `--evaluators` flag and provide a comma-separated list of evaluators by name:
 
 ```bash
-genkit eval:flow qa_flow --input testInputs.json --evaluators=genkitEval/maliciousness,genkitEval/answer_relevancy -- uv run main.py
+genkit eval:flow qa_flow --input testInputs.json --evaluators=genkitEval/regex,genkitEval/deep_equal -- uv run main.py
 ```
 
 You can view the results of your evaluation run in the Dev UI at
@@ -1598,42 +1597,6 @@ genkit eval:run factsEvalDataset.json
 By default, `eval:run` runs against all configured evaluators, and as with
 `eval:flow`, results for `eval:run` appear in the evaluation page of Developer
 UI, located at `localhost:4000/evaluate`.
-
-### Custom extractors
-
-Genkit provides reasonable default logic for extracting the necessary fields
-(`input`, `output` and `context`) while doing an evaluation. However, you may
-find that you need more control over the extraction logic for these fields.
-Genkit supports customs extractors to achieve this. You can provide custom
-extractors to be used in `eval:extractData` and `eval:flow` commands.
-
-First, as a preparatory step, introduce an auxiliary step in our `qa_flow`
-example:
-
-```python
-@ai.flow()
-async def qa_flow(input: QAInput) -> QAOutput:
-    fact_docs = await dummy_retrieve(input.query)
-
-    # Add a custom step to process the retrieved facts
-    async def _process_facts():
-        # Let us use only facts that are considered silly. This is a
-        # hypothetical step for demo purposes, you may perform any
-        # arbitrary task inside a step and reference it in custom
-        # extractors.
-        #
-        # Assume you have a method that checks if a fact is silly
-        return [doc for doc in fact_docs if is_silly_fact(doc)]
-
-    fact_docs_modified = await ai.run(name='factModified', fn=_process_facts)
-
-    response = await ai.generate(
-        model='googleai/gemini-flash-latest',
-        prompt=f'Answer this question with the given context: {input.query}',
-        docs=fact_docs_modified,
-    )
-    return QAOutput(answer=response.text)
-```
 
 ### Synthesizing test data using an LLM
 

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -1288,8 +1288,19 @@ If variants have different input schemas, schema validation will be performed ag
 
 ### Genkit evaluators
 
-Install `genkit-evaluators` and call `register_genkit_evaluators(ai)` to register
-these built-in heuristic metrics:
+Install the package and register the built-in heuristic metrics:
+
+```bash
+uv add genkit-evaluators
+```
+
+```python
+from genkit_evaluators import register_genkit_evaluators
+
+register_genkit_evaluators(ai)
+```
+
+That registers:
 
 - **Regex** (`genkitEval/regex`) -- Checks if the generated output matches a regular expression pattern provided in the reference field
 - **Deep Equal** (`genkitEval/deep_equal`) -- Checks if the generated output is deep-equal to the reference output

--- a/src/content/docs/docs/flows.mdx
+++ b/src/content/docs/docs/flows.mdx
@@ -1552,8 +1552,8 @@ log.Fatal(router.Run(":3400"))
 
 ### FastAPI
 
-Install `genkit-fastapi`, then expose the flow with `genkit_fastapi_handler` so
-requests use the Genkit HTTP envelope (`{"data": ...}`):
+Install `genkit-fastapi`, then mount the flow with `serve_flow` so requests use
+the Genkit HTTP envelope (`{"data": ...}`):
 
 ```python
 import os
@@ -1562,7 +1562,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
-from genkit_fastapi import genkit_fastapi_handler
+from genkit_fastapi import serve_flow
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(
@@ -1578,14 +1578,14 @@ class MenuSuggestionInput(BaseModel):
 class MenuSuggestionOutput(BaseModel):
     menu_item: str = Field(description='Generated menu item')
 
-@app.post('/menuSuggestionFlow', response_model=None)
-@genkit_fastapi_handler(ai)
-@ai.flow()
+@ai.flow(name='menuSuggestionFlow')
 async def menu_suggestion_flow(input: MenuSuggestionInput) -> MenuSuggestionOutput:
     response = await ai.generate(
         prompt=f'Invent a menu item for a {input.theme} themed restaurant.',
     )
     return MenuSuggestionOutput(menu_item=response.text)
+
+app.include_router(serve_flow(menu_suggestion_flow))
 
 if __name__ == '__main__':
     import uvicorn
@@ -1595,6 +1595,28 @@ if __name__ == '__main__':
         host='0.0.0.0',
         port=int(os.environ.get('PORT', 3400)),
     )
+```
+
+To attach per-request context (auth, tenancy, and so on), pass a FastAPI dependency as `context_dependency`. Its return value must be a dict; Genkit exposes that dict on the flow as `ctx.context`:
+
+```python
+from fastapi import Header
+from genkit import ActionRunContext
+
+async def user_context(authorization: str = Header(...)) -> dict[str, object]:
+    return {'uid': authorization.removeprefix('Bearer ').strip()}
+
+@ai.flow(name='menuSuggestionFlow')
+async def menu_suggestion_flow(
+    input: MenuSuggestionInput,
+    ctx: ActionRunContext,
+) -> MenuSuggestionOutput:
+    uid = (ctx.context or {}).get('uid')
+    ...
+
+app.include_router(
+    serve_flow(menu_suggestion_flow, context_dependency=user_context),
+)
 ```
 
 For production, run your app with a production ASGI server (for example, Uvicorn with Gunicorn workers):
@@ -1623,8 +1645,6 @@ curl -X POST "http://localhost:3400/menuSuggestionFlow" \
   -d '{"data": {"theme": "banana"}}'
 ```
 
-You can also use the Genkit web client library to call flows from web applications. See [Accessing flows from the client](/docs/client) for detailed examples of using the `runFlow()` and `streamFlow()` functions.
-
 ### Learn more about deployment
 
 For detailed deployment instructions and platform-specific guides, see:
@@ -1632,6 +1652,8 @@ For detailed deployment instructions and platform-specific guides, see:
 - [Deploy with Cloud Run](/docs/deployment/cloud-run)
 
 <Lang lang="js">
+
+You can also use the Genkit web client library to call flows from web applications. See [Accessing flows from the client](/docs/client) for detailed examples of using the `runFlow()` and `streamFlow()` functions.
 
 - [Deploy with Firebase](/docs/deployment/firebase)
 - [Authorization and integrity](/docs/deployment/authorization)
@@ -1641,6 +1663,7 @@ For detailed deployment instructions and platform-specific guides, see:
 
 <Lang lang="python">
 
-- [Deploy with FastAPI](/docs/backend-frameworks/fastapi)
+- [FastAPI tutorial](/docs/backend-frameworks/fastapi) (`serve_flow` / `serve_agent`)
+- [Deploy to any platform](/docs/deployment/any-platform)
 
 </Lang>

--- a/src/content/docs/docs/flows.mdx
+++ b/src/content/docs/docs/flows.mdx
@@ -177,6 +177,7 @@ from pydantic import BaseModel, Field
 
 ai = Genkit(
     plugins=[GoogleAI()],
+    model='googleai/gemini-flash-latest',
 )
 
 class MenuSuggestionInput(BaseModel):
@@ -1306,13 +1307,10 @@ Each of Genkit's fundamental actions show up as separate steps in the trace view
 
 - `ai.generate()`
 - `ai.embed()`
-- `ai.index()`
-- `ai.retrieve()`
 
-If you want to include code other than the above in your traces, you can do so
-by wrapping the code in an `ai.run()` call. You might do this for calls to
-third-party libraries that are not Genkit-aware, or for any critical section of
-code.
+If you want to include other code in your traces (for example retrieval against
+your own vector store, or calls to third-party libraries), wrap it in an
+`ai.run()` call.
 
 For example, here's a flow with two steps: the first step retrieves a menu using
 some unspecified method, and the second step includes the menu in a `generate()`
@@ -1325,6 +1323,7 @@ from pydantic import BaseModel, Field
 
 ai = Genkit(
     plugins=[GoogleAI()],
+    model='googleai/gemini-flash-latest',
 )
 
 class MenuQuestionInput(BaseModel):
@@ -1343,7 +1342,7 @@ async def menu_question_flow(input: MenuQuestionInput) -> MenuQuestionOutput:
         #
         return "Soup: tomato bisque\nMain: roast chicken\nDessert: panna cotta"
 
-    menu = await ai.run("retrieve-daily-menu", retrieve_daily_menu)
+    menu = await ai.run(name='retrieve-daily-menu', fn=retrieve_daily_menu)
 
     response = await ai.generate(
         system="Help the user answer questions about today's menu.",
@@ -1553,7 +1552,8 @@ log.Fatal(router.Run(":3400"))
 
 ### FastAPI
 
-To deploy flows using FastAPI, create a FastAPI app and expose routes that call your flows:
+Install `genkit-fastapi`, then expose the flow with `genkit_fastapi_handler` so
+requests use the Genkit HTTP envelope (`{"data": ...}`):
 
 ```python
 import os
@@ -1562,9 +1562,9 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from genkit import Genkit
+from genkit_fastapi import genkit_fastapi_handler
 from genkit_google_genai import GoogleAI
 
-# Initialize Genkit
 ai = Genkit(
     plugins=[GoogleAI()],
     model='googleai/gemini-flash-latest',
@@ -1578,6 +1578,8 @@ class MenuSuggestionInput(BaseModel):
 class MenuSuggestionOutput(BaseModel):
     menu_item: str = Field(description='Generated menu item')
 
+@app.post('/menuSuggestionFlow', response_model=None)
+@genkit_fastapi_handler(ai)
 @ai.flow()
 async def menu_suggestion_flow(input: MenuSuggestionInput) -> MenuSuggestionOutput:
     response = await ai.generate(
@@ -1585,17 +1587,13 @@ async def menu_suggestion_flow(input: MenuSuggestionInput) -> MenuSuggestionOutp
     )
     return MenuSuggestionOutput(menu_item=response.text)
 
-@app.post("/menuSuggestionFlow")
-async def menu_suggestion_endpoint(input: MenuSuggestionInput) -> MenuSuggestionOutput:
-    return await menu_suggestion_flow(input)
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     import uvicorn
 
     uvicorn.run(
-        "main:app",
-        host="0.0.0.0",
-        port=int(os.environ.get("PORT", 3400)),
+        'main:app',
+        host='0.0.0.0',
+        port=int(os.environ.get('PORT', 3400)),
     )
 ```
 

--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -381,7 +381,7 @@ Start from the web framework you already use, or pick one for a new Genkit servi
   <FrameworkCard
     framework="django"
     title="Django"
-    description="Add Genkit flows to Django projects using Django Ninja or REST framework."
+    description="Add Genkit flows to Django projects as async views with streaming support."
     href="/docs/backend-frameworks/django"
   />
 </CardGrid>

--- a/src/content/docs/docs/integrations/anthropic.mdx
+++ b/src/content/docs/docs/integrations/anthropic.mdx
@@ -991,7 +991,7 @@ async def get_weather(input: WeatherInput) -> str:
 
 response = await ai.generate(
     prompt='What is the weather in San Francisco?',
-    tools=['get_weather'],
+    tools=[get_weather],
 )
 print(response.text)
 ```

--- a/src/content/docs/docs/integrations/anthropic.mdx
+++ b/src/content/docs/docs/integrations/anthropic.mdx
@@ -985,7 +985,7 @@ class WeatherInput(BaseModel):
     location: str = Field(description='City name')
 
 @ai.tool()
-def get_weather(input: WeatherInput) -> str:
+async def get_weather(input: WeatherInput) -> str:
     """Get current weather for a location."""
     return f'72°F and sunny in {input.location}'
 

--- a/src/content/docs/docs/integrations/deepseek.mdx
+++ b/src/content/docs/docs/integrations/deepseek.mdx
@@ -70,7 +70,7 @@ export const deepseekFlow = ai.defineFlow(
   },
   async ({ subject }) => {
     // Reference a model
-    const deepseekChat = deepSeek.model('deepseek-chat');
+    const deepseekChat = deepSeek.model('deepseek-v4-flash');
 
     // Use it in a generate call
     const llmResponse = await ai.generate({
@@ -87,7 +87,7 @@ You can also pass model-specific configuration:
 
 ```ts
 const llmResponse = await ai.generate({
-  model: deepSeek.model('deepseek-chat'),
+  model: deepSeek.model('deepseek-v4-flash'),
   prompt: 'Tell me something about deep learning.',
   config: {
     temperature: 0.8,
@@ -166,7 +166,7 @@ import (
 ctx := context.Background()
 
 resp, err := genkit.Generate(ctx, g,
-    ai.WithModelName("deepseek/deepseek-chat"),
+    ai.WithModelName("deepseek/deepseek-v4-flash"),
     ai.WithPrompt("tell me a fun fact about Mars"),
 )
 ```
@@ -175,10 +175,10 @@ resp, err := genkit.Generate(ctx, g,
 
 <Lang lang="python">
 
-The `genkit-openai` package handles integration for [DeepSeek](https://www.deepseek.com/) models, including the powerful R1 reasoning model and the efficient V3 chat model.
+The `genkit-openai` package handles integration for [DeepSeek](https://www.deepseek.com/) models, including the powerful V4-Pro model and the efficient V4-Flash model.
 
 :::note
-The DeepSeek plugin is built on top of the OpenAI-compatible plugin architecture. It is pre-configured for DeepSeek's API endpoints.
+DeepSeek uses the OpenAI-compatible plugin (`genkit-openai`). Point `OpenAI` at DeepSeek with `base_url='https://api.deepseek.com'` (and your DeepSeek API key).
 :::
 
 ## Installation
@@ -238,7 +238,7 @@ async def deepseek_flow(subject: str) -> str:
         Information about the subject.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-chat'),
+        model=openai_model('deepseek-v4-flash'),
         prompt=f'Tell me something about {subject}.',
     )
     return response.text
@@ -248,16 +248,16 @@ async def deepseek_flow(subject: str) -> str:
 
 The DeepSeek plugin provides access to several models:
 
-- **`deepseek-chat`**: Standard chat model for most conversational tasks
-- **`deepseek-reasoner`**: R1 reasoning model with chain-of-thought capabilities
-- **`deepseek-v3`**: Latest V3 model with improved performance
-- **`deepseek-r1`**: Advanced R1 reasoning model
+- **`deepseek-v4-flash`**: Fast, cost-effective model with reasoning capabilities that closely approach V4-Pro, supporting both thinking and non-thinking modes
+- **`deepseek-v4-pro`**: Flagship model with the strongest reasoning and agent capabilities, supporting both thinking and non-thinking modes
+
+Both models support a large context window. Prefer the explicit V4 model IDs above over older `deepseek-chat` / `deepseek-reasoner` aliases.
 
 ## Advanced usage
 
 ### Reasoning Model
 
-The `deepseek-reasoner` model shows step-by-step reasoning, making it ideal for complex logic, math, and coding problems:
+DeepSeek thinking mode shows step-by-step reasoning, making it ideal for complex logic, math, and coding problems:
 
 ```python
 @ai.flow()
@@ -271,7 +271,7 @@ async def reasoning_flow(problem: str) -> str:
         The solution with reasoning steps.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-reasoner'),
+        model=openai_model('deepseek-v4-pro'),
         prompt=f'Solve this problem step by step: {problem}',
     )
     return response.text
@@ -281,7 +281,7 @@ Example with a classic reasoning problem:
 
 ```python
 response = await ai.generate(
-    model=openai_model('deepseek-reasoner'),
+    model=openai_model('deepseek-v4-pro'),
     prompt='What is heavier, one kilo of steel or one kilo of feathers?',
 )
 print(response.text)  # Shows reasoning steps before the answer
@@ -299,7 +299,7 @@ class WeatherInput(BaseModel):
     location: str = Field(description='City name')
 
 @ai.tool(description='Get current weather for a location')
-def get_weather(input: WeatherInput) -> str:
+async def get_weather(input: WeatherInput) -> str:
     """Get the current weather for a location."""
     # In a real implementation, call a weather API
     return f'22°C and sunny in {input.location}'
@@ -315,7 +315,7 @@ async def weather_flow(location: str) -> str:
         Weather information for the location.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-chat'),
+        model=openai_model('deepseek-v4-flash'),
         prompt=f'What is the weather in {location}?',
         tools=['get_weather'],
     )
@@ -330,7 +330,7 @@ The plugin supports streaming responses for real-time output:
 from genkit import ActionRunContext
 
 @ai.flow()
-async def streaming_flow(topic: str, ctx: ActionRunContext | None = None) -> str:
+async def streaming_flow(topic: str, ctx: ActionRunContext) -> str:
     """Generate content with streaming output.
 
     Args:
@@ -340,12 +340,13 @@ async def streaming_flow(topic: str, ctx: ActionRunContext | None = None) -> str
     Returns:
         The complete generated content.
     """
-    response = await ai.generate(
-        model=openai_model('deepseek-chat'),
+    stream_response = ai.generate_stream(
+        model=openai_model('deepseek-v4-flash'),
         prompt=f'Tell me about {topic}',
-        on_chunk=ctx.send_chunk if ctx else None,
     )
-    return response.text
+    async for chunk in stream_response.stream:
+        ctx.send_chunk(chunk.text)
+    return (await stream_response.response).text
 ```
 
 ### Multi-turn Chat
@@ -366,7 +367,7 @@ async def chat_flow() -> str:
 
     # First message
     response1 = await ai.generate(
-        model=openai_model('deepseek-chat'),
+        model=openai_model('deepseek-v4-flash'),
         prompt='I love Japanese food, especially ramen.',
         system='You are a helpful assistant.',
     )
@@ -381,7 +382,7 @@ async def chat_flow() -> str:
 
     # Follow-up using context
     response2 = await ai.generate(
-        model=openai_model('deepseek-chat'),
+        model=openai_model('deepseek-v4-flash'),
         messages=[
             *history,
             Message(
@@ -400,7 +401,6 @@ Generate structured data using Pydantic models:
 
 ```python
 from pydantic import BaseModel, Field
-from genkit import Output
 
 class BookRecommendation(BaseModel):
     """A book recommendation."""
@@ -421,9 +421,9 @@ async def recommend_book(preferences: str) -> BookRecommendation:
         A structured book recommendation.
     """
     response = await ai.generate(
-        model=openai_model('deepseek-chat'),
+        model=openai_model('deepseek-v4-flash'),
         prompt=f'Recommend a book for someone who likes: {preferences}',
-        output=Output(schema=BookRecommendation),
+        output_schema=BookRecommendation,
     )
     return response.output
 ```

--- a/src/content/docs/docs/integrations/deepseek.mdx
+++ b/src/content/docs/docs/integrations/deepseek.mdx
@@ -175,11 +175,7 @@ resp, err := genkit.Generate(ctx, g,
 
 <Lang lang="python">
 
-The `genkit-openai` package handles integration for [DeepSeek](https://www.deepseek.com/) models, including the powerful V4-Pro model and the efficient V4-Flash model.
-
-:::note
-DeepSeek uses the OpenAI-compatible plugin (`genkit-openai`). Point `OpenAI` at DeepSeek with `base_url='https://api.deepseek.com'` (and your DeepSeek API key).
-:::
+DeepSeek is available through the OpenAI-compatible plugin in `genkit-openai`.
 
 ## Installation
 
@@ -189,7 +185,7 @@ uv add genkit-openai
 
 ## Configuration
 
-To use this plugin, import `OpenAI` and specify it when you initialize Genkit:
+Point `OpenAI` at DeepSeek's API:
 
 ```python
 from genkit import Genkit
@@ -197,22 +193,16 @@ from genkit_openai import OpenAI
 import os
 
 ai = Genkit(
-    plugins=[OpenAI(base_url='https://api.deepseek.com/v1', api_key=os.getenv('DEEPSEEK_API_KEY'))],
+    plugins=[
+        OpenAI(
+            base_url='https://api.deepseek.com/v1',
+            api_key=os.getenv('DEEPSEEK_API_KEY'),
+        ),
+    ],
 )
 ```
 
-You must provide an API key from DeepSeek. You can get an API key from your [DeepSeek account settings](https://platform.deepseek.com/).
-
-Configure the plugin to use your API key by doing one of the following:
-
-- Set the `DEEPSEEK_API_KEY` environment variable to your API key.
-- Specify the API key when you initialize the plugin:
-
-```python
-OpenAI(base_url='https://api.deepseek.com/v1', api_key='YOUR_API_KEY')
-```
-
-As always, avoid embedding API keys directly in your code.
+Get an API key from your [DeepSeek account settings](https://platform.deepseek.com/) and pass it as `api_key=` when you initialize the plugin—for example from the `DEEPSEEK_API_KEY` environment variable. Don't embed API keys directly in code.
 
 ## Usage
 
@@ -317,7 +307,7 @@ async def weather_flow(location: str) -> str:
     response = await ai.generate(
         model=openai_model('deepseek-v4-flash'),
         prompt=f'What is the weather in {location}?',
-        tools=['get_weather'],
+        tools=[get_weather],
     )
     return response.text
 ```

--- a/src/content/docs/docs/integrations/google-cloud.mdx
+++ b/src/content/docs/docs/integrations/google-cloud.mdx
@@ -199,15 +199,15 @@ uv add genkit-google-cloud
 ## Configuration
 
 To enable exporting to Google Cloud Tracing and Monitoring, import
-`add_gcp_telemetry()` and call it during initialization. After calling it, your
+`enable_google_cloud_telemetry()` and call it during initialization. After calling it, your
 telemetry gets automatically exported.
 
 ```python
-from genkit_google_cloud import add_gcp_telemetry
+from genkit_google_cloud import enable_google_cloud_telemetry
 ```
 
 ```python
-add_gcp_telemetry(project_id="your-google-cloud-project")
+enable_google_cloud_telemetry(project_id="your-google-cloud-project")
 ```
 
 You must specify the Google Cloud project to which you want to export telemetry

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1801,10 +1801,9 @@ response = await ai.generate(
     },
 )
 
-# Access generated image
-if response.message and response.message.content:
-    media_part = response.message.content[0]
-    print(f'Generated image: {media_part.root.media.url}')
+# Access generated images (response.media is a list)
+for media in response.media:
+    print(f'Generated image: {media.url}')
 ```
 
 ## Video Models (Veo)
@@ -1883,10 +1882,9 @@ response = await ai.generate(
     },
 )
 
-# Extract audio
-if response.message and response.message.content:
-    audio_part = response.message.content[0]
-    audio_data = audio_part.root.media.url
+# Extract audio (response.media is a list)
+if response.media:
+    audio_data = response.media[0].url
     print(f'Audio generated: {audio_data[:50]}...')
 ```
 

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1821,6 +1821,8 @@ Veo models generate videos from text prompts using the background model pattern
 
 ```python
 import asyncio
+
+from genkit import ModelResponse
 from genkit_google_genai import VeoVersion
 
 # Start video generation (returns an Operation)
@@ -1843,9 +1845,9 @@ if operation:
     if operation.error:
         print(f'Error: {operation.error.message}')
     else:
-        # Extract video from result
-        video = operation.output.message.content[0]
-        print(f'Video URL: {video.root.media.url}')
+        result = ModelResponse.model_validate(operation.output)
+        for media in result.media:
+            print(f'Video URL: {media.url}')
 ```
 
 **Configuration Options:**

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1639,9 +1639,8 @@ response = await ai.generate(
 print(response.text)
 
 # Non-text parts (images, audio, etc.)
-if response.message:
-    for media in response.message.media:
-        print(f'Media type: {media.content_type}')
+for media in response.media:
+    print(f'Media type: {media.content_type}')
 
 # Usage may include thinking and context-cache token counts on supported models
 print(response.usage.thoughts_tokens)
@@ -1654,7 +1653,6 @@ Gemini models support structured output generation using Pydantic schemas:
 
 ```python
 from pydantic import BaseModel, Field
-from genkit import Output
 
 class Character(BaseModel):
     """An RPG character."""
@@ -1664,7 +1662,7 @@ class Character(BaseModel):
 
 response = await ai.generate(
     prompt='Generate a profile for a fictional fantasy character',
-    output=Output(schema=Character),
+    output_schema=Character,
 )
 print(response.output)  # Character instance
 ```

--- a/src/content/docs/docs/integrations/ollama.mdx
+++ b/src/content/docs/docs/integrations/ollama.mdx
@@ -482,7 +482,7 @@ async def weather_flow(location: str) -> str:
     response = await ai.generate(
         model=ollama_name('mistral-nemo'),
         prompt=f"What's the weather like in {location}?",
-        tools=['get_weather'],
+        tools=[get_weather],
     )
     return response.text
 ```

--- a/src/content/docs/docs/integrations/ollama.mdx
+++ b/src/content/docs/docs/integrations/ollama.mdx
@@ -406,7 +406,7 @@ ai = Genkit(
 )
 
 @ai.flow()
-async def get_embeddings(text: str) -> list[float]:
+async def get_embeddings(text: str):
     """Generate embeddings for text.
 
     Args:
@@ -430,7 +430,7 @@ Ollama models support streaming responses for real-time output:
 from genkit import ActionRunContext
 
 @ai.flow()
-async def streaming_story(topic: str, ctx: ActionRunContext | None = None) -> str:
+async def streaming_story(topic: str, ctx: ActionRunContext) -> str:
     """Generate a story with streaming output.
 
     Args:
@@ -440,12 +440,13 @@ async def streaming_story(topic: str, ctx: ActionRunContext | None = None) -> st
     Returns:
         The complete generated story.
     """
-    response = await ai.generate(
+    stream_response = ai.generate_stream(
         model=ollama_name('llama3.2'),
         prompt=f'Write a short story about {topic}',
-        on_chunk=ctx.send_chunk if ctx else None,
     )
-    return response.text
+    async for chunk in stream_response.stream:
+        ctx.send_chunk(chunk.text)
+    return (await stream_response.response).text
 ```
 
 ### Tool Calling
@@ -460,7 +461,7 @@ class WeatherInput(BaseModel):
     location: str = Field(description='City name')
 
 @ai.tool(description='Get current weather for a location')
-def get_weather(input: WeatherInput) -> str:
+async def get_weather(input: WeatherInput) -> str:
     """Get the current weather for a location."""
     # In a real implementation, call a weather API
     return f'The weather in {input.location} is 72°F and sunny.'
@@ -492,7 +493,6 @@ Generate structured data using Pydantic models:
 
 ```python
 from pydantic import BaseModel, Field
-from genkit import Output
 
 class Recipe(BaseModel):
     """A cooking recipe."""
@@ -514,7 +514,7 @@ async def create_recipe(dish: str) -> Recipe:
     response = await ai.generate(
         model=ollama_name('llama3.2'),
         prompt=f'Create a recipe for {dish}',
-        output=Output(schema=Recipe),
+        output_schema=Recipe,
     )
     return response.output
 ```

--- a/src/content/docs/docs/integrations/openai-compatible.mdx
+++ b/src/content/docs/docs/integrations/openai-compatible.mdx
@@ -207,7 +207,7 @@ The OpenAI-Compatible API package (`genkit-openai`) provides a unified interface
 
 ## Overview
 
-The `compat_oai` package serves as a foundation for building plugins that work with OpenAI-compatible APIs. It includes:
+The `genkit-openai` package serves as a foundation for building plugins that work with OpenAI-compatible APIs. It includes:
 
 - **Base Implementation**: Common functionality for OpenAI-compatible APIs
 - [**OpenAI Plugin**](/docs/integrations/openai): Direct access to OpenAI's models and embeddings

--- a/src/content/docs/docs/integrations/openai.mdx
+++ b/src/content/docs/docs/integrations/openai.mdx
@@ -688,14 +688,14 @@ async def embed_flow(text: str) -> list[float]:
         text: The text to embed.
 
     Returns:
-        The embedding vector.
+        The first embedding vector values.
     """
-    embedding = await ai.embed(
+    embeddings = await ai.embed(
         embedder='openai/text-embedding-3-small',
         content=text,
     )
 
-    return embedding
+    return embeddings[0].embedding
 ```
 
 ### Tool Calling
@@ -719,7 +719,7 @@ class WeatherRequest(BaseModel):
     longitude: Decimal
 
 @ai.tool(description='Get current temperature for provided coordinates in celsius')
-def get_weather_tool(coordinates: WeatherRequest) -> float:
+async def get_weather_tool(coordinates: WeatherRequest) -> float:
     """Get the current temperature for provided coordinates in celsius.
 
     Args:
@@ -733,8 +733,8 @@ def get_weather_tool(coordinates: WeatherRequest) -> float:
         f'latitude={coordinates.latitude}&longitude={coordinates.longitude}'
         f'&current=temperature_2m'
     )
-    with httpx.Client() as client:
-        response = client.get(url)
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
         data = response.json()
         return float(data['current']['temperature_2m'])
 
@@ -772,14 +772,14 @@ async def say_hi_stream(name: str) -> str:
     Returns:
         The response from the OpenAI API.
     """
-    stream, _ = ai.generate_stream(
+    result = ai.generate_stream(
         model=openai_model('gpt-5.5'),
         prompt=f'hi {name}',
     )
-    result = ''
-    async for chunk in stream:
-        result += chunk.text
-    return result
+    text = ''
+    async for chunk in result.stream:
+        text += chunk.text
+    return text
 ```
 
 ## Advanced usage

--- a/src/content/docs/docs/integrations/openai.mdx
+++ b/src/content/docs/docs/integrations/openai.mdx
@@ -751,7 +751,7 @@ async def get_weather_flow(location: str) -> str:
     response = await ai.generate(
         model=openai_model('gpt-5.4-mini'),
         prompt=f"What's the weather like in {location} today?",
-        tools=['get_weather_tool'],
+        tools=[get_weather_tool],
     )
     # The response will contain the tool output if the model decided to call it.
     return response.text

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -961,10 +961,10 @@ The following advanced features are available in Python. Note that some features
 uv add genkit-google-genai
 ```
 
-**Model Garden and Vector Search** (requires separate plugin):
+**Model Garden** (separate package):
 
 ```bash
-uv add genkit-plugin-vertex-ai
+uv add genkit-vertexai
 ```
 
 If you want to locally run flows that use these plugins, you also need the [Google Cloud CLI tool](https://cloud.google.com/sdk/docs/install) installed.
@@ -1103,24 +1103,23 @@ llm_response = await ai.generate(
 
 ### Model Garden Integration
 
-Access third-party models through Vertex AI Model Garden using the `genkit-plugin-vertex-ai` package (`ModelGardenPlugin`). The plugin requires a Google Cloud project ID: pass `project_id`, or set `GCLOUD_PROJECT` / `GOOGLE_CLOUD_PROJECT`. Model IDs must use the publisher-qualified names shown in the Google Cloud console (for example `meta/...` for Llama, `anthropic/...` for Claude on Vertex). Pass them to `model_garden_name()` so Genkit resolves the action as `modelgarden/<model-id>`.
+Access third-party models through Vertex AI Model Garden using the `genkit-vertexai` package (`ModelGarden`). The plugin requires a Google Cloud project ID: pass `project_id`, or set `GCLOUD_PROJECT` / `GOOGLE_CLOUD_PROJECT`. Model IDs must use the publisher-qualified names shown in the Google Cloud console (for example `meta/...` for Llama, `anthropic/...` for Claude on Vertex). Pass them to `model_garden_name()` so Genkit resolves the action as `modelgarden/<model-id>`.
 
 **Installation:**
 
 ```bash
-uv add genkit-plugin-vertex-ai
+uv add genkit-vertexai
 ```
 
 #### Llama (Meta) models
 
 ```python
 from genkit import Genkit
-from genkit.plugins.vertex_ai import ModelGardenPlugin
-from genkit.plugins.vertex_ai.model_garden import model_garden_name
+from genkit_vertexai.model_garden import ModelGarden, model_garden_name
 
 ai = Genkit(
     plugins=[
-        ModelGardenPlugin(
+        ModelGarden(
             project_id='my-gcp-project',
             location='us-central1',
         ),
@@ -1141,12 +1140,11 @@ Claude on Vertex uses `anthropic/...` model IDs. Version strings often include d
 
 ```python
 from genkit import Genkit
-from genkit.plugins.vertex_ai import ModelGardenPlugin
-from genkit.plugins.vertex_ai.model_garden import model_garden_name
+from genkit_vertexai.model_garden import ModelGarden, model_garden_name
 
 ai = Genkit(
     plugins=[
-        ModelGardenPlugin(
+        ModelGarden(
             project_id='my-gcp-project',
             location='us-central1',
         ),
@@ -1190,15 +1188,11 @@ Available built-in metrics from the Vertex AI plugin include:
 
 See the [evaluation documentation](/docs/evaluation) for more details on implementing comprehensive evaluation workflows.
 
-### Vector Search
-
-Advanced Vertex AI features like Vector Search require custom implementation using the Google Cloud SDK directly in Python. See the [Vertex AI documentation](https://cloud.google.com/vertex-ai/docs) for implementation details.
-
 ## Next Steps
 
 - Learn about [generating content](/docs/models) to understand how to use these models effectively
 - Explore [evaluation](/docs/evaluation) to leverage Vertex AI's evaluation metrics
-- See [RAG](/docs/rag) to implement retrieval-augmented generation with Vector Search
+- See [RAG](/docs/rag) to implement retrieval-augmented generation
 - Check out [creating flows](/docs/flows) to build structured AI workflows
 - For simple API key access, see the [Google AI plugin](/docs/integrations/google-genai)
 

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -913,9 +913,8 @@ response = await ai.generate(
     prompt='A beautiful watercolor painting of a castle in the mountains.',
 )
 
-if response.message and response.message.content:
-    media_part = response.message.content[0]
-    generated_image = media_part.root.media.url
+if response.media:
+    generated_image = response.media[0].url
 ```
 
 ### Thinking Config

--- a/src/content/docs/docs/integrations/xai.mdx
+++ b/src/content/docs/docs/integrations/xai.mdx
@@ -224,7 +224,7 @@ func main() {
 The `genkit-openai` package manages integration for [xAI (Grok)](https://x.ai/) models. The `OpenAI` compatible plugin provides access to the `grok` family of models, including vision models.
 
 :::note
-The xAI plugin is built on top of the OpenAI-compatible plugin architecture. It is pre-configured for xAI's API endpoints.
+xAI uses the OpenAI-compatible plugin (`genkit-openai`). Point `OpenAI` at xAI with `base_url='https://api.x.ai/v1'` (and your xAI API key).
 :::
 
 ## Installation
@@ -313,7 +313,7 @@ class WeatherInput(BaseModel):
     location: str = Field(description='City name')
 
 @ai.tool(description='Get current weather for a location')
-def get_weather(input: WeatherInput) -> str:
+async def get_weather(input: WeatherInput) -> str:
     """Get the current weather for a location."""
     # In a real implementation, call a weather API
     return f'The weather in {input.location} is 72°F and sunny.'
@@ -333,14 +333,15 @@ The plugin supports streaming responses for real-time output:
 from genkit import ActionRunContext
 
 @ai.flow()
-async def streaming_story(name: str, ctx: ActionRunContext | None = None) -> str:
+async def streaming_story(name: str, ctx: ActionRunContext) -> str:
     """Generate a story with streaming output."""
-    response = await ai.generate(
+    stream_response = ai.generate_stream(
         model=openai_model('grok-4.3'),
         prompt=f'Write a short story about {name}',
-        on_chunk=ctx.send_chunk if ctx else None,
     )
-    return response.text
+    async for chunk in stream_response.stream:
+        ctx.send_chunk(chunk.text)
+    return (await stream_response.response).text
 ```
 
 **Vision Capabilities:**
@@ -365,7 +366,6 @@ Generate structured data using Pydantic models:
 
 ```python
 from pydantic import BaseModel, Field
-from genkit import Output
 
 class MovieRecommendation(BaseModel):
     """A movie recommendation."""
@@ -377,7 +377,7 @@ class MovieRecommendation(BaseModel):
 response = await ai.generate(
     model=openai_model('grok-4.3'),
     prompt=f'Recommend a movie for someone who likes: {preferences}',
-    output=Output(schema=MovieRecommendation),
+    output_schema=MovieRecommendation,
 )
 movie = response.output  # Typed as MovieRecommendation
 ```

--- a/src/content/docs/docs/integrations/xai.mdx
+++ b/src/content/docs/docs/integrations/xai.mdx
@@ -221,11 +221,7 @@ func main() {
 
 <Lang lang="python">
 
-The `genkit-openai` package manages integration for [xAI (Grok)](https://x.ai/) models. The `OpenAI` compatible plugin provides access to the `grok` family of models, including vision models.
-
-:::note
-xAI uses the OpenAI-compatible plugin (`genkit-openai`). Point `OpenAI` at xAI with `base_url='https://api.x.ai/v1'` (and your xAI API key).
-:::
+xAI (Grok) is available through the OpenAI-compatible plugin in `genkit-openai`, including vision models.
 
 ## Installation
 
@@ -235,7 +231,7 @@ uv add genkit-openai
 
 ## Configuration
 
-To use this plugin, import `OpenAI` and specify it when you initialize Genkit:
+Point `OpenAI` at xAI's API:
 
 ```python
 from genkit import Genkit
@@ -243,22 +239,16 @@ from genkit_openai import OpenAI
 import os
 
 ai = Genkit(
-    plugins=[OpenAI(base_url='https://api.x.ai/v1', api_key=os.getenv('XAI_API_KEY'))],
+    plugins=[
+        OpenAI(
+            base_url='https://api.x.ai/v1',
+            api_key=os.getenv('XAI_API_KEY'),
+        ),
+    ],
 )
 ```
 
-You must provide an API key from xAI. You can get an API key from your [xAI account settings](https://console.x.ai/).
-
-Configure the plugin to use your API key by doing one of the following:
-
-- Set the `XAI_API_KEY` environment variable to your API key.
-- Specify the API key when you initialize the plugin:
-
-```python
-OpenAI(base_url='https://api.x.ai/v1', api_key='YOUR_API_KEY')
-```
-
-As always, avoid embedding API keys directly in your code.
+Get an API key from your [xAI account settings](https://console.x.ai/) and pass it as `api_key=` when you initialize the plugin—for example from the `XAI_API_KEY` environment variable. Don't embed API keys directly in code.
 
 ## Usage
 
@@ -321,7 +311,7 @@ async def get_weather(input: WeatherInput) -> str:
 response = await ai.generate(
     model=openai_model('grok-4.3'),
     prompt="What's the weather like in Austin?",
-    tools=['get_weather'],
+    tools=[get_weather],
 )
 ```
 
@@ -351,6 +341,8 @@ Use the Grok Vision model to analyze images:
 ```python
 from genkit import Part, TextPart, MediaPart, Media
 
+image_url = 'https://example.com/photo.jpg'
+
 response = await ai.generate(
     model=openai_model('grok-4.3'),
     prompt=[
@@ -373,6 +365,8 @@ class MovieRecommendation(BaseModel):
     year: int = Field(description='Release year')
     genre: str = Field(description='Primary genre')
     reason: str = Field(description='Why this movie is recommended')
+
+preferences = 'sci-fi and heist movies'
 
 response = await ai.generate(
     model=openai_model('grok-4.3'),

--- a/src/content/docs/docs/interrupts.mdx
+++ b/src/content/docs/docs/interrupts.mdx
@@ -925,10 +925,11 @@ interacting with an LLM:
 The most common kind of interrupt allows the LLM to request clarification from
 the user, for example by asking a multiple-choice question.
 
-For this use case, use the Genkit instance's `tool()` decorator with `ctx.interrupt()`:
+For this use case, register an interrupt tool with `define_interrupt`, or raise
+`Interrupt` from a normal tool when you need to pause conditionally.
 
 ```python
-from genkit import FinishReason, Genkit, tool_response, ToolRunContext
+from genkit import FinishReason, Genkit, respond_to_interrupt
 from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
@@ -943,23 +944,15 @@ class QuestionInput(BaseModel):
     choices: list[str] = Field(description='the choices to display to the user')
     allow_other: bool = Field(default=False, description='when true, allow write-ins')
 
-@ai.tool()
-async def ask_question(input: QuestionInput, ctx: ToolRunContext) -> str:
-    """Use this to ask the user a clarifying question."""
-    # Interrupt with metadata that the caller can use.
-    ctx.interrupt({
-        'question': input.question,
-        'choices': input.choices,
-        'allow_other': input.allow_other,
-    })
+ask_question = ai.define_interrupt(
+    name='ask_question',
+    description='Use this to ask the user a clarifying question.',
+    input_schema=QuestionInput,
+)
 ```
 
-Note that the output type of an interrupt tool corresponds to the response data
-you will provide when resuming, as opposed to something that will be automatically
-populated by the tool function.
-
-To resume, build each entry in `tool_responses` with `tool_response` from `genkit`,
-wrapping the interrupted `ToolRequestPart` in `Part(root=...)` (see below).
+The output you later provide with `respond_to_interrupt` is what the model sees
+as the tool result when generation resumes.
 
 ### Use interrupts
 
@@ -970,11 +963,12 @@ same `generate` call:
 ```python
 response = await ai.generate(
     prompt='Ask me a movie trivia question.',
-    tools=['ask_question'],
+    tools=[ask_question],
 )
 ```
 
-Genkit immediately returns a response on receipt of an interrupt tool call.
+Genkit returns as soon as an interrupt tool is called
+(`finish_reason=FinishReason.INTERRUPTED`).
 
 ### Respond to interrupts
 
@@ -990,29 +984,24 @@ if response.finish_reason == FinishReason.INTERRUPTED:
 if response.interrupts:
     print(f"Interrupts found: {len(response.interrupts)}")
     for interrupt in response.interrupts:
-        # Access the interrupt metadata
         tool_input = interrupt.tool_request.input
         print(f"Question: {tool_input.get('question')}")
         print(f"Choices: {tool_input.get('choices')}")
 ```
 
-Responding to an interrupt is done using the `tool_responses` option on a subsequent
-`generate` call, making sure to pass in the existing message history. Use `tool_response`
-with each interrupted request and the user's answer:
+Resume with `respond_to_interrupt` and pass the result to `resume_respond`,
+keeping the existing message history:
 
 ```python
-from genkit import tool_response
-
 # Get the user's answer (e.g., from user input)
 user_answer = 'b'  # User selected option b
 
-tool_request = response.interrupts[0]
+interrupt = response.interrupts[0]
 
-# Resume generation with the tool response
 response = await ai.generate(
     messages=response.messages,
-    tool_responses=[tool_response(tool_request, user_answer)],
-    tools=['ask_question'],
+    resume_respond=respond_to_interrupt(user_answer, interrupt=interrupt),
+    tools=[ask_question],
 )
 ```
 
@@ -1022,41 +1011,33 @@ For interactive applications, you'll often need to handle multiple interrupts
 in a loop until the model completes its task:
 
 ```python
-from genkit import tool_response
-
 async def interactive_session():
     response = await ai.generate(
         prompt='Help me plan a backyard BBQ.',
         system='Ask clarifying questions until you have a complete solution.',
-        tools=['ask_question'],
+        tools=[ask_question],
     )
 
-    # Continue until no more interrupts
     while response.interrupts:
         answers = []
-
-        # Handle all interrupts (multiple can occur at once)
         for interrupt in response.interrupts:
-            tool_input = interrupt.tool_request.input
+            tool_input = interrupt.tool_request.input or {}
             question = tool_input.get('question', 'Unknown question')
             choices = tool_input.get('choices', [])
 
-            # Display to user and get their answer
             print(f"\nQuestion: {question}")
             for i, choice in enumerate(choices):
                 print(f"  {i + 1}. {choice}")
 
             user_input = input("Your answer: ")
-            answers.append(tool_response(interrupt, user_input))
+            answers.append(respond_to_interrupt(user_input, interrupt=interrupt))
 
-        # Resume generation with all answers
         response = await ai.generate(
             messages=response.messages,
-            tool_responses=answers,
-            tools=['ask_question'],
+            resume_respond=answers,
+            tools=[ask_question],
         )
 
-    # No more interrupts - print final response
     print(f"\nFinal response: {response.text}")
 ```
 
@@ -1065,36 +1046,38 @@ async def interactive_session():
 You can also use interrupts within flows for more structured applications:
 
 ```python
-from genkit import Genkit, ToolRunContext
+from genkit import Genkit
 from genkit_google_genai import GoogleAI
 from pydantic import BaseModel, Field
 
-ai = Genkit(plugins=[GoogleAI()])
+ai = Genkit(plugins=[GoogleAI()], model='googleai/gemini-flash-latest')
 
 class TriviaQuestion(BaseModel):
     """A trivia question with multiple choice answers."""
     question: str = Field(description='the trivia question')
     answers: list[str] = Field(description='multiple choice answers')
 
-@ai.tool()
-async def present_question(input: TriviaQuestion, ctx: ToolRunContext) -> None:
-    """Presents a trivia question to the user."""
-    ctx.interrupt(input.model_dump())
+present_question = ai.define_interrupt(
+    name='present_question',
+    description='Presents a trivia question to the user.',
+    input_schema=TriviaQuestion,
+)
 
 @ai.flow()
 async def play_trivia(theme: str) -> str:
     """Plays a trivia game on the given theme."""
     response = await ai.generate(
         prompt=f'Ask me a trivia question about {theme}.',
-        tools=['present_question'],
+        tools=[present_question],
     )
 
     if response.interrupts:
         interrupt = response.interrupts[0]
-        question_data = interrupt.tool_request.input
-
-        # In a real app, you'd get this from user input
-        return f"Question: {question_data.get('question')}\nAnswers: {question_data.get('answers')}"
+        question_data = interrupt.tool_request.input or {}
+        return (
+            f"Question: {question_data.get('question')}\n"
+            f"Answers: {question_data.get('answers')}"
+        )
 
     return response.text
 ```
@@ -1158,8 +1141,8 @@ if response.interrupts:
     if user_approved:
         # Rerun the tool by passing a restart part to resume_restart
         restart = restart_tool(
-            interrupt,
-            resumed_metadata={'approved_by': 'user'}
+            interrupt=interrupt,
+            resumed_metadata={'approved_by': 'user'},
         )
         response = await ai.generate(
             messages=messages,
@@ -1191,7 +1174,7 @@ meta = interrupt.tool_request.input
 adjusted_input = TransferInput(to_account=meta.get('to_account'), amount=100.0)
 
 restart = restart_tool(
-    interrupt,
+    interrupt=interrupt,
     resumed_metadata={'approved_by': 'user'},
     replace_input=adjusted_input,
 )

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -697,7 +697,7 @@ response = await ai.generate(
 
 ### 3. Tool approval middleware (`ToolApproval`)
 
-Restricts execution of tools to an approved list. If the model attempts to call an unapproved tool, it throws a `ToolInterruptError` allowing you to prompt the user for manual confirmation before resuming.
+Restricts execution of tools to an approved list. If the model attempts to call an unapproved tool, generation finishes interrupted (`FinishReason.INTERRUPTED`) so you can prompt the user for confirmation before resuming.
 
 ```python
 from genkit import FinishReason, Genkit, restart_tool
@@ -840,7 +840,7 @@ response = await ai.generate(
 )
 ```
 
-For more complex examples of building custom middleware, you can refer to the source code of the built-in middleware in the [Genkit GitHub repository](https://github.com/genkit-ai/genkit/tree/main/py/plugins/middleware).
+For more complex examples of building custom middleware, you can refer to the source code of the built-in middleware in the [Genkit GitHub repository](https://github.com/genkit-ai/genkit/tree/main/py/packages/genkit-middleware).
 
 </Lang>
 

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -652,7 +652,9 @@ The `genkit-middleware` package provides several useful middleware options out o
 
 ### 1. FileSystem middleware (`Filesystem`)
 
-Grants the model access to the local filesystem by injecting standard file manipulation tools (`list_files`, `read_file`, `write_file`, `edit_file`). All operations are safely restricted to a specified root directory.
+Grants the model access to a root directory by injecting `list_files` and
+`read_file`. When `allow_write_access=True` (default `False`), it also injects
+`write_file` and `edit_file`. All paths are restricted to that root.
 
 ```python
 from genkit import Genkit
@@ -671,7 +673,7 @@ response = await ai.generate(
 
 **Configuration options:**
 - `root_dir` (required): The root directory to which all filesystem operations are restricted.
-- `allow_write_access` (optional): If `True`, allows write access to the filesystem (defaults to `False`).
+- `allow_write_access` (optional): If `True`, adds write/edit tools (defaults to `False` — read-only).
 - `tool_name_prefix` (optional): Prefix to add to the name of the injected tools.
 
 ### 2. Skills middleware (`Skills`)
@@ -702,34 +704,48 @@ Restricts execution of tools to an approved list. If the model attempts to call 
 ```python
 from genkit import FinishReason, Genkit, restart_tool
 from genkit_middleware import ToolApproval
+from pydantic import BaseModel, Field
 
 ai = Genkit(...)
+
+
+class WriteFileInput(BaseModel):
+    path: str = Field(description='File path')
+    content: str = Field(description='File contents')
+
+
+@ai.tool(description='Write a text file')
+async def write_file_tool(input: WriteFileInput) -> str:
+    # Persist input.content to input.path in a real app.
+    return f'Wrote {input.path}'
+
 
 # 1. Initial attempt
 response = await ai.generate(
     prompt='write a file',
     tools=[write_file_tool],
     use=[
-        ToolApproval(allowed_tools=[]) # Empty list means all tool calls trigger interrupt
-    ]
+        ToolApproval(allowed_tools=[])  # Empty list means all tool calls trigger interrupt
+    ],
 )
 
 if response.finish_reason == FinishReason.INTERRUPTED:
     interrupt = response.interrupts[0]
-    
+
     # 2. Ask user for approval, then recreate the tool request with approval
     approved_part = restart_tool(
         interrupt=interrupt,
-        resumed_metadata={'tool_approved': True}
+        resumed_metadata={'tool_approved': True},
     )
 
     # 3. Resume execution
     resumed_response = await ai.generate(
         messages=list(response.messages),
+        tools=[write_file_tool],
         use=[
-            ToolApproval(allowed_tools=[])
+            ToolApproval(allowed_tools=[]),
         ],
-        resume_restart=approved_part
+        resume_restart=approved_part,
     )
 ```
 

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1695,12 +1695,11 @@ object's `output` property:
 output = result.output
 ```
 
-For multimodal responses, iterate `result.message.media` (each item is a `Media` value):
+For multimodal responses, iterate `result.media` (each item is a `Media` value):
 
 ```python
-if result.message:
-    for media in result.message.media:
-        print(media.content_type)
+for media in result.media:
+    print(media.content_type)
 ```
 
 #### Handling errors

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1537,9 +1537,11 @@ result = await ai.generate(
 )
 ```
 
-You can also pass a per-request API key, provider-specific options, and middleware on a single call. The `config` object allows extra fields for provider-specific parameters, and the `use` parameter accepts middleware to attach to that generation (for example logging or custom behavior):
+You can also pass a per-request API key, provider-specific options, and middleware on a single call. The `config` object allows extra fields for provider-specific parameters, and `use` takes middleware instances (see [middleware](/docs/middleware)):
 
 ```python
+from genkit_middleware import Retry
+
 result = await ai.generate(
     model='googleai/gemini-flash-latest',
     prompt='Hello',
@@ -1548,7 +1550,7 @@ result = await ai.generate(
         'temperature': 0.5,
         'provider_specific_option': 'value',
     },
-    use=[{'name': 'my-middleware', 'config': {'option': True}}],
+    use=[Retry()],
 )
 ```
 

--- a/src/content/docs/docs/overview.mdx
+++ b/src/content/docs/docs/overview.mdx
@@ -462,13 +462,15 @@ from genkit import Genkit
 from genkit_google_genai import GoogleAI
 
 ai = Genkit(
-	plugins=[GoogleAI()],
+    plugins=[GoogleAI()],
 )
 
 response = await ai.generate(
-	model='googleai/imagen-3.0-generate-002',
-	prompt='a banana riding a bicycle'
+    model='googleai/imagen-3.0-generate-002',
+    prompt='a banana riding a bicycle',
 )
+if response.media:
+    print(response.media[0].url)
 ```
 
 </TabItem>

--- a/src/content/docs/docs/overview.mdx
+++ b/src/content/docs/docs/overview.mdx
@@ -477,7 +477,7 @@ response = await ai.generate(
 
 ```python
 from genkit import Genkit
-from genkit.plugins.compat_oai import OpenAI
+from genkit_openai import OpenAI
 
 ai = Genkit(
 plugins=[OpenAI()],
@@ -496,8 +496,7 @@ print(response.text)
 
 ```python
 from genkit import Genkit
-from genkit.plugins.ollama import Ollama
-from genkit.plugins.ollama.models import ModelDefinition
+from genkit_ollama import Ollama, ModelDefinition
 
 ai = Genkit(
 	plugins=[

--- a/src/content/docs/docs/plugin-authoring/overview.mdx
+++ b/src/content/docs/docs/plugin-authoring/overview.mdx
@@ -1125,7 +1125,7 @@ class MyPlugin(Plugin):
             List of ActionMetadata describing available actions.
         """
         return [
-            ActionMetadata(kind=ActionKind.MODEL, name='my-plugin/my-model'),
+            ActionMetadata(action_type=ActionKind.MODEL, name='my-plugin/my-model'),
         ]
 
     def _create_model_action(self, name: str) -> Action:
@@ -1296,13 +1296,13 @@ The `supports` dict declares what features the model supports:
 
 ## Publishing a Plugin
 
-Genkit plugins can be published as normal Python packages on PyPI. To increase
-discoverability, your package should be named `genkit-plugin-{name}` to indicate
-it is a Genkit plugin. Include relevant keywords in your `pyproject.toml`:
+Genkit plugins can be published as normal Python packages on PyPI. Official
+plugins use the `genkit-{name}` package name (import as `genkit_{name}`). Include
+relevant keywords in your `pyproject.toml`:
 
 ```toml
 [project]
-name = "genkit-plugin-my-service"
+name = "genkit-my-service"
 description = "Genkit plugin for My Service"
 keywords = [
     "genkit",
@@ -1312,7 +1312,7 @@ keywords = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourorg/genkit-plugin-my-service"
+Homepage = "https://github.com/yourorg/genkit-my-service"
 ```
 
 ### Recommended Keywords

--- a/src/content/docs/docs/rag.mdx
+++ b/src/content/docs/docs/rag.mdx
@@ -808,10 +808,6 @@ _Note_: The `rerank` function is a placeholder for your own logic and is not pro
 
 For **Python**, Genkit’s RAG support centers on the shared **[`Document`](/docs/models)** model and **embedders**: use `ai.embed` and `ai.embed_many` with plugin-registered embedder names to produce vectors. Combine those embeddings with your ingestion, storage, and search code, then pass retrieved documents into **`ai.generate(..., docs=...)`** to ground answers.
 
-### Indexers
-
-### Retrievers
-
 RAG is a very broad area and there are many different techniques used to achieve
 the best quality RAG. Conceptually, most pipelines involve:
 
@@ -897,5 +893,16 @@ Any async function that returns `list[Document]` can supply context: call databa
 
 - Learn about [tool calling](/docs/tool-calling) to give your RAG system access to external APIs and functions
 - Explore [multi-agent systems](/docs/multi-agent) for coordinating multiple AI agents with RAG capabilities
-- Check out the vector database plugins for production-ready RAG implementations
 - See the [evaluation guide](/docs/evaluation) for testing and improving your RAG system's performance
+
+<Lang lang="js">
+
+- Check out the vector database plugins for production-ready RAG implementations
+
+</Lang>
+
+<Lang lang="go">
+
+- Check out the vector database plugins for production-ready RAG implementations
+
+</Lang>

--- a/src/content/docs/docs/rag.mdx
+++ b/src/content/docs/docs/rag.mdx
@@ -824,8 +824,9 @@ Typical steps: chunk source text, compute embeddings with `ai.embed` or `ai.embe
 
 ```python
 from genkit import Document, Genkit
+from genkit_google_genai import VertexAI
 
-ai = Genkit(plugins=[...])  # e.g. VertexAI / GoogleAI for embedders
+ai = Genkit(plugins=[VertexAI(location='us-central1')])
 
 async def ingest_chunks(chunks: list[Document], embedder: str) -> None:
     for doc in chunks:

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -891,7 +891,7 @@ class GetWeatherInput(BaseModel):
     location: str = Field(description='The location to get the current weather for')
 
 @ai.tool(name='getWeather', description='Gets the current weather in a given location')
-def get_weather(input: GetWeatherInput) -> str:
+async def get_weather(input: GetWeatherInput) -> str:
     # Here, we would typically make an API call or database query. For this
     # example, we just return a fixed value.
     return f'The current weather in {input.location} is 63°F and sunny.'
@@ -954,15 +954,15 @@ response = await weather_prompt({'location': 'Baltimore'})
 When combining tool calling with streaming responses, you will receive `toolRequest` and `toolResponse` content parts in the chunks of the stream. For example, the following code:
 
 ```python
-stream, response_future = ai.generate_stream(
+result = ai.generate_stream(
     prompt='What is the weather in Baltimore?',
     tools=['getWeather'],
 )
 
-async for chunk in stream:
+async for chunk in result.stream:
     print(chunk)
 
-response = await response_future
+response = await result.response
 ```
 
 Might produce a sequence of chunks similar to:
@@ -1003,7 +1003,7 @@ class WebSearchInput(BaseModel):
     query: str = Field(description='Search query')
 
 @ai.tool(name='webSearch', description='Search the web for current information')
-def web_search(input: WebSearchInput) -> str:
+async def web_search(input: WebSearchInput) -> str:
     # Simulate web search API call
     return f'Search results for "{input.query}": [relevant information here]'
 
@@ -1026,7 +1026,7 @@ class CalculatorInput(BaseModel):
     expression: str = Field(description='Mathematical expression to evaluate')
 
 @ai.tool(name='calculator', description='Perform mathematical calculations')
-def calculator(input: CalculatorInput) -> float:
+async def calculator(input: CalculatorInput) -> float:
     # Safe evaluation of mathematical expressions
     return eval(input.expression)  # In production, use a safe math parser
 
@@ -1042,7 +1042,10 @@ response = await ai.generate(
 
 **What happens when `max_turns` is reached?**
 
-When the limit is reached, Genkit stops the tool-calling loop and raises a [`GenkitError`](/docs/error-types). You can handle this error in your application to define specific behavior for this scenario.
+When the limit is reached, Genkit stops the tool-calling loop and raises an
+error from the generate path (today: `GenerationResponseError`). That type is
+not a `GenkitError` subclass, so `except GenkitError` will not catch it—catch
+the exception around your `generate` / `generate_stream` call instead.
 
 ### Pause the tool loop by using interrupts
 
@@ -1065,42 +1068,40 @@ apply more complicated logic, set the `return_tool_requests` parameter to `True`
 Now it's your responsibility to ensure all of the tool requests are fulfilled:
 
 ```python
-from genkit import tool_response
+from genkit import Message, Part, Role, ToolResponse, ToolResponsePart
 
-generate_options = dict(
+response = await ai.generate(
     prompt="What's the weather like in Baltimore?",
     tools=['getWeather'],
     return_tool_requests=True,
 )
 
-llm_response = None
-tool_responses = None
-messages = None
+while response.tool_requests:
+    tool_parts = []
+    for req in response.tool_requests:
+        if req.tool_request.name != 'getWeather':
+            raise ValueError(f'Unexpected tool: {req.tool_request.name}')
+        output = await get_weather(GetWeatherInput(**req.tool_request.input))
+        tool_parts.append(
+            Part(
+                root=ToolResponsePart(
+                    tool_response=ToolResponse(
+                        name=req.tool_request.name,
+                        ref=req.tool_request.ref,
+                        output=output,
+                    )
+                )
+            )
+        )
 
-while True:
-    llm_response = await ai.generate(
-        **generate_options,
-        messages=messages,
-        tool_responses=tool_responses,
+    response = await ai.generate(
+        messages=[
+            *response.messages,
+            Message(role=Role.TOOL, content=tool_parts),
+        ],
+        tools=['getWeather'],
+        return_tool_requests=True,
     )
-
-    tool_requests = llm_response.tool_requests
-    if len(tool_requests) < 1:
-        break
-
-    tool_responses = []
-    for req in tool_requests:
-        match req.tool_request.name:
-            case 'getWeather':
-                output = await get_weather(GetWeatherInput(**req.tool_request.input))
-                tool_responses.append(tool_response(req, output))
-            case _:
-                raise ValueError('Tool not found')
-
-    # Continue the loop from the updated message history
-    messages = llm_response.messages
-    # Only include the initial prompt on the first turn
-    generate_options.pop('prompt', None)
 ```
 
 ## Extending tool capabilities with MCP

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -911,16 +911,16 @@ Include defined tools in your prompts to generate content.
 ```python
 response = await ai.generate(
     prompt='What is the weather in Baltimore?',
-    tools=['getWeather'],
+    tools=[get_weather],
 )
 ```
 
-**Using `definePrompt()`:**
+**Using `define_prompt()`:**
 
 ```python
 weather_prompt = ai.define_prompt(
     name='weatherPrompt',
-    tools=['getWeather'],
+    tools=[get_weather],
     prompt='What is the weather in {{location}}?',
 )
 
@@ -951,33 +951,28 @@ response = await weather_prompt({'location': 'Baltimore'})
 
 ### Streaming and tool calling
 
-When combining tool calling with streaming responses, you will receive `toolRequest` and `toolResponse` content parts in the chunks of the stream. For example, the following code:
+When combining tool calling with streaming, chunks are `ModelResponseChunk` values.
+Use `chunk.text` for text deltas, and inspect `chunk.content` for `tool_request` /
+`tool_response` parts (snake_case on the Python models):
 
 ```python
 result = ai.generate_stream(
     prompt='What is the weather in Baltimore?',
-    tools=['getWeather'],
+    tools=[get_weather],
 )
 
 async for chunk in result.stream:
-    print(chunk)
+    if chunk.text:
+        print(chunk.text, end='', flush=True)
+    for part in chunk.content:
+        root = part.root
+        if hasattr(root, 'tool_request') and root.tool_request is not None:
+            print(f'\n[tool request] {root.tool_request.name}({root.tool_request.input})')
+        if hasattr(root, 'tool_response') and root.tool_response is not None:
+            print(f'\n[tool response] {root.tool_response.name} -> {root.tool_response.output}')
 
 response = await result.response
 ```
-
-Might produce a sequence of chunks similar to:
-
-```json
-{index: 0, role: "model", content: [{text: "Okay, I'll check the weather"}]}
-{index: 0, role: "model", content: [{text: "for Baltimore."}]}
-// toolRequests will be emitted as a single chunk by most models
-{index: 0, role: "model", content: [{toolRequest: {name: "getWeather", input: {location: "Baltimore"}}}]}
-// when streaming multiple messages, Genkit increments the index and indicates the new role
-{index: 1, role: "tool", content: [{toolResponse: {name: "getWeather", output: "Temperature: 68 degrees\nStatus: Cloudy."}}]}
-{index: 2, role: "model", content: [{text: "The weather in Baltimore is 68 degrees and cloudy."}]}
-```
-
-You can use these chunks to dynamically construct the full generated message sequence.
 
 ### Limiting tool call iterations with `max_turns`
 
@@ -1012,7 +1007,7 @@ response = await ai.generate(
         'Research the latest developments in quantum computing, including recent breakthroughs, '
         'key companies, and future applications.'
     ),
-    tools=['webSearch'],
+    tools=[web_search],
     max_turns=8,  # Allow up to 8 research iterations
 )
 ```
@@ -1035,7 +1030,7 @@ response = await ai.generate(
         'Calculate the total value of my portfolio: 100 shares of AAPL, 50 shares of GOOGL, and '
         '200 shares of MSFT. Also calculate what percentage each holding represents.'
     ),
-    tools=['calculator'],
+    tools=[calculator],
     max_turns=12,  # Multiple calculation steps needed
 )
 ```
@@ -1072,7 +1067,7 @@ from genkit import Message, Part, Role, ToolResponse, ToolResponsePart
 
 response = await ai.generate(
     prompt="What's the weather like in Baltimore?",
-    tools=['getWeather'],
+    tools=[get_weather],
     return_tool_requests=True,
 )
 
@@ -1099,7 +1094,7 @@ while response.tool_requests:
             *response.messages,
             Message(role=Role.TOOL, content=tool_parts),
         ],
-        tools=['getWeather'],
+        tools=[get_weather],
         return_tool_requests=True,
     )
 ```

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -952,8 +952,7 @@ response = await weather_prompt({'location': 'Baltimore'})
 ### Streaming and tool calling
 
 When combining tool calling with streaming, chunks are `ModelResponseChunk` values.
-Use `chunk.text` for text deltas, and inspect `chunk.content` for `tool_request` /
-`tool_response` parts (snake_case on the Python models):
+Use `chunk.text` for text deltas, and inspect `chunk.content` for tool parts:
 
 ```python
 result = ai.generate_stream(
@@ -965,11 +964,12 @@ async for chunk in result.stream:
     if chunk.text:
         print(chunk.text, end='', flush=True)
     for part in chunk.content:
-        root = part.root
-        if hasattr(root, 'tool_request') and root.tool_request is not None:
-            print(f'\n[tool request] {root.tool_request.name}({root.tool_request.input})')
-        if hasattr(root, 'tool_response') and root.tool_response is not None:
-            print(f'\n[tool response] {root.tool_response.name} -> {root.tool_response.output}')
+        if part.root.tool_request is not None:
+            req = part.root.tool_request
+            print(f'\n[tool request] {req.name}({req.input})')
+        if part.root.tool_response is not None:
+            res = part.root.tool_response
+            print(f'\n[tool response] {res.name} -> {res.output}')
 
 response = await result.response
 ```


### PR DESCRIPTION
Cleanup and improvements to FastAPI docs page.

- **Packages/imports** — `genkit-*` / `genkit_*` everywhere; drop legacy `genkit.plugins.*` / `genkit-plugin-*`
- **FastAPI** — Prefer `serve_flow` / `serve_agent` (with `context_dependency`); snapshot/abort only when a store is set (`FirestoreSessionStore` documented)
- **Tools & interrupts** — Pass tool object refs; fix interrupt/resume APIs; stream tool parts without `hasattr`
- **Responses** — Use `response.media` / `result.media`; AgentError artifacts from `err.response.raw.state.artifacts`
- **Integrations** — DeepSeek/xAI pass `api_key=`; correct model IDs, streaming, `output_schema`, and embed shapes
- **Other** — Middleware/eval/RAG/Django install order; deploy tips point at `serve_flow`; middleware blog says Python is available