### PR TITLE
fix: point generated language pages' edit links at source files

### DIFF
--- a/src/scripts/generate-language-pages.ts
+++ b/src/scripts/generate-language-pages.ts
@@ -6,6 +6,10 @@ import { rewriteInternalDocsLinks } from '../utils/docs-link-routing.js';
 
 const SOURCE_ROOT = path.resolve('src/content/docs/docs');
 const OUTPUT_ROOT = path.resolve('src/content/docs/docs');
+// Generated language directories are gitignored, so Starlight's derived edit
+// URLs would 404. Point each generated page back at its source file instead.
+// Must match editLink.baseUrl in astro.config.mjs.
+const EDIT_LINK_BASE_URL = 'https://github.com/genkit-ai/docsite/edit/main/';
 const LANGUAGES = ['js', 'go', 'dart', 'python'] as const;
 const FALLBACK_LANGUAGES = ['js', 'go', 'dart', 'python'] as const;
 const MIN_LANGUAGE_CONTENT_CHARS_WARNING = 120;
@@ -527,6 +531,7 @@ async function generateForSourceFile(filePath: string, context: GenerateContext)
       {
         ...frontmatterWithoutDescription,
         ...(resolvedDescription !== undefined ? { description: resolvedDescription } : {}),
+        editUrl: frontmatter.editUrl ?? `${EDIT_LINK_BASE_URL}${fileRelativePath}`,
         supportedLanguages: [language],
       },
       filePath,


### PR DESCRIPTION
## Problem

The "Edit this page on GitHub" link 404s on every language-prefixed page (`/docs/js/*`, `/docs/go/*`, `/docs/dart/*`, `/docs/python/*`) - 239 pages in the current build.

These pages are generated at build time by `generate-language-pages` into `src/content/docs/docs/{js,go,dart,python}/`, which is gitignored. Starlight derives each page's edit URL from its content file path, so it produces links like:

```
https://github.com/genkit-ai/docsite/edit/main/src/content/docs/docs/js/flows.mdx
```

which doesn't exist in the repo. Language-neutral pages (e.g. `/docs/flows`) are unaffected.

## Fix

The generator now stamps each generated page with an `editUrl` frontmatter override (Starlight supports per-page overrides) pointing at the real source file, e.g.:

```yaml
editUrl: https://github.com/genkit-ai/docsite/edit/main/src/content/docs/docs/flows.mdx
```

A source page's own `editUrl`, if ever set, is preserved.

## Verification

- `pnpm generate-language-pages` + `astro build` (401 pages) succeed
- Post-build, zero `edit/main/src/content/docs/docs/{js,go,dart,python}/...` links remain in `dist`; language pages now link to their source `.mdx`