### PR TITLE
Update language metadata to include Dart

### DIFF
--- a/src/content/docs/docs/tutorials/chat-with-pdf.mdx
+++ b/src/content/docs/docs/tutorials/chat-with-pdf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat with a PDF file
-description: Learn how to build a conversational application that allows users to extract information from PDF documents using natural language across JavaScript, Go, and Python.
+description: Learn how to build a conversational application that allows users to extract information from PDF documents using natural language.
 supportedLanguages:
   - js
 ---

--- a/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
+++ b/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
@@ -1,6 +1,6 @@
 ---
 title: Summarize YouTube videos
-description: Learn how to build a conversational application that allows users to summarize YouTube videos and chat about their contents using natural language across JavaScript, Go, and Python.
+description: Learn how to build a conversational application that allows users to summarize YouTube videos and chat about their contents using natural language.
 supportedLanguages:
   - js
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ import DocsLanguageClient from "../components/DocsLanguageClient.astro";
   <meta charset="UTF-8">
   <meta name="description" content="Open-source framework for building AI-powered apps with unified APIs for Google Gemini, GPT, Claude, and more. Built-in developer tools, structured outputs, tool calling, and production monitoring. Deploy anywhere.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Genkit - Open-source AI framework by Google in JavaScript, Go, Python and Dart</title>
+  <title>Genkit - Open-source AI framework by Google in JavaScript, Go, Python, and Dart</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="sitemap" href="/sitemap-index.xml" />
   <Fonts />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ import DocsLanguageClient from "../components/DocsLanguageClient.astro";
   <meta charset="UTF-8">
   <meta name="description" content="Open-source framework for building AI-powered apps with unified APIs for Google Gemini, GPT, Claude, and more. Built-in developer tools, structured outputs, tool calling, and production monitoring. Deploy anywhere.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Genkit - Open-source AI framework by Google in JavaScript, Go and Python</title>
+  <title>Genkit - Open-source AI framework by Google in JavaScript, Go, Python and Dart</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="sitemap" href="/sitemap-index.xml" />
   <Fonts />
@@ -25,4 +25,3 @@ import DocsLanguageClient from "../components/DocsLanguageClient.astro";
   <GA bannerForceDarkMode={true} />
 </body>
 </html>
-


### PR DESCRIPTION
## Summary

- Add Dart to the landing page title used in browser tabs and search results.
- Remove outdated JavaScript/Go/Python-only wording from the Chat with a PDF and Summarize YouTube Videos tutorial descriptions.

## Why

Dart is now a supported Genkit SDK, so the site metadata should not imply that Genkit supports only the earlier language set. The tutorial descriptions now describe the content without claiming coverage for an incomplete list of languages.

## Validation

- Prettier check passed for both modified MDX files.
- `git diff --check` passed.

The Astro type check was not run because this checkout does not have the optional `@astrojs/check` dependency installed.