### PR TITLE
docs(go): fix verified API defects and fill the four empty Go sidebar sections

### DIFF
--- a/public/GENKIT.go.md
+++ b/public/GENKIT.go.md
@@ -1,8 +1,8 @@
 # Genkit Go API rules
 
-Written against the current Genkit Go release. Check the released versions at
-https://pkg.go.dev/github.com/firebase/genkit/go?tab=versions and pin one in
-your `go.mod`; the `genkit/exp` packages can change in a minor release.
+Refer to released versions at
+https://pkg.go.dev/github.com/firebase/genkit/go?tab=versions. Note that preview
+features in `genkit/exp` packages may experience breaking changes in minor version releases.
 
 This document provides rules and examples for building with the Genkit API in Go.
 

--- a/public/GENKIT.go.md
+++ b/public/GENKIT.go.md
@@ -1,4 +1,8 @@
-# Genkit Go API Rules (v1.20.0)
+# Genkit Go API rules
+
+Written against the current Genkit Go release. Check the released versions at
+https://pkg.go.dev/github.com/firebase/genkit/go?tab=versions and pin one in
+your `go.mod`; the `genkit/exp` packages can change in a minor release.
 
 This document provides rules and examples for building with the Genkit API in Go.
 

--- a/src/content/docs/docs/agentic-patterns.mdx
+++ b/src/content/docs/docs/agentic-patterns.mdx
@@ -11,7 +11,8 @@ import Lang from '../../../components/Lang.astro';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 :::tip[Looking for the Agents API?]
-This page covers low-level composition patterns using flows and `generate()`.
+This page covers low-level composition patterns built from flows and direct
+model calls.
 For the higher-level managed agent primitive with built-in session management,
 persistence, and streaming, see [Agents](/docs/agents/overview).
 :::
@@ -93,7 +94,25 @@ export const storyWriterFlow = ai.defineFlow(
 
 <Lang lang="go">
 
+This first example is a complete program. Every later snippet shows only its
+types and its flow: the flow is defined inside the same `main`, reusing this `g`
+and `ctx`, and any package-level helper it declares sits beside `main` in the
+same file. The package clause and the import block are left out.
+
 ```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
 type StoryWriterRequest struct {
 	Topic string `json:"topic"`
 }
@@ -102,31 +121,46 @@ type StoryIdea struct {
 	Idea string `json:"idea" jsonschema_description:"A short, compelling story concept"`
 }
 
-storyWriterFlow := genkit.DefineFlow(g, "storyWriterFlow",
-	func(ctx context.Context, req *StoryWriterRequest) (string, error) {
-		// Step 1: Generate a creative story idea
-		idea, _, err := genkit.GenerateData[StoryIdea](ctx, g,
-			ai.WithPrompt("Generate a unique story idea about a %v.", req.Topic),
-		)
-		if err != nil {
-			return "", err
-		}
-		// GenerateData returns a nil value with no error when the response
-		// carried nothing to parse, such as a tool request or an interrupt.
-		if idea == nil {
-			return "", errors.New("the model returned no story idea")
-		}
+func main() {
+	ctx := context.Background()
 
-		// Step 2: Use the idea to write the beginning of the story
-		storyResponse, err := genkit.Generate(ctx, g,
-			ai.WithPrompt("Write the opening paragraph for a story based on this idea: %v", idea.Idea),
-		)
-		if err != nil {
-			return "", err
-		}
-		return storyResponse.Text(), nil
-	},
-)
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
+	)
+
+	storyWriterFlow := genkit.DefineFlow(g, "storyWriterFlow",
+		func(ctx context.Context, req *StoryWriterRequest) (string, error) {
+			// Step 1: Generate a creative story idea
+			idea, _, err := genkit.GenerateData[StoryIdea](ctx, g,
+				ai.WithPrompt("Generate a unique story idea about a %v.", req.Topic),
+			)
+			if err != nil {
+				return "", err
+			}
+			// GenerateData returns a nil value with no error when the response
+			// carried nothing to parse, such as a tool request or an interrupt.
+			if idea == nil {
+				return "", errors.New("the model returned no story idea")
+			}
+
+			// Step 2: Use the idea to write the beginning of the story
+			storyResponse, err := genkit.Generate(ctx, g,
+				ai.WithPrompt("Write the opening paragraph for a story based on this idea: %v", idea.Idea),
+			)
+			if err != nil {
+				return "", err
+			}
+			return storyResponse.Text(), nil
+		},
+	)
+
+	story, err := storyWriterFlow.Run(ctx, &StoryWriterRequest{Topic: "lighthouse keeper"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(story)
+}
 ```
 
 </Lang>
@@ -227,6 +261,9 @@ export const imageGeneratorFlow = ai.defineFlow(
 </Lang>
 
 <Lang lang="go">
+
+`genai.GenerateContentConfig` is the Google GenAI SDK's own config type, so this
+one needs `import "google.golang.org/genai"` on top of the imports above.
 
 ```go
 type ImageGeneratorRequest struct {
@@ -484,7 +521,7 @@ ai.defineFlow(
 
 ## Workflow: Parallel execution
 
-This pattern executes multiple LLM calls simultaneously, either to perform independent sub-tasks faster (Sectioning) or to generate multiple diverse outputs for comparison (Voting). `Promise.all()` within a Genkit flow is perfect for this.
+This pattern executes multiple LLM calls simultaneously, either to perform independent sub-tasks faster (Sectioning) or to generate multiple diverse outputs for comparison (Voting). A flow is a good place to fan the calls out and join their results.
 
 This example uses sectioning to generate a product name and a marketing tagline at the same time.
 
@@ -527,7 +564,13 @@ export const marketingCopyFlow = ai.defineFlow(
 
 <Lang lang="go">
 
+Run the branches in goroutines and join them with
+[`golang.org/x/sync/errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup),
+which propagates the first error and cancels the rest:
+
 ```go
+import "golang.org/x/sync/errgroup"
+
 type MarketingCopyRequest struct {
 	Product string `json:"product"`
 }
@@ -539,60 +582,44 @@ type MarketingCopyResponse struct {
 
 marketingCopyFlow := genkit.DefineFlow(g, "marketingCopyFlow",
 	func(ctx context.Context, req *MarketingCopyRequest) (*MarketingCopyResponse, error) {
-		type result struct {
-			key   string
-			value string
-			err   error
+		prompts := []string{
+			fmt.Sprintf("Generate a creative name for a new product: %v.", req.Product),
+			fmt.Sprintf("Generate a catchy tagline for a new product: %v.", req.Product),
 		}
-		ch := make(chan result, 2)
+		results := make([]string, len(prompts))
 
-		// Task 1: Generate a creative name
-		go func() {
-			resp, err := genkit.Generate(ctx, g,
-				ai.WithPrompt("Generate a creative name for a new product: %v.", req.Product),
-			)
-			if err != nil {
-				ch <- result{key: "name", err: err}
-				return
-			}
-			ch <- result{key: "name", value: resp.Text()}
-		}()
+		group, gctx := errgroup.WithContext(ctx)
+		// Cap the fan-out so a wide batch does not walk into the provider's
+		// rate limit. Drop the line to run every branch at once.
+		group.SetLimit(4)
 
-		// Task 2: Generate a catchy tagline
-		go func() {
-			resp, err := genkit.Generate(ctx, g,
-				ai.WithPrompt("Generate a catchy tagline for a new product: %v.", req.Product),
-			)
-			if err != nil {
-				ch <- result{key: "tagline", err: err}
-				return
-			}
-			ch <- result{key: "tagline", value: resp.Text()}
-		}()
-
-		response := &MarketingCopyResponse{}
-		var errs []error
-		for i := 0; i < 2; i++ {
-			r := <-ch
-			if r.err != nil {
-				errs = append(errs, r.err)
-			} else {
-				if r.key == "name" {
-					response.Name = r.value
-				} else if r.key == "tagline" {
-					response.Tagline = r.value
+		for i, prompt := range prompts {
+			group.Go(func() error {
+				resp, err := genkit.Generate(gctx, g, ai.WithPrompt(prompt))
+				if err != nil {
+					return err
 				}
-			}
+				// Each branch owns one slot, so no lock is needed.
+				results[i] = resp.Text()
+				return nil
+			})
 		}
 
-		if len(errs) > 0 {
-			return nil, fmt.Errorf("failed to generate marketing copy: %v", errs)
+		// Wait returns the first error, and cancelling gctx has already
+		// stopped the siblings.
+		if err := group.Wait(); err != nil {
+			return nil, err
 		}
 
-		return response, nil
+		return &MarketingCopyResponse{Name: results[0], Tagline: results[1]}, nil
 	},
 )
 ```
+
+A `*genkit.Genkit` is safe for concurrent `genkit.Generate` calls, so the
+branches can share the one instance. Because `gctx` derives from the flow's
+context, it still carries the flow's span, and each concurrent generation nests
+under the flow in the trace tree rather than appearing as an orphan.
 
 </Lang>
 
@@ -844,7 +871,20 @@ Do not add or change items on the menu.`,
 
 <Lang lang="go">
 
+`localvec.Retriever(g, "menuQA")` only looks up a retriever that
+`localvec.DefineRetriever(g, "menuQA", cfg, opts)` already registered, and it
+returns nothing until the menu documents are loaded with
+`localvec.Index(ctx, docs, ds)`. Do both during startup, before the flow runs.
+See [Local vector store](/docs/integrations/dev-local-vectorstore) and
+[RAG](/docs/rag) for that half.
+
 ```go
+import (
+	"strings"
+
+	"github.com/firebase/genkit/go/plugins/localvec"
+)
+
 type AgenticRagRequest struct {
 	Question string `json:"question"`
 }
@@ -1276,6 +1316,11 @@ type AskUserRequest struct {
 	Question string `json:"question"`
 }
 
+// AskUser is the interrupt payload: what the person answering needs to see.
+type AskUser struct {
+	Question string `json:"question"`
+}
+
 // A tool for the agent to search the web.
 searchWeb := genkit.DefineTool(g,
 	"searchWeb",
@@ -1291,14 +1336,13 @@ askUser := genkit.DefineTool(g,
 	"askUser",
 	"Ask the user a clarifying question.",
 	func(ctx *ai.ToolContext, req *AskUserRequest) (string, error) {
-		// This tool interrupts the flow to ask the user a question.
-		return "", ctx.Interrupt(&ai.InterruptOptions{
-			Metadata: map[string]any{
-				"question": req.Question,
-			},
-		})
+		// InterruptWith pauses the loop with a typed payload, which
+		// ai.InterruptAs reads back below.
+		return "", ai.InterruptWith(ctx, AskUser{Question: req.Question})
 	},
 )
+
+const maxRounds = 5
 
 researchAgent := genkit.DefineFlow(g, "researchAgent",
 	func(ctx context.Context, req *ResearchAgentRequest) (string, error) {
@@ -1313,23 +1357,35 @@ researchAgent := genkit.DefineFlow(g, "researchAgent",
 			return "", err
 		}
 
-		for response.FinishReason == ai.FinishReasonInterrupted {
+		for round := 0; round < maxRounds && response.FinishReason == ai.FinishReasonInterrupted; round++ {
 			var answers []*ai.Part
 			for _, part := range response.Interrupts() {
-				if part.ToolRequest.Name == "askUser" {
-					// In a real app, you would present the question to the user and get their answer.
-					question := part.ToolRequest.Input.(map[string]any)["question"]
-					userAnswer := fmt.Sprintf("The user answered: \"Sample answer for '%s'\"", question)
-					answer, err := askUser.RespondWith(part, userAnswer)
-					if err != nil {
-						return "", err
-					}
-					answers = append(answers, answer)
+				// Every interrupt in the turn has to be answered, so an
+				// unrecognized one is an error rather than a skip.
+				if part.ToolRequest.Name != askUser.Name() {
+					return "", fmt.Errorf("no handler for interrupt from tool %q", part.ToolRequest.Name)
 				}
+				meta, ok := ai.InterruptAs[AskUser](part)
+				if !ok {
+					return "", errors.New("askUser interrupt carried no AskUser metadata")
+				}
+
+				// In a real app, you would put the question to the user and
+				// wait for their answer.
+				userAnswer := fmt.Sprintf("The user answered: \"Sample answer for '%s'\"", meta.Question)
+				answer, err := askUser.RespondWith(part, userAnswer)
+				if err != nil {
+					return "", err
+				}
+				answers = append(answers, answer)
 			}
 
 			response, err = genkit.Generate(ctx, g,
 				ai.WithMessages(response.History()...),
+				// The model and the turn limit are request options, not
+				// messages, so repeat them on every resume.
+				ai.WithModelName("googleai/gemini-pro-latest"),
+				ai.WithMaxTurns(5),
 				ai.WithTools(searchWeb, askUser),
 				ai.WithToolResponses(answers...),
 			)
@@ -1342,6 +1398,14 @@ researchAgent := genkit.DefineFlow(g, "researchAgent",
 	},
 )
 ```
+
+`response.History()` is the request's messages plus the response, and
+`ai.WithSystem` adds a real system message, so the system prompt rides along and
+does not need repeating. The model name and the turn limit do not: leave them
+off a resume and the call falls back to the registry's default model and the
+default limit of five turns. `ai.WithMaxTurns` bounds one `genkit.Generate`
+call, not the resume loop, which is why the loop carries its own round cap.
+See [interrupts](/docs/interrupts) for the rest of the resume surface.
 
 Genkit also ships a managed agent primitive that owns this loop for you, along with session persistence and streaming. The [basic-agents sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) defines six agents in six styles behind one CLI; those APIs are in preview, so it initializes Genkit with `genkit.WithExperimental()`.
 
@@ -1459,7 +1523,7 @@ The key is to:
 
 1.  Load the history for the current session.
 2.  Append the new user message to the history.
-3.  Call `ai.generate()` with the full message history. This is where you can plug in any of the other patterns (like tool calling or routing) to make your conversational agent more powerful.
+3.  Call the model with the full message history. This is where you can plug in any of the other patterns (like tool calling or routing) to make your conversational agent more powerful.
 4.  Save the updated history (including the model's response) for the next turn.
 
 This example shows a simple chat flow that maintains state.
@@ -1516,21 +1580,32 @@ export const statefulChatFlow = ai.defineFlow(
 
 <Lang lang="go">
 
+This snippet needs `slices` and `sync` on top of the imports above.
+
 ```go
 type StatefulChatRequest struct {
 	SessionID string `json:"sessionId"`
 	Message   string `json:"message"`
 }
 
-// A simple in-memory store for conversation history.
+// A simple in-memory store for conversation history. A flow served over HTTP
+// is called concurrently, so the map needs a lock.
 // In a real app, you would use a database like Firestore or Redis.
-var historyStore = make(map[string][]*ai.Message)
+var (
+	historyMu    sync.RWMutex
+	historyStore = make(map[string][]*ai.Message)
+)
 
 func loadHistory(sessionID string) []*ai.Message {
-	return historyStore[sessionID]
+	historyMu.RLock()
+	defer historyMu.RUnlock()
+	// Clone, so the caller's append cannot reach into the stored slice.
+	return slices.Clone(historyStore[sessionID])
 }
 
 func saveHistory(sessionID string, history []*ai.Message) {
+	historyMu.Lock()
+	defer historyMu.Unlock()
 	historyStore[sessionID] = history
 }
 
@@ -1557,6 +1632,11 @@ statefulChatFlow := genkit.DefineFlow(g, "statefulChatFlow",
 	},
 )
 ```
+
+Hand-rolling the store is the lowest-level of three options. [Chat](/docs/chat)
+carries the history for a single caller without a store at all, and
+[Sessions and state](/docs/agents/state) persists it behind an agent's session
+store, which is what you want once the conversation has to survive a restart.
 
 Moving the wording of a multi-turn prompt out of code is a separate step: the [basic-prompts sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-prompts) defines the same chat prompt inline and as a `.prompt` file, with `{{history}}` marking where the conversation lands.
 

--- a/src/content/docs/docs/agents/background.mdx
+++ b/src/content/docs/docs/agents/background.mdx
@@ -129,6 +129,12 @@ Choose background execution when the caller should receive a pending snapshot im
 
 ```go
 import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/localstore"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
@@ -198,6 +204,8 @@ A bare detach does not start an extra turn. To ride a final input on the detach,
 
 The client stream is suppressed the moment the detach directive is read, so nothing the background turn produces afterwards reaches `conn.Receive()`. Session-level side effects still apply: an artifact sent through `Responder.SendArtifact` still lands in the final snapshot's state, so agent code does not have to branch on detach.
 
+The invocation context outlives the transport connection. Before a detach lands, a client disconnect cancels the work. After it lands, the context stays live and the turn keeps running; only `Agent.Abort` or the process exiting cancels it.
+
 ## Wait for completion
 
 Read a snapshot by ID with `agent.GetSnapshot`, or a session's most recent one with `agent.GetLatestSnapshot(ctx, sessionID)`.
@@ -211,24 +219,53 @@ if err != nil {
 fmt.Println(snap.Status)
 ```
 
-When the store implements `aix.SnapshotSubscriber`, subscribe to status changes instead of polling, then read the final snapshot.
+Subscribe to status changes instead of polling when you want the terminal status as soon as it lands.
 
 ```go
-subscriber := agent.Store().(aix.SnapshotSubscriber)
-statusCh := subscriber.OnSnapshotStatusChange(ctx, snapshotID)
+func waitForTerminal(ctx context.Context, agent *aix.Agent[ReportState], snapshotID string) (*aix.SessionSnapshot[ReportState], error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-for status := range statusCh {
-	if status != aix.SnapshotStatusPending {
-		break
+	if subscriber, ok := agent.Store().(aix.SnapshotSubscriber); ok {
+		for status := range subscriber.OnSnapshotStatusChange(subCtx, snapshotID) {
+			if status != aix.SnapshotStatusPending {
+				break
+			}
+		}
+	} else {
+		for {
+			snap, err := agent.GetSnapshot(subCtx, snapshotID)
+			if err != nil {
+				return nil, fmt.Errorf("poll snapshot: %w", err)
+			}
+			if snap.Status != aix.SnapshotStatusPending {
+				break
+			}
+			time.Sleep(time.Second)
+		}
 	}
-}
 
-snap, err := agent.GetSnapshot(ctx, snapshotID)
+	return agent.GetSnapshot(ctx, snapshotID)
+}
 ```
 
-If the store does not support subscriptions, poll `agent.GetSnapshot(ctx, snapshotID)` until `Status` leaves `pending`. Terminal statuses are `completed`, `failed`, `aborted`, and `expired`. Only a completed snapshot is resumable.
+The channel closes when the subscription context is cancelled, so cancel it when you stop reading. Leaving the loop without cancelling leaves the producer running. If the snapshot does not exist when you subscribe, the channel closes without yielding a value.
+
+Every store that supports detach implements `aix.SnapshotSubscriber`, since that subscription is how an abort reaches the background work. The comma-ok branch above therefore only matters for code that also runs against a non-detaching store. Polling `agent.GetSnapshot` until `Status` leaves `pending` is still valid, and is the simpler option when you do not want a subscription goroutine.
+
+Terminal statuses are `completed`, `failed`, `aborted`, and `expired`. Only a completed snapshot is resumable. `Status` is the persistence lifecycle, not the outcome: a turn that ended on an interrupt is `completed` and resumable, and you tell it apart by reading `snap.FinishReason == aix.AgentFinishReasonInterrupted`.
 
 The [basic-agents](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) sample drives this from its CLI: `/detach` leaves a turn running, and returning to the agent later waits on the pending snapshot.
+
+## Lifetime and restarts
+
+Detached work runs in the process that started it. It is not durable execution: a restart, crash, or scale-in orphans every pending snapshot, and no other instance can adopt one.
+
+A running detached turn refreshes its pending snapshot's heartbeat every 30 seconds. A pending snapshot whose heartbeat has not advanced for 60 seconds is reported as `expired` on the next read. `expired` is terminal and not resumable, so treat expiry as a lost run and restart the work from the last completed snapshot.
+
+On `SIGTERM`, either wait for pending snapshots to reach a terminal status before exiting, or call `Agent.Abort` on them. Callers then see `aborted` immediately instead of waiting 60 seconds for expiry.
+
+Detach and durable streaming solve different problems. Detach keeps the work running and gives you a snapshot ID to poll, but it does not replay the stream. [Durable streaming](/docs/durable-streaming) replays the chunk transcript by `streamId`, but it does not keep work alive past the request. `genkitx.Route.Handler` accepts `genkit.HandlerOption`s, so you can apply both to the same agent route.
 
 ## Abort work
 

--- a/src/content/docs/docs/agents/custom-orchestration.mdx
+++ b/src/content/docs/docs/agents/custom-orchestration.mdx
@@ -164,17 +164,52 @@ Use `genkitx.DefineCustomAgent` when the prompt-backed loop does not fit:
 
 The custom function receives:
 
-- **`ctx`** is the invocation context. It is canceled on client disconnect or abort.
+- **`ctx`** is the invocation context, which is not the transport connection. Before a detach, a client disconnect cancels it. After a detach it stays live and the turn keeps running; only `Agent.Abort` or the process exiting cancels it. Every `genkit.GenerateStream` call made with this context follows the same rule.
 - **`resp aix.Responder`** streams model chunks and artifacts to the client.
 - **`sess *aix.SessionRunner[State]`** manages turns, messages, custom state, artifacts, and snapshots.
 
-Call `sess.Run(ctx, fn)` to process input turns. The runner adds each user message to the session before the callback runs, emits turn-end chunks, and writes snapshots when a store exists.
+### SessionRunner methods
+
+`SessionRunner[State]` adds two methods of its own and embeds `*aix.Session[State]` for everything else:
+
+| Method                                                            | Purpose                                                          |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `Run(ctx, fn) error`                                              | Loops over the invocation's inputs, calling `fn` once per turn.  |
+| `Result() *AgentResult`                                           | The last message and artifacts currently recorded.               |
+| `State() *SessionState[State]`                                    | The whole session state.                                         |
+| `SessionID() string`                                              | The session this invocation belongs to.                          |
+| `Messages() []*ai.Message`                                        | Conversation history.                                            |
+| `AddMessages(...*ai.Message)`                                     | Appends messages.                                                |
+| `SetMessages([]*ai.Message)`                                      | Replaces history wholesale.                                      |
+| `UpdateMessages(func([]*ai.Message) []*ai.Message)`               | Atomic read-modify-write on history.                             |
+| `Custom() State`                                                  | Typed custom state.                                              |
+| `UpdateCustom(func(State) State)`                                 | Atomic update; emits a custom patch chunk.                       |
+| `Artifacts() []*Artifact`                                         | Artifacts recorded so far.                                       |
+| `AddArtifacts(...*Artifact)`                                      | Appends artifacts.                                               |
+| `UpdateArtifacts(func([]*Artifact) []*Artifact)`                  | Atomic read-modify-write on artifacts.                           |
+
+The three `Update*` callbacks run while the session lock is held. Do not call another `Session` method or send on a `Responder` from inside one.
+
+### Turn loop semantics
+
+`sess.Run(ctx, fn)` loops over the invocation's input channel, calling `fn` once per turn, and returns only when the invocation ends or `fn` returns an error. It is not a single turn, so put per-turn timeouts and retries inside `fn`, not around `Run`. Each turn runs in its own trace span. The runner adds the user message to the session before `fn`, then emits a `TurnEnd` chunk and writes a snapshot when a store exists.
+
+`fn` returns `(*aix.TurnResult, error)`. `TurnResult` has one field, `FinishReason`. Returning `nil` reports no finish reason and the framework infers nothing.
+
+When `fn` returns an error, `Run` emits `TurnEnd` with `aix.AgentFinishReasonFailed`, takes no snapshot of the turn's partial state, stops looping, and returns the error. Return that error to resolve the invocation as failed with the last-good state, or call `Run` again to keep serving inputs on the same connection after a recoverable turn failure.
+
+`aix.AgentResult`, the agent function's return value, has three fields: `Message`, `Artifacts`, and `FinishReason`. Leave `FinishReason` empty to accept the last turn's reason.
 
 ## Custom agent example
 
 ```go
 import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
 ```
@@ -208,11 +243,14 @@ coder := genkitx.DefineCustomAgent(g, "coder",
 				resp.SendModelChunk(chunk.Chunk)
 			}
 
+			// No TurnResult: report no finish reason. The framework infers
+			// nothing from a nil result.
 			return nil, nil
 		})
 		if err != nil {
-			// sess.Run surfaces a turn-loop failure; the framework marks the
-			// turn failed and resolves the invocation with the last-good state.
+			// sess.Run stopped looping on the first callback error. Returning it
+			// resolves the invocation as failed with the last-good state; calling
+			// sess.Run again would keep serving inputs instead.
 			return nil, fmt.Errorf("run turn: %w", err)
 		}
 		return sess.Result(), nil
@@ -243,6 +281,12 @@ Use this when external resources need to line up with the snapshot that will lat
 ## Failure and detach behavior
 
 If the per-turn callback returns an error, the invocation resolves as a failed `AgentOutput` with structured error details and a last-good recovery point. A client can resume from the last-good state or snapshot. When a client detaches, chunks after detach are not forwarded, but session side effects such as artifacts still apply to the final snapshot.
+
+## Next steps
+
+- [Sessions and state](/docs/agents/state) covers custom state, artifacts, and state transforms.
+- [Background execution](/docs/agents/background) covers detach, pending snapshots, and abort.
+- [Agent error handling](/docs/agents/errors) covers the failure channels a custom agent resolves into.
 
 </Lang>
 

--- a/src/content/docs/docs/agents/define.mdx
+++ b/src/content/docs/docs/agents/define.mdx
@@ -194,11 +194,24 @@ All agents implement `api.BidiAction`, so transports and route helpers can serve
 
 ```go
 import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
+
+// TaskState is this agent's custom session state.
+type TaskState struct {
+	Tasks []string `json:"tasks,omitempty"`
+}
 ```
+
+In the snippet below, `g` is the `*genkit.Genkit` that `genkit.Init` returned, and `addTaskTool` and `toggleTaskTool` are tools defined as shown in [Tool calling](/docs/tool-calling).
 
 ```go
 store, err := localstore.NewFileSessionStore[TaskState]("./.genkit/snapshots/tasks")
@@ -218,7 +231,45 @@ taskAgent := genkitx.DefineAgent(g, "taskAgent",
 )
 ```
 
+`genkitx.DefineAgent` returns `*aix.Agent[State]`. The value type lives in `github.com/firebase/genkit/go/ai/exp` even though the constructor lives in `github.com/firebase/genkit/go/genkit/exp`, so write the `aix` type when you store the agent in a struct field or pass it between functions:
+
+```go
+type App struct {
+	Tasks *aix.Agent[TaskState]
+}
+```
+
 The agent's custom state type is inferred from typed options such as `WithSessionStore[TaskState]`, `WithStateTransform[TaskState]`, or the explicit type argument on `DefineAgent[TaskState]`. An agent that passes no typed option needs the argument written out, as in `DefineAgent[any]`.
+
+### Constructor and entry-point signatures
+
+The `genkitx.Define*` constructors all return `aix` types, so a helper that takes an agent, a tool, or a turn result names the type from `github.com/firebase/genkit/go/ai/exp`.
+
+```go
+func DefineAgent[State any](g *genkit.Genkit, name string, prompt aix.InlinePrompt,
+	opts ...aix.AgentOption[State]) *aix.Agent[State]
+
+func DefineTool[In, Out any](g *genkit.Genkit, name, description string,
+	fn aix.ToolFunc[In, Out], opts ...ai.ToolOption) *aix.Tool[In, Out]
+
+func DefineInterruptibleTool[In, Out, Resume any](g *genkit.Genkit, name, description string,
+	fn aix.InterruptibleToolFunc[In, Out, Resume], opts ...ai.ToolOption) *aix.InterruptibleTool[In, Out, Resume]
+```
+
+The entry points on the agent itself:
+
+```go
+func (a *aix.Agent[State]) Run(ctx context.Context, input *aix.AgentInput,
+	opts ...aix.InvocationOption[State]) (*aix.AgentOutput[State], error)
+
+func (a *aix.Agent[State]) RunText(ctx context.Context, text string,
+	opts ...aix.InvocationOption[State]) (*aix.AgentOutput[State], error)
+
+func (a *aix.Agent[State]) Connect(ctx context.Context,
+	opts ...aix.InvocationOption[State]) (*aix.AgentConnection[State], error)
+```
+
+`AgentOutput` and `AgentConnection` are generic over the same `State`, so a helper signature is `*aix.AgentOutput[TaskState]`, never a bare `*aix.AgentOutput`. See [Run and stream agents](/docs/agents/run) for the field sets.
 
 The `pirate.go` file of [`go/samples/basic-agents`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) is the shortest working version of this shape: one inline prompt, one file store, no state of its own.
 
@@ -232,6 +283,64 @@ The `pirate.go` file of [`go/samples/basic-agents`](https://github.com/genkit-ai
 
 Typed options are deliberately strict. Passing a state option with the wrong `State` type fails at compile time.
 
+### Prompt options
+
+`aix.InlinePrompt` is a `[]ai.PromptOption`, so every option `genkit.DefinePrompt` accepts is valid inside it, including `ai.WithConfig`, `ai.WithOutputType`, `ai.WithInputType`, `ai.WithMaxTurns`, and `ai.WithDocs` or `ai.WithDocsFn`.
+
+An agent turn runs the same tool loop as `genkit.Generate`, with the same default cap of five tool-call iterations. `ai.WithMaxTurns` returns a `CommonGenOption`, which embeds `PromptOption`, so it belongs in the inline prompt:
+
+```go
+aix.InlinePrompt{
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithSystem("Manage a task list. Use tools when changing tasks."),
+	ai.WithTools(addTaskTool, toggleTaskTool),
+	ai.WithMaxTurns(12),
+}
+```
+
+The cap bounds the tool loop inside one turn, not the number of turns in a conversation. A turn that exceeds it fails with `ai.ErrMaxTurnsExceeded` and the invocation reports `aix.AgentFinishReasonFailed`. See [Agent error handling](/docs/agents/errors).
+
+### Ground a turn in retrieved documents
+
+Because `ai.WithDocsFn` is a prompt option, an agent can retrieve documents on every turn and pass them to the model as context:
+
+```go
+grounded := genkitx.DefineAgent(g, "grounded",
+	aix.InlinePrompt{
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithSystem("Answer from the provided documents. Say so when they do not cover the question."),
+		ai.WithDocsFn(func(ctx context.Context, _ any) ([]*ai.Document, error) {
+			history := ai.HistoryFromContext(ctx)
+			if len(history) == 0 {
+				return nil, nil
+			}
+			query := history[len(history)-1].Text()
+			res, err := genkit.Retrieve(ctx, g,
+				ai.WithRetriever(retriever),
+				ai.WithTextDocs(query),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("retrieve context for %q: %w", query, err)
+			}
+			return res.Documents, nil
+		}),
+	},
+	aix.WithSessionStore(store),
+)
+```
+
+`WithDocsFn[In]` receives the prompt's input, and an agent has no per-turn input unless the inline prompt sets `ai.WithInputType`, so `In` is the zero value by default. Build the query from `ai.HistoryFromContext(ctx)` instead, whose last element is the question this turn is about to answer. See [Retrieval-augmented generation](/docs/rag) for retrievers and indexers.
+
+## Tools in an agent
+
+Agent tools use the same constructors as any other tool. Each one reaches the active session the same way, so the choice is about signature and capability:
+
+- **`genkit.DefineTool`** hands the handler an `*ai.ToolContext`. It embeds `context.Context`, so `aix.SessionFromContext[State](ctx)` works on it directly, and it adds `Interrupt`, `IsResumed`, `Resumed`, and `OriginalInput`.
+- **`genkitx.DefineTool`** hands the handler a plain `context.Context`, plus `tool.AttachParts` for returning extra content parts alongside the output.
+- **`genkitx.DefineInterruptibleTool`** adds a typed resume parameter for tools that pause and wait for an answer.
+
+See [Tool calling](/docs/tool-calling), [Sessions and state](/docs/agents/state), and [Agent interrupts](/docs/agents/interrupts).
+
 ## How a turn is composed
 
 Rendering always builds the request in one order: the system message, then the conversation, then the user prompt. On every turn the runtime hands the session's conversation to the render, and where it lands depends on what the prompt declares.
@@ -239,6 +348,10 @@ Rendering always builds the request in one order: the system message, then the c
 - The prompt declares no conversation, the common case of `ai.WithSystem` alone. The session's messages are placed for you, between the system message and the user prompt.
 - The prompt declares a conversation with `ai.WithMessages` or `ai.WithMessagesFn`. The prompt owns placement, so the session's messages are not placed for you. A function reads them with `ai.HistoryFromContext(ctx)` and returns them where it wants them.
 - The prompt declares the conversation as a template, with `ai.WithMessagesTemplate` or the body of a `.prompt` file. The session's messages land at `{{history}}`, or, when the template has no such marker, immediately before the template's final user message.
+
+The conversation handed to the render already ends with this turn's user message, so `ai.HistoryFromContext(ctx)` inside `ai.WithSystemFn`, `ai.WithMessagesFn`, or `ai.WithDocsFn` sees the current question as its last element. A content function can build a retrieval query or a state summary from the message it is about to answer, with no backwards walk.
+
+An agent's typed custom state is exposed to its own templates as `{{@state.fieldName}}`, JSON-serialized and re-evaluated on every render, so a tool that updates state changes the next turn's instruction with no extra wiring. It works in the template forms only: `ai.WithSystem`, `ai.WithPrompt`, `ai.WithMessagesTemplate`, and `.prompt` bodies. The function forms take their text verbatim and never compile a template, so read state there with `aix.SessionFromContext[State](ctx)` as shown in [Sessions and state](/docs/agents/state). Prefer `{{@state.…}}` for straight interpolation and `ai.WithSystemFn` when the instruction needs Go logic.
 
 `ai.WithMessagesTemplate` and `ai.WithMessages` or `ai.WithMessagesFn` have no meaningful combination, since the template is the whole conversation. Passing both to one prompt definition panics with a message naming the prompt.
 

--- a/src/content/docs/docs/agents/errors.mdx
+++ b/src/content/docs/docs/agents/errors.mdx
@@ -119,6 +119,10 @@ res.assertValid();
 - **Tool domain problems** should return structured tool output when the coordinator or model can recover.
 - **Background failures** appear as snapshot status `failed`, `aborted`, or `expired`. Inspect snapshot error details or retry from a completed snapshot.
 
+An unrecognized `sessionId` is not an error. The agent starts a new conversation under that ID and every snapshot it writes carries it, so there is no `ErrSessionNotFound` sentinel. `aix.ErrSnapshotNotFound` applies only to an unknown `snapshotId`.
+
+The rejected-init cases from `Run`, `RunText`, and `Connect` are narrow: sending a `sessionId` to a client-managed agent (one defined without `WithSessionStore`) is a `status.FailedPrecondition`, and sending `state` to a store-backed agent is rejected the same way. `ai/exp` ships three sentinels in total: `aix.ErrSnapshotNotFound`, `aix.ErrSessionStoreNotConfigured`, and `aix.ErrSessionIDRequired`.
+
 ## Check both error channels
 
 An agent reports failure through two channels. A non-nil Go error means the invocation was rejected or could not produce an output. A failed turn is in-band, so the output can still carry recovery state or a recovery snapshot ID.
@@ -142,8 +146,10 @@ if out.FinishReason == aix.AgentFinishReasonFailed && out.Error != nil {
 	switch out.Error.Status {
 	case status.Unavailable, status.ResourceExhausted:
 		// Overloaded. Resume from out.SnapshotID in a moment.
+		return nil
 	case status.InvalidArgument:
 		// The model or a tool rejected the request. Rephrase it.
+		return nil
 	default:
 		return fmt.Errorf("agent turn failed: %s: %s", out.Error.Status, out.Error.Message)
 	}
@@ -151,6 +157,16 @@ if out.FinishReason == aix.AgentFinishReasonFailed && out.Error != nil {
 
 fmt.Println(out.Message.Text())
 ```
+
+Return from each recovery arm rather than falling through. A failed turn may have ended before any model response, in which case `out.Message` is nil. `Message.Text()` is nil-safe and returns `""`, so falling through prints a blank line instead of the answer the caller expected.
+
+What the rest of `AgentOutput` holds depends on how the invocation finished:
+
+| `FinishReason` | `Error`  | `SnapshotID`                                                                    | `State`                    | `Message`      |
+| -------------- | -------- | ------------------------------------------------------------------------------- | -------------------------- | -------------- |
+| `failed`       | non-nil  | The last committed turn's snapshot: the resume point, without the failed turn's partial mutations. | Last-good client-managed state. | May be nil.    |
+| `detached`     | nil      | The pending snapshot.                                                           | Nil; detach needs a store. | May be nil.    |
+| anything else  | nil      | The most recent turn-end snapshot, or empty with no store.                      | Client-managed final state. | The last model message. |
 
 The [basic-agents](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) sample drives the same switch from its CLI, suggesting a different recovery per status.
 

--- a/src/content/docs/docs/agents/http.mdx
+++ b/src/content/docs/docs/agents/http.mdx
@@ -52,24 +52,130 @@ The primary endpoint handles normal and streaming turns. The snapshot endpoint r
 
 ## Route helpers
 
-The experimental route helpers live in `github.com/firebase/genkit/go/genkit/exp`. They return route descriptors that you can mount on `http.ServeMux` or another router.
+The experimental route helpers live in `github.com/firebase/genkit/go/genkit/exp`. They return route descriptors that you can mount on `http.ServeMux` or another router. This is a complete server: one store-backed agent, the default route layout, and the wrappers a browser client needs.
 
 ```go
-import genkitx "github.com/firebase/genkit/go/genkit/exp"
-```
+package main
 
-```go
-mux := http.NewServeMux()
-for _, route := range genkitx.AllAgentRoutes(g) {
-	mux.HandleFunc(route.Pattern(), route.Handler())
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+// userKey types the context key the auth wrapper stores the caller under.
+type userKey struct{}
+
+func main() {
+	ctx := context.Background()
+
+	// The Google AI plugin reads the API key from GEMINI_API_KEY or
+	// GOOGLE_API_KEY. Agents need the experimental surface.
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithExperimental(),
+	)
+
+	store, err := localstore.NewFileSessionStore[any]("./.genkit/snapshots/chat")
+	if err != nil {
+		log.Fatalf("open session store: %v", err)
+	}
+
+	genkitx.DefineAgent(g, "chat",
+		aix.InlinePrompt{
+			ai.WithModelName("googleai/gemini-flash-latest"),
+			ai.WithSystem("You are a helpful travel assistant."),
+		},
+		aix.WithSessionStore(store),
+	)
+
+	mux := http.NewServeMux()
+	for _, route := range genkitx.AllAgentRoutes(g) {
+		h := withCORS(withAuth(route.Handler()))
+		mux.Handle(route.Pattern(), h)
+		// Pattern() is method-prefixed ("POST /agents/chat"), so a browser
+		// preflight needs its own registration on the same path.
+		mux.Handle("OPTIONS "+route.Path, h)
+	}
+
+	log.Println("listening on http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
 }
 
-log.Fatal(http.ListenAndServe(":8080", mux))
+// withCORS lets a browser frontend on another origin call the agent routes.
+// It allows every origin, which suits local development; restrict it to the
+// origins you actually serve before deploying.
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// withAuth rejects an unauthenticated caller before any turn runs, then puts
+// the identity on the request context. The agent and every tool it calls
+// receive that same context, so they can read it back with ctx.Value.
+func withAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uid, err := verifyToken(r.Header.Get("Authorization"))
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userKey{}, uid)))
+	})
+}
+
+// verifyToken stands in for your identity provider.
+func verifyToken(header string) (string, error) {
+	token := strings.TrimPrefix(header, "Bearer ")
+	if token == "" || token == header {
+		return "", errors.New("missing bearer token")
+	}
+	return token, nil
+}
 ```
 
 Use `genkitx.AgentRoutes(agent)` to mount one agent, or `genkitx.AllAgentRoutes(g)` to mount every registered agent. The fields on `Route` are exported, so a router other than `http.ServeMux` can mount the same layout: read `Method` and `Path`, and serve `Action` with `genkit.Handler`.
 
 An agent is a bidirectional streaming action, but the standard handler also runs it one turn per request, which is what these routes serve. The [basic-agents-server](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents-server) sample serves a store-backed agent and a client-managed one side by side, with `curl` recipes for streaming, detach, poll, and abort.
+
+### Handler options
+
+`Route.Handler` takes the same options as `genkit.Handler`:
+
+```go
+func (r Route) Handler(opts ...genkit.HandlerOption) http.HandlerFunc
+```
+
+Pass `genkit.WithContextProviders` to derive request context server-side, or `genkit.WithStreamManager` to make a streamed turn reconnectable:
+
+```go
+mux.Handle(route.Pattern(), route.Handler(genkit.WithStreamManager(sm)))
+```
+
+The turn response then carries an `X-Genkit-Stream-Id` header. A client that reconnects with `?stream=true` and that header resubscribes to the in-flight stream instead of starting a new turn. See [Durable streaming](/docs/durable-streaming).
+
+### Browser clients and CORS
+
+The route helpers do no CORS handling: no `Access-Control` header is set anywhere in the framework, so a cross-origin browser client cannot call these routes until you add a wrapper like the `withCORS` above. `Route.Pattern()` is `Method + " " + Path`, so the pattern registered for a turn is `POST /agents/chat` and never matches a preflight `OPTIONS`. Register the path a second time under `OPTIONS`, as the server above does.
+
+The response must allow `content-type` and any auth header the client sends. When the frontend and the Go process share an origin, or the frontend proxies to it, no CORS wrapper is needed.
 
 ## Route layout
 
@@ -87,21 +193,55 @@ curl -X POST http://localhost:8080/agents/chat \
   -d '{"data":{"message":{"role":"user","content":[{"text":"Weather in Tokyo?"}]}}}'
 ```
 
-Continue a server-managed conversation:
+## Response envelope
+
+A non-streaming turn answers with the reflection API's `result` envelope wrapping one `AgentOutput`:
+
+```json
+{
+  "result": {
+    "message": {
+      "role": "model",
+      "content": [{ "text": "Tokyo is 18°C and clear." }]
+    },
+    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
+    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40",
+    "finishReason": "stop"
+  }
+}
+```
+
+The fields of `AgentOutput`:
+
+| Field | Meaning |
+| --- | --- |
+| `message` | The last model response message of the conversation. |
+| `sessionId` | The conversation's ID. The framework assigns it on the first invocation and it is stable across resumes. |
+| `snapshotId` | The most recent turn-end snapshot. Present only when the agent has a session store. |
+| `state` | The full `SessionState`. Present only for client-managed agents, those with no store. |
+| `artifacts` | Artifacts produced during the session. |
+| `finishReason` | Why the invocation finished: `stop`, `length`, `blocked`, `interrupted`, `other`, `unknown`, `aborted`, `detached`, or `failed`. |
+| `error` | Structured failure details. Present only when `finishReason` is `failed`. |
+
+Copy `result.sessionId` into `init.sessionId` on the next request, and `result.snapshotId` into the `getSnapshot` and `abort` bodies. When streaming, read the session ID from the terminal `data: {"result": ...}` frame; chunk frames do not carry it. For a client-managed agent it also rides at `result.state.sessionId`.
+
+Continue a server-managed conversation with the ID the previous response returned:
 
 ```sh
 curl -X POST http://localhost:8080/agents/chat \
   -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"What about Paris?"}]}},"init":{"sessionId":"SESSION_ID"}}'
+  -d '{"data":{"message":{"role":"user","content":[{"text":"What about Paris?"}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
 ```
 
-Continue a client-managed conversation:
+Continue a client-managed conversation by sending back the `state` object from the previous response. `statelessChat` here is an agent defined without `aix.WithSessionStore`, so its responses carry the whole `SessionState`: `sessionId`, `messages`, `custom`, and `artifacts`.
 
 ```sh
 curl -X POST http://localhost:8080/agents/statelessChat \
   -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"What is my name?"}]}},"init":{"state":STATE_FROM_PREVIOUS_RESPONSE}}'
+  -d '{"data":{"message":{"role":"user","content":[{"text":"What is my name?"}]}},"init":{"state":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","messages":[{"role":"user","content":[{"text":"My name is Alex."}]},{"role":"model","content":[{"text":"Nice to meet you, Alex."}]}],"custom":{}}}}'
 ```
+
+## Streaming
 
 Stream a turn as server-sent events:
 
@@ -111,6 +251,75 @@ curl -N -X POST 'http://localhost:8080/agents/chat?stream=true' \
   -d '{"data":{"message":{"role":"user","content":[{"text":"Suggest three day trips from Tokyo."}]}},"init":{}}'
 ```
 
+Sending `Accept: text/event-stream` turns streaming on as well, with or without `?stream=true`.
+
+Every frame is one `data:` line. There are three shapes:
+
+```
+data: {"message":{"modelChunk":{"role":"model","content":[{"text":"Nikko"}]}}}
+
+data: {"message":{"modelChunk":{"role":"model","content":[{"text":" is a good day trip."}]}}}
+
+data: {"message":{"turnEnd":{"finishReason":"stop","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}}
+
+data: {"result":{"message":{"role":"model","content":[{"text":"Nikko is a good day trip."}]},"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40","finishReason":"stop"}}
+```
+
+- **`{"message": <chunk>}`** repeats for each streamed chunk. The inner object is the wire encoding of the same `aix.AgentStreamChunk` that `conn.Receive()` yields in Go, with the fields `modelChunk`, `customPatch`, `artifact`, and `turnEnd`. See [Run and stream agents](/docs/agents/run).
+- **`{"result": <AgentOutput>}`** is the terminal frame and the only one that carries `sessionId`.
+- **`{"error": {"status": ..., "message": ...}}`** replaces the terminal frame when the stream fails.
+
+### Reading custom state from a raw client
+
+Custom state reaches a raw HTTP client as `customPatch` on a chunk, an RFC 6902 JSON Patch rooted at the custom document. Its pointers have no `/custom` prefix, so a field named `agentStatus` is at `/agentStatus`:
+
+```
+data: {"message":{"customPatch":[{"op":"replace","path":"","value":{"agentStatus":"searching"}}]}}
+
+data: {"message":{"customPatch":[{"op":"replace","path":"/agentStatus","value":"summarizing"}]}}
+```
+
+The first patch of each turn is a whole-document replace at the root pointer `""`, which re-bases a client that joined mid-conversation. Apply the later patches incrementally to keep a local copy live. Go callers use `aix.ApplyPatch`; a browser client needs any RFC 6902 implementation. The Vercel AI SDK transport described below does this reassembly for you and hands `onData` the full state as a `data-custom` part.
+
+## Interrupts over HTTP
+
+`banker` below is an agent with an interruptible `transferMoney` tool. When such a tool pauses, the turn still returns 200: `finishReason` is `interrupted` and the interrupt rides as a tool-request part on the message content, carrying the tool's payload under `metadata.interrupt`.
+
+```json
+{
+  "result": {
+    "finishReason": "interrupted",
+    "message": {
+      "role": "model",
+      "content": [
+        {
+          "toolRequest": {
+            "name": "transferMoney",
+            "ref": "call_1",
+            "input": { "toAccount": "alice", "amount": 200 }
+          },
+          "metadata": {
+            "interrupt": { "reason": "large_amount", "amount": 200 }
+          }
+        }
+      ]
+    },
+    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
+    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"
+  }
+}
+```
+
+Answer it on the next request through `data.resume`, which takes `respond`, `restart`, or both:
+
+```sh
+curl -X POST http://localhost:8080/agents/banker \
+  -H 'content-type: application/json' \
+  -d '{"data":{"resume":{"restart":[{"toolRequest":{"name":"transferMoney","ref":"call_1","input":{"toAccount":"alice","amount":200}},"metadata":{"resumed":{"approved":true}}}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
+```
+
+`respond` supplies the tool's output directly; `restart` re-runs the tool with a typed answer. The runtime validates the payload: `name` and `ref` must match a pending tool request in the most recent model response, and a restarted request must carry its original input unmodified. See [Agent interrupts](/docs/agents/interrupts).
+
 ## Snapshot and abort companions
 
 Read a snapshot:
@@ -118,7 +327,7 @@ Read a snapshot:
 ```sh
 curl -X POST http://localhost:8080/agents/chat/getSnapshot \
   -H 'content-type: application/json' \
-  -d '{"data":{"snapshotId":"SNAPSHOT_ID"}}'
+  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
 ```
 
 Abort detached work:
@@ -126,12 +335,26 @@ Abort detached work:
 ```sh
 curl -X POST http://localhost:8080/agents/chat/abort \
   -H 'content-type: application/json' \
-  -d '{"data":{"snapshotId":"SNAPSHOT_ID"}}'
+  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
 ```
+
+Both take the `snapshotId` a previous turn returned at `result.snapshotId`. See [Background execution](/docs/agents/background).
 
 ## Failure tiers
 
-Failures arrive at two different levels, and a client has to read both. A failed turn still returns 200, reporting `finishReason` `"failed"` with a structured error and the last-good state, so the client can retry without losing the conversation. A rejected init, such as an unknown session or `state` sent to a store-backed agent, fails the request with a 4xx before any turn runs.
+Failures arrive at two different levels, and a client has to read both. A failed turn still returns 200, reporting `finishReason` `"failed"` with a structured error and the last-good state, so the client can retry without losing the conversation. A rejected init fails the request with a 4xx before any turn runs: an unknown `snapshotId`, `state` sent to a store-backed agent, or `sessionId` sent to a client-managed agent.
+
+:::caution[An unrecognized session ID is not an error]
+A `sessionId` a store-backed agent has never seen is not rejected. The agent starts a brand-new conversation under that ID and stamps it on every snapshot the new session writes, so a typo forks a fresh conversation rather than failing. Validate session IDs in your auth wrapper if a caller must not be able to invent them.
+:::
+
+## Next steps
+
+- [Run and stream agents](/docs/agents/run) covers the in-process `Run`, `RunText`, and `Connect` surface behind these routes.
+- [Agent interrupts](/docs/agents/interrupts) covers building resume payloads.
+- [Background execution](/docs/agents/background) covers detach, snapshot polling, and abort.
+- [Sessions and state](/docs/agents/state) covers custom state and the patches that stream over SSE.
+- [Agent error handling](/docs/agents/errors) covers the two failure tiers in depth.
 
 </Lang>
 
@@ -215,11 +438,38 @@ The turn endpoint handles both streaming and non-streaming requests. The snapsho
 
 The client is independent of the backend language. Point it at the primary turn URL your server exposes, the route you mounted above, and it speaks the same wire protocol either way. The snapshot and abort companion URLs follow your server's route layout.
 
+<Lang lang="go">
+
+Go ships no prebuilt HTTP agent client. Server code should hold the agent value and call `RunText`, `Run`, or `Connect` in process; see [Run and stream agents](/docs/agents/run). Another Go service can POST the envelope shown above directly.
+
+For a browser or mobile frontend in front of a Go backend, use the JavaScript client. It is in the `genkit` npm package:
+
+```sh
+npm i genkit
+```
+
+```ts
+import { remoteAgent } from 'genkit/beta/client';
+
+const agent = remoteAgent({ url: 'http://localhost:8080/agents/chat' });
+
+const chat = agent.chat();
+const res = await chat.send('Weather in Tokyo?');
+```
+
+The JavaScript version of this page documents the client in full.
+
+</Lang>
+
+<Lang lang="js dart python">
+
 The snippets below apply whichever backend language you selected.
+
+</Lang>
 
 <Lang lang="js">
 
-`remoteAgent()` from `genkit/beta/client` creates a browser-safe client with the same `AgentAPI` shape as a local agent.
+`remoteAgent()` from the `genkit` npm package (`npm i genkit`) creates a browser-safe client with the same `AgentAPI` shape as a local agent.
 
 ```ts
 import { remoteAgent } from 'genkit/beta/client';
@@ -347,7 +597,11 @@ res = await turn.response
 
 ## Client behavior
 
+<Lang lang="js dart python">
+
 The remote client calls the primary endpoint with streamed action transport. It resolves dynamic headers per request, supports foreground aborts, applies streamed custom-state patches, and throws `AgentError` for failed turns.
+
+</Lang>
 
 When using server-managed state, make sure the same auth and tenant checks apply to the primary, snapshot, and abort endpoints. Snapshot IDs are powerful because they can reveal conversation history. Treat them like conversation-scoped credentials, and verify that the caller is allowed to read or abort the requested session.
 
@@ -361,7 +615,15 @@ With the agent behind an AI SDK UI binding, you drive it from the SDK's chat pri
 
 This path is server-managed only. The transport sends the chat `id` to the agent as its `sessionId`, and the agent persists each turn in its session store, so there is no client-side snapshot bookkeeping. The `id` must be a bare UUID.
 
-Point the transport at the same agent route you serve for turns. These examples use React and Angular; the Vue and Svelte bindings accept the same `GenkitChatTransport`.
+Install it alongside the AI SDK UI binding you use:
+
+```sh
+npm i @genkit-ai/vercel-ai
+```
+
+Point the transport at the same agent route you serve for turns. The examples below use `/api/weatherAgent`; replace it with the path your own server mounts, shown in the routing section above. A same-origin path works when the frontend is served from the backend process or proxied to it. A cross-origin URL such as `http://localhost:8080/agents/weatherAgent` needs CORS headers on the agent route.
+
+These examples use React and Angular; the Vue and Svelte bindings accept the same `GenkitChatTransport`.
 
 <Tabs syncKey="ai-sdk-ui">
 <TabItem label="React">

--- a/src/content/docs/docs/agents/http.mdx
+++ b/src/content/docs/docs/agents/http.mdx
@@ -52,17 +52,15 @@ The primary endpoint handles normal and streaming turns. The snapshot endpoint r
 
 ## Route helpers
 
-The experimental route helpers live in `github.com/firebase/genkit/go/genkit/exp`. They return route descriptors that you can mount on `http.ServeMux` or another router. This is a complete server: one store-backed agent, the default route layout, and the wrappers a browser client needs.
+The experimental route helpers live in `github.com/firebase/genkit/go/genkit/exp`. They return route descriptors that you can mount on `http.ServeMux` or any standard Go router.
 
 ```go
 package main
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
@@ -72,14 +70,10 @@ import (
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
 
-// userKey types the context key the auth wrapper stores the caller under.
-type userKey struct{}
-
 func main() {
 	ctx := context.Background()
 
-	// The Google AI plugin reads the API key from GEMINI_API_KEY or
-	// GOOGLE_API_KEY. Agents need the experimental surface.
+	// Initialize Genkit with experimental support enabled for Agents.
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 		genkit.WithExperimental(),
@@ -100,60 +94,15 @@ func main() {
 
 	mux := http.NewServeMux()
 	for _, route := range genkitx.AllAgentRoutes(g) {
-		h := withCORS(withAuth(route.Handler()))
-		mux.Handle(route.Pattern(), h)
-		// Pattern() is method-prefixed ("POST /agents/chat"), so a browser
-		// preflight needs its own registration on the same path.
-		mux.Handle("OPTIONS "+route.Path, h)
+		mux.HandleFunc(route.Pattern(), route.Handler())
 	}
 
 	log.Println("listening on http://localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }
-
-// withCORS lets a browser frontend on another origin call the agent routes.
-// It allows every origin, which suits local development; restrict it to the
-// origins you actually serve before deploying.
-func withCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization")
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-// withAuth rejects an unauthenticated caller before any turn runs, then puts
-// the identity on the request context. The agent and every tool it calls
-// receive that same context, so they can read it back with ctx.Value.
-func withAuth(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		uid, err := verifyToken(r.Header.Get("Authorization"))
-		if err != nil {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), userKey{}, uid)))
-	})
-}
-
-// verifyToken stands in for your identity provider.
-func verifyToken(header string) (string, error) {
-	token := strings.TrimPrefix(header, "Bearer ")
-	if token == "" || token == header {
-		return "", errors.New("missing bearer token")
-	}
-	return token, nil
-}
 ```
 
 Use `genkitx.AgentRoutes(agent)` to mount one agent, or `genkitx.AllAgentRoutes(g)` to mount every registered agent. The fields on `Route` are exported, so a router other than `http.ServeMux` can mount the same layout: read `Method` and `Path`, and serve `Action` with `genkit.Handler`.
-
-An agent is a bidirectional streaming action, but the standard handler also runs it one turn per request, which is what these routes serve. The [basic-agents-server](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents-server) sample serves a store-backed agent and a client-managed one side by side, with `curl` recipes for streaming, detach, poll, and abort.
 
 ### Handler options
 
@@ -173,188 +122,7 @@ The turn response then carries an `X-Genkit-Stream-Id` header. A client that rec
 
 ### Browser clients and CORS
 
-The route helpers do no CORS handling: no `Access-Control` header is set anywhere in the framework, so a cross-origin browser client cannot call these routes until you add a wrapper like the `withCORS` above. `Route.Pattern()` is `Method + " " + Path`, so the pattern registered for a turn is `POST /agents/chat` and never matches a preflight `OPTIONS`. Register the path a second time under `OPTIONS`, as the server above does.
-
-The response must allow `content-type` and any auth header the client sends. When the frontend and the Go process share an origin, or the frontend proxies to it, no CORS wrapper is needed.
-
-## Route layout
-
-- **`POST /agents/{name}`** always exists. It handles one turn per request. Add `?stream=true` for server-sent events.
-- **`POST /agents/{name}/getSnapshot`** exists only when the agent has a session store. Use it to read by `snapshotId` or by latest `sessionId`.
-- **`POST /agents/{name}/abort`** exists only when the agent has a store that supports status subscriptions. Use it to cancel detached background work.
-
-There is currently no `abortSnapshot` route.
-
-Every route uses the standard Genkit HTTP envelope. The turn input goes in `data`, and session initialization goes in the optional `init`. Omit `init` to start a fresh conversation, or include `sessionId`, `snapshotId`, or `state` to continue one.
-
-```sh
-curl -X POST http://localhost:8080/agents/chat \
-  -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"Weather in Tokyo?"}]}}}'
-```
-
-## Response envelope
-
-A non-streaming turn answers with the reflection API's `result` envelope wrapping one `AgentOutput`:
-
-```json
-{
-  "result": {
-    "message": {
-      "role": "model",
-      "content": [{ "text": "Tokyo is 18°C and clear." }]
-    },
-    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
-    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40",
-    "finishReason": "stop"
-  }
-}
-```
-
-The fields of `AgentOutput`:
-
-| Field | Meaning |
-| --- | --- |
-| `message` | The last model response message of the conversation. |
-| `sessionId` | The conversation's ID. The framework assigns it on the first invocation and it is stable across resumes. |
-| `snapshotId` | The most recent turn-end snapshot. Present only when the agent has a session store. |
-| `state` | The full `SessionState`. Present only for client-managed agents, those with no store. |
-| `artifacts` | Artifacts produced during the session. |
-| `finishReason` | Why the invocation finished: `stop`, `length`, `blocked`, `interrupted`, `other`, `unknown`, `aborted`, `detached`, or `failed`. |
-| `error` | Structured failure details. Present only when `finishReason` is `failed`. |
-
-Copy `result.sessionId` into `init.sessionId` on the next request, and `result.snapshotId` into the `getSnapshot` and `abort` bodies. When streaming, read the session ID from the terminal `data: {"result": ...}` frame; chunk frames do not carry it. For a client-managed agent it also rides at `result.state.sessionId`.
-
-Continue a server-managed conversation with the ID the previous response returned:
-
-```sh
-curl -X POST http://localhost:8080/agents/chat \
-  -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"What about Paris?"}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
-```
-
-Continue a client-managed conversation by sending back the `state` object from the previous response. `statelessChat` here is an agent defined without `aix.WithSessionStore`, so its responses carry the whole `SessionState`: `sessionId`, `messages`, `custom`, and `artifacts`.
-
-```sh
-curl -X POST http://localhost:8080/agents/statelessChat \
-  -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"What is my name?"}]}},"init":{"state":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","messages":[{"role":"user","content":[{"text":"My name is Alex."}]},{"role":"model","content":[{"text":"Nice to meet you, Alex."}]}],"custom":{}}}}'
-```
-
-## Streaming
-
-Stream a turn as server-sent events:
-
-```sh
-curl -N -X POST 'http://localhost:8080/agents/chat?stream=true' \
-  -H 'content-type: application/json' \
-  -d '{"data":{"message":{"role":"user","content":[{"text":"Suggest three day trips from Tokyo."}]}},"init":{}}'
-```
-
-Sending `Accept: text/event-stream` turns streaming on as well, with or without `?stream=true`.
-
-Every frame is one `data:` line. There are three shapes:
-
-```
-data: {"message":{"modelChunk":{"role":"model","content":[{"text":"Nikko"}]}}}
-
-data: {"message":{"modelChunk":{"role":"model","content":[{"text":" is a good day trip."}]}}}
-
-data: {"message":{"turnEnd":{"finishReason":"stop","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}}
-
-data: {"result":{"message":{"role":"model","content":[{"text":"Nikko is a good day trip."}]},"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40","finishReason":"stop"}}
-```
-
-- **`{"message": <chunk>}`** repeats for each streamed chunk. The inner object is the wire encoding of the same `aix.AgentStreamChunk` that `conn.Receive()` yields in Go, with the fields `modelChunk`, `customPatch`, `artifact`, and `turnEnd`. See [Run and stream agents](/docs/agents/run).
-- **`{"result": <AgentOutput>}`** is the terminal frame and the only one that carries `sessionId`.
-- **`{"error": {"status": ..., "message": ...}}`** replaces the terminal frame when the stream fails.
-
-### Reading custom state from a raw client
-
-Custom state reaches a raw HTTP client as `customPatch` on a chunk, an RFC 6902 JSON Patch rooted at the custom document. Its pointers have no `/custom` prefix, so a field named `agentStatus` is at `/agentStatus`:
-
-```
-data: {"message":{"customPatch":[{"op":"replace","path":"","value":{"agentStatus":"searching"}}]}}
-
-data: {"message":{"customPatch":[{"op":"replace","path":"/agentStatus","value":"summarizing"}]}}
-```
-
-The first patch of each turn is a whole-document replace at the root pointer `""`, which re-bases a client that joined mid-conversation. Apply the later patches incrementally to keep a local copy live. Go callers use `aix.ApplyPatch`; a browser client needs any RFC 6902 implementation. The Vercel AI SDK transport described below does this reassembly for you and hands `onData` the full state as a `data-custom` part.
-
-## Interrupts over HTTP
-
-`banker` below is an agent with an interruptible `transferMoney` tool. When such a tool pauses, the turn still returns 200: `finishReason` is `interrupted` and the interrupt rides as a tool-request part on the message content, carrying the tool's payload under `metadata.interrupt`.
-
-```json
-{
-  "result": {
-    "finishReason": "interrupted",
-    "message": {
-      "role": "model",
-      "content": [
-        {
-          "toolRequest": {
-            "name": "transferMoney",
-            "ref": "call_1",
-            "input": { "toAccount": "alice", "amount": 200 }
-          },
-          "metadata": {
-            "interrupt": { "reason": "large_amount", "amount": 200 }
-          }
-        }
-      ]
-    },
-    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
-    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"
-  }
-}
-```
-
-Answer it on the next request through `data.resume`, which takes `respond`, `restart`, or both:
-
-```sh
-curl -X POST http://localhost:8080/agents/banker \
-  -H 'content-type: application/json' \
-  -d '{"data":{"resume":{"restart":[{"toolRequest":{"name":"transferMoney","ref":"call_1","input":{"toAccount":"alice","amount":200}},"metadata":{"resumed":{"approved":true}}}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
-```
-
-`respond` supplies the tool's output directly; `restart` re-runs the tool with a typed answer. The runtime validates the payload: `name` and `ref` must match a pending tool request in the most recent model response, and a restarted request must carry its original input unmodified. See [Agent interrupts](/docs/agents/interrupts).
-
-## Snapshot and abort companions
-
-Read a snapshot:
-
-```sh
-curl -X POST http://localhost:8080/agents/chat/getSnapshot \
-  -H 'content-type: application/json' \
-  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
-```
-
-Abort detached work:
-
-```sh
-curl -X POST http://localhost:8080/agents/chat/abort \
-  -H 'content-type: application/json' \
-  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
-```
-
-Both take the `snapshotId` a previous turn returned at `result.snapshotId`. See [Background execution](/docs/agents/background).
-
-## Failure tiers
-
-Failures arrive at two different levels, and a client has to read both. A failed turn still returns 200, reporting `finishReason` `"failed"` with a structured error and the last-good state, so the client can retry without losing the conversation. A rejected init fails the request with a 4xx before any turn runs: an unknown `snapshotId`, `state` sent to a store-backed agent, or `sessionId` sent to a client-managed agent.
-
-:::caution[An unrecognized session ID is not an error]
-A `sessionId` a store-backed agent has never seen is not rejected. The agent starts a brand-new conversation under that ID and stamps it on every snapshot the new session writes, so a typo forks a fresh conversation rather than failing. Validate session IDs in your auth wrapper if a caller must not be able to invent them.
-:::
-
-## Next steps
-
-- [Run and stream agents](/docs/agents/run) covers the in-process `Run`, `RunText`, and `Connect` surface behind these routes.
-- [Agent interrupts](/docs/agents/interrupts) covers building resume payloads.
-- [Background execution](/docs/agents/background) covers detach, snapshot polling, and abort.
-- [Sessions and state](/docs/agents/state) covers custom state and the patches that stream over SSE.
-- [Agent error handling](/docs/agents/errors) covers the two failure tiers in depth.
+When browser clients connect across origins, apply standard CORS middleware (such as `github.com/rs/cors` or your framework's CORS middleware) to your HTTP router to allow `POST` and `OPTIONS` requests along with headers such as `Content-Type` and `Authorization`. When the frontend and the Go process share an origin, or the frontend proxies to it, no CORS wrapper is needed.
 
 </Lang>
 
@@ -433,6 +201,179 @@ The turn endpoint handles both streaming and non-streaming requests. The snapsho
 `context_dependency` is a FastAPI dependency that returns a dict. Genkit threads that dict into the action as context on the turn, snapshot, and abort routes, so auth and other request-scoped values resolve once through FastAPI's `Depends` graph. Tools and custom orchestration read the same map from turn context.
 
 </Lang>
+
+## Route layout
+
+Agent routes follow a consistent layout across backend frameworks:
+
+- **`POST /agents/{name}`** (or `/api/{name}`): Always exists. It handles one turn per request. Add `?stream=true` for server-sent events.
+- **`POST /agents/{name}/getSnapshot`** (or `/api/{name}/getSnapshot`): Exists when the agent has a session store. Use it to read by `snapshotId` or by latest `sessionId`.
+- **`POST /agents/{name}/abort`** (or `/api/{name}/abort`): Exists when the agent has a store that supports status subscriptions. Use it to cancel detached background work.
+
+Every route uses the standard Genkit HTTP envelope. The turn input goes in `data`, and session initialization goes in the optional `init`. Omit `init` to start a fresh conversation, or include `sessionId`, `snapshotId`, or `state` to continue one.
+
+```sh
+curl -X POST http://localhost:8080/agents/chat \
+  -H 'content-type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"Weather in Tokyo?"}]}}}'
+```
+
+## Response envelope
+
+A non-streaming turn answers with the reflection API's `result` envelope wrapping one `AgentOutput`:
+
+```json
+{
+  "result": {
+    "message": {
+      "role": "model",
+      "content": [{ "text": "Tokyo is 18°C and clear." }]
+    },
+    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
+    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40",
+    "finishReason": "stop"
+  }
+}
+```
+
+The fields of `AgentOutput`:
+
+| Field | Meaning |
+| --- | --- |
+| `message` | The last model response message of the conversation. |
+| `sessionId` | The conversation's ID. The framework assigns it on the first invocation and it is stable across resumes. |
+| `snapshotId` | The most recent turn-end snapshot. Present only when the agent has a session store. |
+| `state` | The full `SessionState`. Present only for client-managed agents, those with no store. |
+| `artifacts` | Artifacts produced during the session. |
+| `finishReason` | Why the invocation finished: `stop`, `length`, `blocked`, `interrupted`, `other`, `unknown`, `aborted`, `detached`, or `failed`. |
+| `error` | Structured failure details. Present only when `finishReason` is `failed`. |
+
+Copy `result.sessionId` into `init.sessionId` on the next request, and `result.snapshotId` into the `getSnapshot` and `abort` bodies. When streaming, read the session ID from the terminal `data: {"result": ...}` frame; chunk frames do not carry it. For a client-managed agent it also rides at `result.state.sessionId`.
+
+Continue a server-managed conversation with the ID the previous response returned:
+
+```sh
+curl -X POST http://localhost:8080/agents/chat \
+  -H 'content-type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"What about Paris?"}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
+```
+
+Continue a client-managed conversation by sending back the `state` object from the previous response. An agent defined without a session store returns responses that carry the whole `SessionState`: `sessionId`, `messages`, `custom`, and `artifacts`.
+
+```sh
+curl -X POST http://localhost:8080/agents/statelessChat \
+  -H 'content-type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"What is my name?"}]}},"init":{"state":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","messages":[{"role":"user","content":[{"text":"My name is Alex."}]},{"role":"model","content":[{"text":"Nice to meet you, Alex."}]}],"custom":{}}}}'
+```
+
+## Streaming
+
+Stream a turn as server-sent events:
+
+```sh
+curl -N -X POST 'http://localhost:8080/agents/chat?stream=true' \
+  -H 'content-type: application/json' \
+  -d '{"data":{"message":{"role":"user","content":[{"text":"Suggest three day trips from Tokyo."}]}},"init":{}}'
+```
+
+Sending `Accept: text/event-stream` turns streaming on as well, with or without `?stream=true`.
+
+Every frame is one `data:` line. There are three shapes:
+
+```
+data: {"message":{"modelChunk":{"role":"model","content":[{"text":"Nikko"}]}}}
+
+data: {"message":{"modelChunk":{"role":"model","content":[{"text":" is a good day trip."}]}}}
+
+data: {"message":{"turnEnd":{"finishReason":"stop","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}}
+
+data: {"result":{"message":{"role":"model","content":[{"text":"Nikko is a good day trip."}]},"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11","snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40","finishReason":"stop"}}
+```
+
+- **`{"message": <chunk>}`** repeats for each streamed chunk. The inner object represents the stream chunk, carrying fields such as `modelChunk`, `customPatch`, `artifact`, and `turnEnd`.
+- **`{"result": <AgentOutput>}`** is the terminal frame and the only one that carries `sessionId`.
+- **`{"error": {"status": ..., "message": ...}}`** replaces the terminal frame when the stream fails.
+
+### Reading custom state from a raw client
+
+Custom state reaches a raw HTTP client as `customPatch` on a chunk, an RFC 6902 JSON Patch rooted at the custom document. Its pointers have no `/custom` prefix, so a field named `agentStatus` is at `/agentStatus`:
+
+```
+data: {"message":{"customPatch":[{"op":"replace","path":"","value":{"agentStatus":"searching"}}]}}
+
+data: {"message":{"customPatch":[{"op":"replace","path":"/agentStatus","value":"summarizing"}]}}
+```
+
+The first patch of each turn is a whole-document replace at the root pointer `""`, which re-bases a client that joined mid-conversation. Apply later patches incrementally to keep a local copy live. In Go, use `aix.ApplyPatch`; browser clients can use standard RFC 6902 libraries like `fast-json-patch`. The Vercel AI SDK transport described below performs this reassembly automatically.
+
+## Interrupts over HTTP
+
+When an interruptible tool pauses, the turn returns HTTP 200: `finishReason` is `interrupted` and the interrupt rides as a tool-request part on the message content, carrying the tool's payload under `metadata.interrupt`.
+
+```json
+{
+  "result": {
+    "finishReason": "interrupted",
+    "message": {
+      "role": "model",
+      "content": [
+        {
+          "toolRequest": {
+            "name": "transferMoney",
+            "ref": "call_1",
+            "input": { "toAccount": "alice", "amount": 200 }
+          },
+          "metadata": {
+            "interrupt": { "reason": "large_amount", "amount": 200 }
+          }
+        }
+      ]
+    },
+    "sessionId": "6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11",
+    "snapshotId": "9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"
+  }
+}
+```
+
+Answer it on the next request through `data.resume`, which takes `respond`, `restart`, or both:
+
+```sh
+curl -X POST http://localhost:8080/agents/banker \
+  -H 'content-type: application/json' \
+  -d '{"data":{"resume":{"restart":[{"toolRequest":{"name":"transferMoney","ref":"call_1","input":{"toAccount":"alice","amount":200}},"metadata":{"resumed":{"approved":true}}}]}},"init":{"sessionId":"6b1c2f3e-6a1e-4c1b-9c74-1f2b8d0a5e11"}}'
+```
+
+`respond` supplies the tool's output directly; `restart` re-runs the tool with a typed answer. The runtime validates the payload: `name` and `ref` must match a pending tool request in the most recent model response, and a restarted request must carry its original input unmodified. See [Agent interrupts](/docs/agents/interrupts).
+
+## Snapshot and abort companions
+
+Read a snapshot:
+
+```sh
+curl -X POST http://localhost:8080/agents/chat/getSnapshot \
+  -H 'content-type: application/json' \
+  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
+```
+
+Abort detached work:
+
+```sh
+curl -X POST http://localhost:8080/agents/chat/abort \
+  -H 'content-type: application/json' \
+  -d '{"data":{"snapshotId":"9f2a41d6-0c2b-4f0e-8a7a-3f9d1c6b2e40"}}'
+```
+
+Both take the `snapshotId` a previous turn returned at `result.snapshotId`. See [Background execution](/docs/agents/background).
+
+## Failure tiers
+
+Failures arrive at two different levels:
+- **Turn-level failures:** A failed turn returns 200 with `finishReason: "failed"` along with structured error details and the last known good state, allowing the client to retry or handle the failure without losing conversation state.
+- **Request-level failures:** A malformed init payload (such as an unknown `snapshotId` or sending `state` to a store-backed agent) fails immediately with an HTTP 4xx error before running the turn.
+
+:::note[Session ID handling]
+If a store-backed agent receives a `sessionId` that does not exist in the store, it initializes a new conversation under that ID. If your application needs to restrict client-generated session IDs, validate the identifier in your authentication or authorization middleware before invoking the agent handler.
+:::
 
 ## Connect a client
 

--- a/src/content/docs/docs/agents/interrupts.mdx
+++ b/src/content/docs/docs/agents/interrupts.mdx
@@ -148,12 +148,20 @@ Wait for the final response before treating the turn as durably interrupted, bec
 
 <Lang lang="go">
 
+Interrupts are one feature with two transports. The tool-side API is the same as on [Interrupts](/docs/interrupts): `genkitx.DefineInterruptibleTool`, `tool.Interrupt`, `tool.InterruptAs`, and the tool's `Resume`/`Respond` builders. Only the delivery differs. A plain generate call takes the resume parts through `ai.WithToolRestarts` and `ai.WithToolResponses`; an agent takes them through `conn.SendResume` or `AgentInput.Resume`, which the agent forwards to the identical generate resume path.
+
 ## Interrupt from a tool
 
 Define an interruptible tool with `genkitx.DefineInterruptibleTool`. Its third parameter is a typed _resume payload_: `nil` on the first call, and populated with the client's answer when the turn is resumed. The tool pauses by returning `tool.Interrupt(metadata)`; on resume it runs again from the top with the payload set. Keep approval and execution logic in one tool, and require the client to explicitly resume the turn.
 
 ```go
 import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/tool"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 )
@@ -200,6 +208,16 @@ transferMoney := genkitx.DefineInterruptibleTool(g, "transferMoney",
 )
 ```
 
+`DefineInterruptibleTool` returns `*aix.InterruptibleTool[In, Out, Resume]`, so the tool above has type `*aix.InterruptibleTool[TransferInput, TransferOutput, Confirmation]`. Write the type out when the tool must outlive the enclosing function:
+
+```go
+type App struct {
+	Transfer *aix.InterruptibleTool[TransferInput, TransferOutput, Confirmation]
+}
+```
+
+`InterruptibleTool` embeds `aix.Tool[In, Out]` and adds two resume-part builders, `Resume(part *ai.Part, res Resume) (*ai.Part, error)` and `Respond(part *ai.Part, out Out) (*ai.Part, error)`.
+
 The banker agent in the [basic-agents](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) sample runs this end to end: its tool interrupts with a discriminated payload, and the CLI asks the user and resumes the turn.
 
 ## Collect interrupts from the stream
@@ -231,13 +249,45 @@ if ok {
 }
 ```
 
+### Recover interrupts from a snapshot
+
+`(*ai.ModelResponse).Interrupts()` and `chunk.ModelChunk.Interrupts()` cover the live paths. From a stored snapshot there is no response object, so filter the messages yourself: take the newest message whose `Role` is `ai.RoleModel` and keep the parts for which `part.IsInterrupt()` reports true. `*ai.Part` implements `MarshalJSON` and `UnmarshalJSON`, so an interrupt part can be persisted in your own queue and reloaded verbatim.
+
+```go
+// BankState is the agent's custom state type.
+type BankState struct {
+	Balance float64 `json:"balance,omitempty"`
+}
+
+func pendingInterrupts(snap *aix.SessionSnapshot[BankState]) []*ai.Part {
+	if snap == nil || snap.State == nil {
+		// State is nil on a pending snapshot: detached work is still running.
+		return nil
+	}
+
+	for i := len(snap.State.Messages) - 1; i >= 0; i-- {
+		msg := snap.State.Messages[i]
+		if msg.Role != ai.RoleModel {
+			continue
+		}
+
+		var pending []*ai.Part
+		for _, part := range msg.Content {
+			if part.IsInterrupt() {
+				pending = append(pending, part)
+			}
+		}
+		return pending
+	}
+	return nil
+}
+```
+
+Stop at the first model message. Resume validation only searches the most recent model response, so parts from an earlier turn are rejected as stale.
+
 ## Resume an interrupted turn
 
 Build resume parts from the tool, then send them with `conn.SendResume`. Use `Resume` to re-execute the tool, delivering the client's typed answer to its resume parameter. The tool runs again from the top, this time with a non-nil payload.
-
-```go
-import aix "github.com/firebase/genkit/go/ai/exp"
-```
 
 ```go
 part, err := transferMoney.Resume(interrupts[0], Confirmation{Approved: true})
@@ -277,6 +327,82 @@ A resumed turn can interrupt again. Streaming clients should handle interrupts i
 
 The same interruptible-tool API works outside an agent. The [basic-tool-interrupts-exp](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-tool-interrupts-exp) sample runs the pause-and-resume cycle across two ordinary generate turns instead.
 
+## Resume without a live connection
+
+An `AgentConnection` is a convenience, not a requirement. `aix.AgentInput` carries the same payload on its `Resume` field, and `Agent.Run` accepts invocation options alongside a full `AgentInput`, so one call resumes a session from any process:
+
+```go
+out, err := agent.Run(ctx, &aix.AgentInput{
+	Resume: &aix.ToolResume{Restart: []*ai.Part{part}},
+}, aix.WithSessionID[BankState](sessionID))
+```
+
+An `AgentInput` carrying only `Resume`, with no `Message`, is valid. The two fields of `aix.ToolResume` match the two builders:
+
+| Field     | Type         | Effect                                                          |
+| --------- | ------------ | --------------------------------------------------------------- |
+| `Restart` | `[]*ai.Part` | Re-runs the tool with the typed resume payload attached.        |
+| `Respond` | `[]*ai.Part` | Supplies the tool output directly; the tool does not run again. |
+
+Both may appear in one payload. Over HTTP the same object rides in `data.resume`.
+
+### Resume from another process
+
+The process that paused the turn does not need to be the one that answers it. Read the session's latest snapshot, find the pending interrupt parts, build the resume parts with the tool, then run:
+
+```go
+func approveTransfer(
+	ctx context.Context,
+	agent *aix.Agent[BankState],
+	transferMoney *aix.InterruptibleTool[TransferInput, TransferOutput, Confirmation],
+	sessionID string,
+) error {
+	snap, err := agent.GetLatestSnapshot(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("read latest snapshot: %w", err)
+	}
+	if snap.FinishReason != aix.AgentFinishReasonInterrupted {
+		return fmt.Errorf("session %q is not waiting on an interrupt", sessionID)
+	}
+
+	var restarts []*ai.Part
+	for _, part := range pendingInterrupts(snap) {
+		meta, ok := tool.InterruptAs[TransferInterrupt](part)
+		if !ok {
+			continue
+		}
+		fmt.Printf("Approve transfer of %.2f to %s?\n", meta.Amount, meta.To)
+
+		restart, err := transferMoney.Resume(part, Confirmation{Approved: true})
+		if err != nil {
+			return fmt.Errorf("build resume part: %w", err)
+		}
+		restarts = append(restarts, restart)
+	}
+	if len(restarts) == 0 {
+		return errors.New("no pending interrupts for this tool")
+	}
+
+	out, err := agent.Run(ctx, &aix.AgentInput{
+		Resume: &aix.ToolResume{Restart: restarts},
+	}, aix.WithSessionID[BankState](sessionID))
+	if err != nil {
+		return fmt.Errorf("resume session: %w", err)
+	}
+
+	fmt.Println(out.Message.Text())
+	return nil
+}
+```
+
+The approver never sees the original request payload, and does not need to: the server re-validates the payload with `aix.ValidateResumeAgainstHistory` before it reaches the model, so a forged restart is rejected.
+
+## Durability
+
+An interrupted turn is an ordinary completed turn. With a session store it writes a snapshot whose `Status` is `completed` and whose `FinishReason` is `interrupted`, so it satisfies the "only a completed snapshot is resumable" rule on [Background execution](/docs/agents/background). Read `FinishReason`, not `Status`, to tell an interrupt apart from a plain finished turn.
+
+There is no expiry on a paused turn. The `pending` and `expired` statuses apply only to detached background work. The only constraint is that a resume must target tool requests in the snapshot's most recent model message, so answer the interrupt before sending an unrelated user message on the same session.
+
 ## Resume validation
 
 The runtime validates a resume payload against session history before it reaches the model. A `respond` entry must match an interrupted tool request by name and ref. A `restart` entry must match the original request and carry its unmodified input. This protects server tools from forged client payloads.
@@ -292,6 +418,12 @@ if input.Resume != nil {
 	}
 }
 ```
+
+## Next steps
+
+- [Interrupts](/docs/interrupts) covers the same tool API outside an agent turn.
+- [Sessions and state](/docs/agents/state) explains snapshots and the `FinishReason` field a paused turn records.
+- [Background execution](/docs/agents/background) covers detaching from a turn and reading its snapshot later.
 
 </Lang>
 

--- a/src/content/docs/docs/agents/multi-agent.mdx
+++ b/src/content/docs/docs/agents/multi-agent.mdx
@@ -123,10 +123,25 @@ The experimental middleware package `github.com/firebase/genkit/go/plugins/middl
 
 ```go
 import (
+	"github.com/firebase/genkit/go/ai"
 	aix "github.com/firebase/genkit/go/ai/exp"
+	"github.com/firebase/genkit/go/ai/exp/localstore"
+	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
 	middlewarex "github.com/firebase/genkit/go/plugins/middleware/exp"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
 )
+```
+
+The snippets below share one Genkit instance and one store for the orchestrator:
+
+```go
+g := genkit.Init(ctx,
+	genkit.WithExperimental(), // Required: the exp constructors panic without it.
+	genkit.WithPlugins(&googlegenai.GoogleAI{}),
+)
+
+store := localstore.NewInMemorySessionStore[any]()
 ```
 
 ```go
@@ -170,6 +185,8 @@ Reference a sub-agent by name (`aix.AgentRef{Name: "researcher"}`) or capture it
 
 The middleware resolves sub-agents through the `Genkit` instance seeded on the turn context, which `genkitx.DefineAgent` (and `genkit.Generate`) set automatically. Attach it to the orchestrator agent.
 
+Middleware is per-agent. A delegation tool runs the sub-agent as its own invocation, so middleware attached with `ai.WithUse` on the orchestrator's inline prompt wraps only the orchestrator's model calls, never a sub-agent's. Attach cross-cutting middleware such as redaction or logging to every agent that should have it. Doing so does not double-apply: the two agents' generate calls are separate.
+
 The orchestrator agent in the [basic-agents](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) sample is this arrangement running: it delegates to two client-managed sub-agents and reads their work back through session artifacts.
 
 ## Delegation options
@@ -202,9 +219,16 @@ Using the middlewares through `ai.WithUse` needs no plugin. Register `&middlewar
 
 ```go
 g := genkit.Init(ctx,
+	genkit.WithExperimental(),
 	genkit.WithPlugins(&googlegenai.GoogleAI{}, &middlewarex.Middleware{}),
 )
 ```
+
+## Next steps
+
+- [Sessions and state](/docs/agents/state) covers the session artifacts a sub-agent writes into.
+- [Agent error handling](/docs/agents/errors) covers what a delegated failure looks like to the orchestrator.
+- [Custom orchestration](/docs/agents/custom-orchestration) covers taking over the turn loop when middleware delegation is not enough.
 
 </Lang>
 

--- a/src/content/docs/docs/agents/overview.mdx
+++ b/src/content/docs/docs/agents/overview.mdx
@@ -108,13 +108,13 @@ The Go examples in this section follow [`go/samples/basic-agents`](https://githu
 
 ## Install
 
-The Agents API needs Genkit Go v1.10.0 or later. These pages are written against v1.12.0.
+The Agents API requires Genkit Go v1.10.0 or later.
 
 ```bash
-go get github.com/firebase/genkit/go@v1.12.0
+go get github.com/firebase/genkit/go
 ```
 
-Pin the version rather than tracking `@latest`. The API is in preview, so a minor release can change it.
+The Agents API is in preview (`genkit/exp`) and may experience breaking changes in minor version releases.
 
 ## Your first agent
 

--- a/src/content/docs/docs/agents/overview.mdx
+++ b/src/content/docs/docs/agents/overview.mdx
@@ -95,7 +95,26 @@ This makes the Dev UI a fast way to test conversational behavior, debug tool tur
 
 The Agents API is available from the experimental Genkit packages. It supports server-side agents, session stores, HTTP routes, custom state, interrupts, background work, and JavaScript clients that call agent routes.
 
+:::caution[Opt in first]
+Every constructor in `github.com/firebase/genkit/go/genkit/exp` — `DefineAgent`,
+`DefinePromptAgent`, `DefineCustomAgent`, and the experimental tool and flow
+constructors — panics unless the Genkit instance was created with
+`genkit.WithExperimental()`. Pass it to `genkit.Init` once, before you define
+anything. Snippets later in this section that show only the option relevant to
+their topic still assume it. See [API stability channels](/docs/api-stability/).
+:::
+
 The Go examples in this section follow [`go/samples/basic-agents`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents), which defines six agents in six styles behind one command-line client, and [`go/samples/basic-agents-server`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents-server), which serves the same kind of agent over plain HTTP.
+
+## Install
+
+The Agents API needs Genkit Go v1.10.0 or later. These pages are written against v1.12.0.
+
+```bash
+go get github.com/firebase/genkit/go@v1.12.0
+```
+
+Pin the version rather than tracking `@latest`. The API is in preview, so a minor release can change it.
 
 ## Your first agent
 

--- a/src/content/docs/docs/agents/run.mdx
+++ b/src/content/docs/docs/agents/run.mdx
@@ -136,11 +136,26 @@ Initialization misuse, such as sending `state` to a server-managed agent or `ses
 
 <Lang lang="go">
 
-Go calls an agent through the agent value itself. `Run` and `RunText` send one turn, and `Connect` opens a live connection that carries many turns. Go has no `Chat` type and no background task handle: a detached invocation is tracked by its pending snapshot ID through `GetSnapshot`, `GetLatestSnapshot`, and `Abort`.
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
+)
+```
+
+Go calls an agent through the agent value itself. `Run` and `RunText` send one turn, and `Connect` opens a live connection that carries many turns. Go has no `Chat` type and no background task handle: a detached invocation is tracked by its pending snapshot ID through `GetSnapshot`, `GetLatestSnapshot`, and `Abort`. See [Background execution](/docs/agents/background).
+
+`weatherAgent` below is the `*aix.Agent[WeatherState]` that `genkitx.DefineAgent` returned; see [Define agents](/docs/agents/define).
 
 ## Single-turn calls
 
-Use `RunText` for the common text-only case. Use `Run` when you need to send a full `AgentInput`, such as a resume payload or detach request.
+Use `RunText` for the common text-only case. Use `Run` when you need to send a full `aix.AgentInput`, such as a [resume payload](/docs/agents/interrupts) or a [detach request](/docs/agents/background).
 
 ```go
 out, err := weatherAgent.RunText(ctx, "Weather in Tokyo?")
@@ -158,21 +173,101 @@ fmt.Println(out.SnapshotID)
 For a structured input:
 
 ```go
-import aix "github.com/firebase/genkit/go/ai/exp"
-```
-
-```go
 out, err := weatherAgent.Run(ctx, &aix.AgentInput{
 	Message: ai.NewUserTextMessage("Weather in Tokyo?"),
 })
 ```
 
-In-band failures resolve as `AgentOutput` with `FinishReason` set to `failed` and structured details in `out.Error`. A non-nil Go error means the invocation did not start or could not produce an output.
+In-band failures resolve as an `AgentOutput` whose `FinishReason` is `aix.AgentFinishReasonFailed`, with structured details in `out.Error`. A non-nil Go error means the invocation did not start or could not produce an output.
+
+## Turn input and output
+
+Three types carry everything that crosses the agent boundary, and each is small enough to read in full.
+
+```go
+type AgentInput struct {
+	// Detach moves the invocation to the background after this input.
+	Detach bool `json:"detach,omitempty"`
+	// Message is the user's input for this turn.
+	Message *ai.Message `json:"message,omitempty"`
+	// Resume answers an interrupted tool request instead of sending a new turn.
+	Resume *ToolResume `json:"resume,omitempty"`
+}
+```
+
+`Run` and `RunText` return `*aix.AgentOutput[State]`, where `State` is the agent's custom-state type. The type is generic, so a helper signature is `*aix.AgentOutput[WeatherState]`, never a bare `*aix.AgentOutput`.
+
+```go
+type AgentOutput[State any] struct {
+	// Artifacts are the artifacts produced during the session.
+	Artifacts []*Artifact `json:"artifacts,omitempty"`
+	// Error is the structured failure, set only when FinishReason is "failed".
+	Error *status.Error `json:"error,omitempty"`
+	// FinishReason is why the invocation finished.
+	FinishReason AgentFinishReason `json:"finishReason,omitempty"`
+	// Message is the last model response message of the conversation.
+	Message *ai.Message `json:"message,omitempty"`
+	// SessionID identifies the conversation. Stable across resumes.
+	SessionID string `json:"sessionId,omitempty"`
+	// SnapshotID is the most recent turn-end snapshot. Empty with no store.
+	SnapshotID string `json:"snapshotId,omitempty"`
+	// State is the final conversation state, for client-managed agents only.
+	State *SessionState[State] `json:"state,omitempty"`
+}
+```
+
+`State` is populated only when no session store is configured. A store-backed agent returns `SnapshotID` instead, and the state lives in the snapshot. `AgentOutput` carries no token or usage counts; read those from the [trace](/docs/local-observability).
+
+```go
+type AgentStreamChunk struct {
+	// Artifact is a newly produced artifact.
+	Artifact *Artifact `json:"artifact,omitempty"`
+	// CustomPatch is an RFC 6902 JSON Patch against the custom state document.
+	CustomPatch JSONPatch `json:"customPatch,omitempty"`
+	// ModelChunk holds generation tokens from the model.
+	ModelChunk *ai.ModelResponseChunk `json:"modelChunk,omitempty"`
+	// TurnEnd is non-nil once the agent finishes the current input.
+	TurnEnd *TurnEnd `json:"turnEnd,omitempty"`
+}
+
+type TurnEnd struct {
+	// FinishReason is why this turn finished.
+	FinishReason AgentFinishReason `json:"finishReason,omitempty"`
+	// SnapshotID is the snapshot persisted at the end of this turn, if any.
+	SnapshotID string `json:"snapshotId,omitempty"`
+}
+```
+
+Those four fields are the whole chunk, and more than one can be set on a single chunk. There is no interrupt field and no detach field: interrupts arrive on `chunk.ModelChunk`, so read them with `chunk.ModelChunk.Interrupts()`, and a detach is reported on `AgentOutput.FinishReason`. Tool requests and responses stream as ordinary model chunk content, so a tool-call indicator reads `chunk.ModelChunk.Content`.
+
+### Finish reasons
+
+The first six values are forwarded verbatim from the model's own finish reason. The last three are agent-specific and never arise from a model.
+
+| Constant | Wire value | Meaning |
+| --- | --- | --- |
+| `aix.AgentFinishReasonStop` | `stop` | The model stopped naturally. |
+| `aix.AgentFinishReasonLength` | `length` | Generation hit the token limit. |
+| `aix.AgentFinishReasonBlocked` | `blocked` | Generation was blocked, usually by a safety filter. |
+| `aix.AgentFinishReasonInterrupted` | `interrupted` | A tool paused for input. See [Agent interrupts](/docs/agents/interrupts). |
+| `aix.AgentFinishReasonOther` | `other` | The model stopped for some other reason. |
+| `aix.AgentFinishReasonUnknown` | `unknown` | The model gave no reason. |
+| `aix.AgentFinishReasonAborted` | `aborted` | The turn or invocation was aborted. |
+| `aix.AgentFinishReasonDetached` | `detached` | The client detached and the work continues in the background. |
+| `aix.AgentFinishReasonFailed` | `failed` | The turn or invocation ended in an error. Read `out.Error`. |
 
 ## Invocation options
 
+`Run`, `RunText`, and `Connect` all take the same `aix.InvocationOption[State]` values.
+
+```go
+func WithSessionID[State any](id string) InvocationOption[State]
+func WithSnapshotID[State any](id string) InvocationOption[State]
+func WithState[State any](state *SessionState[State]) InvocationOption[State]
+```
+
 - **`aix.WithSessionID[State](id)`** resumes the latest server-managed snapshot for a conversation.
-- **`aix.WithSnapshotID[State](id)`** resumes or branches from a specific server-managed snapshot.
+- **`aix.WithSnapshotID[State](id)`** resumes or branches from a specific server-managed snapshot. See [Session stores](/docs/agents/session-stores).
 - **`aix.WithState[State](state)`** continues a client-managed conversation by sending the full state.
 
 `WithState` is mutually exclusive with `WithSessionID` and `WithSnapshotID`. `WithSessionID` and `WithSnapshotID` can be combined to assert that the snapshot belongs to the session.
@@ -183,13 +278,45 @@ next, err := weatherAgent.RunText(ctx, "What about Paris?",
 )
 ```
 
+Because all three return the same interface type, you can build the list up and spread it into any entry point:
+
+```go
+opts := []aix.InvocationOption[WeatherState]{}
+if sessionID != "" {
+	opts = append(opts, aix.WithSessionID[WeatherState](sessionID))
+}
+
+out, err := weatherAgent.RunText(ctx, "What about Paris?", opts...)
+```
+
+## Bounding a turn
+
+There is no per-turn deadline option. Cap the tool loop inside a turn with `ai.WithMaxTurns(n)` in the agent's `aix.InlinePrompt`, and bound wall-clock time with `context.WithTimeout` on the context you pass to `Run`, `RunText`, or `Connect`.
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+
+out, err := weatherAgent.RunText(ctx, "Plan a two-week itinerary.")
+```
+
+Cancelling that context ends the invocation: `Run`, `RunText`, and `Output` return a non-nil error, and the in-flight turn writes no snapshot, so the last committed turn's snapshot stays the resume point. A custom agent should also check `ctx.Err()` between turns.
+
 ## Open a bidirectional stream
 
 Use `Connect` for multi-turn local clients and streaming UIs. The connection lets you send text, messages, resume payloads, or a detach signal while receiving chunks.
 
 Reach for `Connect` when the caller needs direct control over both sides of the conversation on one live connection. It is useful for command-line tools, local services, workers, and lower-level integrations that need to stream output, observe custom state patches, handle interrupts, send a resume payload, or send another message after a `TurnEnd` without reconnecting.
 
-For most single-turn server code, use `RunText` or `Run`. For browser, mobile, and other HTTP clients, use the JavaScript `chat().send()` and `chat().sendStream()` clients through `remoteAgent()` rather than managing a bidirectional stream directly.
+For most single-turn server code, use `RunText` or `Run`. For browser, mobile, and other HTTP clients, [serve the agent over HTTP](/docs/agents/http) and drive it from the prebuilt client rather than managing a bidirectional stream directly.
+
+`Connect` takes the same invocation options as `Run` and `RunText`, so a streaming connection can resume a stored conversation:
+
+```go
+conn, err := weatherAgent.Connect(ctx, aix.WithSessionID[WeatherState](previousSessionID))
+```
+
+A full turn over a fresh connection:
 
 ```go
 conn, err := weatherAgent.Connect(ctx)
@@ -197,6 +324,7 @@ if err != nil {
 	// Connect fails when the init payload is rejected before any turn runs.
 	return fmt.Errorf("connect to agent: %w", err)
 }
+defer conn.Close()
 
 if err := conn.SendText("Weather in Tokyo?"); err != nil {
 	return fmt.Errorf("send message: %w", err)
@@ -223,9 +351,21 @@ if err != nil {
 fmt.Println(out.SnapshotID)
 ```
 
-Breaking from `Receive` does not cancel the connection. Multi-turn clients commonly break on `TurnEnd`, send another input, and call `Receive` again. Call `Output()` when the invocation should finish. Do not call `Output()` from one goroutine while another goroutine is iterating `Receive`.
+Breaking from `Receive` does not cancel the connection. Multi-turn clients commonly break on `TurnEnd`, send another input, and call `Receive` again.
 
 The `cli.go` file of [`go/samples/basic-agents`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) is a complete client written this way: it streams each turn, renders tool calls, routes interrupts, and drives detach and resume, all against the `Agent` and `AgentConnection` surface.
+
+## Connection lifecycle
+
+- **`conn.Close()`** signals that no more inputs will be sent. Write `defer conn.Close()` right after `Connect` so an early return on an error path still releases the invocation.
+- **`conn.Output()`** is the terminator. It closes the input side for you, drains any chunks `Receive` did not consume, and blocks until the agent finalizes. It is idempotent, so the deferred `Close` and a later `Output()` do not conflict.
+- **`conn.Done()`** returns a channel closed when the invocation completes, for a caller that waits on it in a `select`.
+
+## Concurrency
+
+An `Agent` value is immutable after definition and safe for concurrent use. Share one `*aix.Agent[State]` across every HTTP handler and call `Run`, `RunText`, `Connect`, `GetSnapshot`, `GetLatestSnapshot`, and `Abort` from any goroutine.
+
+An `AgentConnection` belongs to one invocation and is not a shared object. Do not call `Output()` from one goroutine while another iterates `Receive()`: both consume the stream and would split chunks between them. Finish `Receive` first.
 
 ## Live custom state
 
@@ -247,7 +387,18 @@ for chunk, err := range conn.Receive() {
 }
 ```
 
+`Custom()` returns `(State, error)`, the state value itself rather than a pointer, so there is nothing to nil-check. Before the first patch of a turn arrives it returns the zero value of `State`. The error is non-nil only when an applied patch cannot decode into `State`. The patch itself is an RFC 6902 JSON Patch rooted at the custom document; see [Sessions and state](/docs/agents/state).
+
 The authoritative final state is on `AgentOutput.State` for client-managed agents, or in the saved snapshot for server-managed agents.
+
+## Next steps
+
+- [Sessions and state](/docs/agents/state) covers custom state, artifacts, and how patches are produced.
+- [Session stores](/docs/agents/session-stores) covers snapshot IDs, branching, and store implementations.
+- [Agent interrupts](/docs/agents/interrupts) covers building the `Resume` payload.
+- [Background execution](/docs/agents/background) covers detach, snapshot polling, and abort.
+- [Serve agents over HTTP](/docs/agents/http) covers the wire protocol and browser clients.
+- [Agent error handling](/docs/agents/errors) covers failed turns and rejected init payloads.
 
 </Lang>
 

--- a/src/content/docs/docs/agents/session-stores.mdx
+++ b/src/content/docs/docs/agents/session-stores.mdx
@@ -14,7 +14,7 @@ import Lang from '../../../../components/Lang.astro';
 The Agents API is in **Beta.** It can introduce breaking changes in minor version releases.
 :::
 
-Session stores persist snapshots for server-managed agents. They are the storage layer behind `sessionId`, `snapshotId`, `loadChat()`, snapshot reads, branching, background execution, and aborting detached work.
+Session stores persist snapshots for server-managed agents. They are the storage layer behind `sessionId` and `snapshotId` resumption, snapshot reads, branching, background execution, and aborting detached work.
 
 Use the [Sessions and state](/docs/agents/state) guide first when you are deciding between server-managed and client-managed state. Use this page when you know the server should own state and need to choose or implement the persistence layer.
 
@@ -297,7 +297,38 @@ class MyDatabaseSessionStore implements SessionStore {
 - **Firestore store** for production apps on Google Cloud or Firebase that want a managed, multi-instance database without writing a store.
 - **Custom store** for production web apps that need a different database, cloud storage, centralized authorization, retention policies, or tenant-aware persistence that the built-in stores do not cover.
 
-Most applications only pass a store to `aix.WithSessionStore(store)`. The agent runtime calls the store when it creates a snapshot, resumes with `aix.WithSessionID` or `aix.WithSnapshotID`, exposes snapshot companion actions, starts detached work, or aborts an in-flight turn.
+Most applications only pass a store to `aix.WithSessionStore(store)`. The agent runtime calls the store when it creates a snapshot, resumes with `aix.WithSessionID` or `aix.WithSnapshotID`, serves `Agent.GetSnapshot` and `Agent.GetLatestSnapshot`, starts detached work, or aborts an in-flight turn with `Agent.Abort`.
+
+## The snapshot record
+
+Every store method reads or writes an `aix.SessionSnapshot[State]`. Both the built-in stores and a custom store move this value verbatim:
+
+```go
+type SessionSnapshot[State any] struct {
+	SnapshotID   string               `json:"snapshotId"`
+	SessionID    string               `json:"sessionId,omitempty"`
+	ParentID     string               `json:"parentId,omitempty"`
+	State        *SessionState[State] `json:"state,omitempty"`
+	Status       SnapshotStatus       `json:"status,omitempty"`
+	FinishReason AgentFinishReason    `json:"finishReason,omitempty"`
+	Error        *status.Error        `json:"error,omitempty"`
+	CreatedAt    time.Time            `json:"createdAt"`
+	UpdatedAt    time.Time            `json:"updatedAt,omitempty"`
+	HeartbeatAt  *time.Time           `json:"heartbeatAt,omitempty"`
+}
+```
+
+The runtime owns the meaning of `SnapshotID`, `SessionID`, `ParentID`, `State`, `Status`, `FinishReason`, `Error`, and `HeartbeatAt`. The store owns durable persistence: it must preserve `SessionID` across rewrites, and it must not advance `UpdatedAt` on a heartbeat-only refresh, so liveness stays distinct from state changes. `SessionState[State]` is described on [Sessions and state](/docs/agents/state).
+
+`Status` is an `aix.SnapshotStatus`, a string with five constants: `pending`, `completed`, `failed`, `aborted`, `expired`.
+
+Three traps that the rest of this page depends on:
+
+- The ID field is `SnapshotID`. There is no `ID`.
+- `State` is a pointer and is nil on a `pending` snapshot, because a detached invocation has not committed its state yet. Check it before reading `snap.State.Messages`, `snap.State.Custom`, or `snap.State.Artifacts`.
+- An empty `Status` must be read as `completed`, for backwards compatibility. `SnapshotStatusExpired` is never persisted: it is computed on read from a stale `HeartbeatAt`, so the raw row stays `pending`.
+
+Full field documentation is on [pkg.go.dev](https://pkg.go.dev/github.com/firebase/genkit/go/ai/exp#SessionSnapshot).
 
 ## Use an in-memory store
 
@@ -346,15 +377,83 @@ if err != nil {
 }
 ```
 
+`NewFileSessionStore[State]` returns `(*localstore.FileSessionStore[State], error)`. The in-memory and Firestore constructors likewise return their concrete types, `*localstore.InMemorySessionStore[State]` and `(*firebasex.FirestoreSessionStore[State], error)`. All of them satisfy `aix.SessionStore[State]`, so hold one in a struct field or pass it around typed as the interface:
+
+```go
+type Service struct {
+	Store aix.SessionStore[SupportState]
+}
+```
+
+Type the value concretely only when you need methods that a specific store adds.
+
 Snapshots are written under the directory passed to `NewFileSessionStore`, inside a subdirectory named by the path prefix. Without the option, every session shares one `global` subdirectory. Each agent in [`go/samples/basic-agents`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-agents) keeps its own file store under `./.genkit/snapshots/<agent>/`, so conversations survive a restart of the command-line client.
 
 Use `WithMaxPersistedChainLength` to bound how many snapshots are retained in one parent chain. A value of `1` keeps only the latest snapshot in a chain. Omitting the option leaves pruning disabled. Pruning follows parent links, so sibling branches are pruned independently when they are extended.
 
-Use `WithSnapshotPathPrefix` to scope reads and writes to a subdirectory. Return a stable tenant or user identity from `context.Context` so one caller cannot read another caller's snapshots. Prefixes may contain `/` for nested directories, but values that escape the store directory are rejected.
+Use `WithSnapshotPathPrefix` to scope reads and writes to a subdirectory. Return a stable tenant or user identity from `context.Context` so one caller cannot read another caller's snapshots. Prefixes may contain `/` for nested directories, but values that escape the store directory are rejected. See [Scope a store by tenant](#scope-a-store-by-tenant) for where the identity in `ctx` comes from.
 
 Use `WithPollInterval` to control how often the file store checks for status changes written by another process or store instance sharing the same directory. The default is one second. A value less than or equal to zero disables cross-process polling, so subscriptions observe only changes written through the same store instance.
 
 The file store is safe for concurrent use inside one process, writes snapshots atomically with temporary files and rename, and implements `aix.SnapshotSubscriber`. It is still a local filesystem store, so use a custom store when many app instances need to coordinate durable sessions.
+
+## Scope a store by tenant
+
+Both `WithSnapshotPathPrefix` options take a `func(ctx context.Context) string`. The `ctx` they receive is the request context the handler built, so the tenant identity travels from the HTTP request into the store through the action context.
+
+Populate the action context with `genkit.WithContextProviders` when you mount the routes:
+
+```go
+import (
+	"context"
+	"net/http"
+
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/genkit"
+	genkitx "github.com/firebase/genkit/go/genkit/exp"
+)
+```
+
+```go
+for _, route := range genkitx.AgentRoutes(supportAgent) {
+	mux.HandleFunc(route.Pattern(), route.Handler(
+		genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+			// Authenticate the request first, then return the identity it proved.
+			return core.ActionContext{"tenantId": req.Headers["x-tenant-id"]}, nil
+		}),
+	))
+}
+```
+
+Read it back out inside the prefix function with `core.FromContext`:
+
+```go
+func tenantIDFromContext(ctx context.Context) string {
+	tenantID, _ := core.FromContext(ctx)["tenantId"].(string)
+	if tenantID == "" {
+		return "global"
+	}
+	return tenantID
+}
+```
+
+The prefix is recomputed from `context.Context` on every store call, so there is no operator bypass. A privileged reader such as a support console or a back-office approval queue must authorize the operator first, then build a context whose prefix function resolves to the target tenant, and only then read:
+
+```go
+ctx = core.WithActionContext(ctx, core.ActionContext{"tenantId": targetTenant})
+
+snap, err := supportAgent.GetSnapshot(ctx, snapshotID)
+```
+
+Do the authorization check outside the prefix function. The prefix is a scoping mechanism, not an access-control check.
+
+## Concurrent turns on one session
+
+The runtime does not serialize invocations that share a `sessionId`. Two concurrent turns both resume from the same latest snapshot and both commit, creating sibling snapshots with the same `ParentID`. The next `GetLatestSnapshot` returns whichever was created last, so the other turn's changes stop being reachable without its `snapshotId`.
+
+Serialize turns per session in your application: a per-session lock, a queue, or disabling the send button client-side. To detect a fork after the fact, compare the `snapshotId` you resumed from with `AgentOutput.SnapshotID`.
+
+An `*aix.Agent` is read-only after definition and safe to share across goroutines. An `*aix.AgentConnection` is a single-owner value: do not call `Output()` from one goroutine while another iterates `Receive()`.
 
 ## Use a Firestore store
 
@@ -370,7 +469,10 @@ import (
 ```
 
 ```go
-g := genkit.Init(ctx, genkit.WithPlugins(&firebase.Firebase{ProjectId: "my-project"}))
+g := genkit.Init(ctx,
+	genkit.WithExperimental(),
+	genkit.WithPlugins(&firebase.Firebase{ProjectId: "my-project"}),
+)
 
 store, err := firebasex.NewFirestoreSessionStore[SupportState](ctx, g,
 	firebasex.WithCollection("genkit-sessions"),

--- a/src/content/docs/docs/agents/session-stores.mdx
+++ b/src/content/docs/docs/agents/session-stores.mdx
@@ -322,11 +322,11 @@ The runtime owns the meaning of `SnapshotID`, `SessionID`, `ParentID`, `State`, 
 
 `Status` is an `aix.SnapshotStatus`, a string with five constants: `pending`, `completed`, `failed`, `aborted`, `expired`.
 
-Three traps that the rest of this page depends on:
+Important implementation details:
 
-- The ID field is `SnapshotID`. There is no `ID`.
-- `State` is a pointer and is nil on a `pending` snapshot, because a detached invocation has not committed its state yet. Check it before reading `snap.State.Messages`, `snap.State.Custom`, or `snap.State.Artifacts`.
-- An empty `Status` must be read as `completed`, for backwards compatibility. `SnapshotStatusExpired` is never persisted: it is computed on read from a stale `HeartbeatAt`, so the raw row stays `pending`.
+- The identifier field is `SnapshotID`.
+- `State` is a pointer and is nil on a `pending` snapshot, because a detached invocation has not committed its state yet. Check for nil before reading `snap.State.Messages`, `snap.State.Custom`, or `snap.State.Artifacts`.
+- An empty `Status` should be treated as `completed` for backwards compatibility. `SnapshotStatusExpired` is not directly persisted; it is computed on read from a stale `HeartbeatAt`, while the underlying record remains `pending`.
 
 Full field documentation is on [pkg.go.dev](https://pkg.go.dev/github.com/firebase/genkit/go/ai/exp#SessionSnapshot).
 

--- a/src/content/docs/docs/agents/state.mdx
+++ b/src/content/docs/docs/agents/state.mdx
@@ -282,6 +282,8 @@ sess.UpdateCustom(func(state TravelState) TravelState {
 
 A tool reaches the same session through its context with `aix.SessionFromContext[State]`. The updater takes and returns the state as its own Go type, so a mistyped field is a compile error rather than a lost key.
 
+`SessionFromContext[State]` returns nil in two cases: there is no session in context, and the active session's state type is not `State`. A tool shared between agents with different state types therefore gets nil from the mismatching agent, with no error. Fail closed on nil. Return a `status.ErrFailedPrecondition` (or `status.ErrPermissionDenied` when the state carries scoping) rather than treating nil as an empty identity, or the tool silently drops whatever it derived from state.
+
 ```go
 import (
 	aix "github.com/firebase/genkit/go/ai/exp"
@@ -397,6 +399,15 @@ These methods apply `WithStateTransform` and read-time shaping. Reading `agent.S
 
 Synchronous turns write `completed` snapshots. A failed turn does not make its partial state the normal continuation point. The output reports the last-good state or snapshot ID.
 
+`Status` is the persistence lifecycle, not the outcome. A turn that ends on an interrupt still writes `completed`, because it is resumable. To detect an interrupt, read `snap.FinishReason`, which is a separate field:
+
+```go
+paused := snap.Status == aix.SnapshotStatusCompleted &&
+	snap.FinishReason == aix.AgentFinishReasonInterrupted
+```
+
+`FinishReason` carries the semantic outcome of the turn or invocation the snapshot captured: `aix.AgentFinishReasonStop`, `AgentFinishReasonInterrupted`, `AgentFinishReasonFailed`, `AgentFinishReasonAborted`, and the other values on `aix.AgentFinishReason`. See [Agent interrupts](/docs/agents/interrupts) for what a paused turn allows next.
+
 ## Invocation options
 
 Use `WithSessionID` when the caller tracks a conversation:
@@ -425,6 +436,18 @@ out, err := agent.RunText(ctx, "Add buy milk.",
 
 An empty session ID is rejected. `WithState` cannot be combined with snapshot or session options.
 
+You may also choose the session ID yourself. If `aix.WithSessionID(id)` resolves no existing snapshot, the runtime starts a fresh conversation under that ID and stamps it on every snapshot it persists, so a client can mint a UUID up front instead of waiting for a server-issued ID. `SessionID` is framework-owned only in the sense that the framework mints one when you supply none, and that for server-managed agents the snapshot row's ID is canonical.
+
+## Changing your state type
+
+Custom state is persisted as plain JSON and decoded with `encoding/json`. That gives three rules:
+
+- **Adding a field is safe.** Old snapshots load it as the Go zero value.
+- **Removing or renaming a field is safe to load, but drops the old data silently.** Nothing rejects the unknown key.
+- **Changing a field's JSON type is not safe.** The decode fails, the store read returns an error, and the resume fails with it.
+
+Keep changes additive. Keep an old field readable with its original `json` tag through a migration window, and carry your own version field inside `Custom` when you need to branch on shape. There is no schema version on the snapshot envelope.
+
 ## State and stream transforms
 
 `WithStateTransform` redacts or reshapes session state on the way out to clients. It applies to snapshot reads and client-managed output, not to persisted raw state or the agent function's internal view.
@@ -442,15 +465,61 @@ agent := genkitx.DefineAgent(g, "support",
 )
 ```
 
-`WithStreamTransform[State]` runs on every streamed `AgentStreamChunk` at the wire boundary. Return `nil` to drop a chunk. Return an error to fail closed, which prevents unshaped data from reaching the client.
+`aix.WithStreamTransform[State](fn)` runs on every streamed chunk at the wire boundary. It takes a `func(ctx context.Context, chunk *aix.AgentStreamChunk) (*aix.AgentStreamChunk, error)`. A chunk carries no state type, so `State` cannot be inferred and must be written out.
 
-Prefer `WithStateTransform` for custom state redaction because the runtime diffs transformed state before emitting custom patches.
+```go
+aix.WithStreamTransform[SupportState](func(ctx context.Context, chunk *aix.AgentStreamChunk) (*aix.AgentStreamChunk, error) {
+	if chunk.Artifact != nil && chunk.Artifact.Name == "internal-notes" {
+		// Drop the chunk from the wire; the session still records the artifact.
+		return nil, nil
+	}
+	return chunk, nil
+})
+```
+
+`AgentStreamChunk` has four fields, and more than one can be set on a single chunk:
+
+| Field         | Type                       | Contents                                              |
+| ------------- | -------------------------- | ----------------------------------------------------- |
+| `ModelChunk`  | `*ai.ModelResponseChunk`   | Generation tokens from the model.                     |
+| `Artifact`    | `*aix.Artifact`            | A newly produced artifact.                            |
+| `CustomPatch` | `aix.JSONPatch`            | An RFC 6902 delta to custom state.                    |
+| `TurnEnd`     | `*aix.TurnEnd`             | The turn-end signal, including the new snapshot ID.   |
+
+The chunk is a fresh deep copy the transform owns, so mutating it in place is safe. Returning `nil` drops the chunk from the wire only: side effects and the final `AgentOutput` keep the data. Never drop a chunk whose `TurnEnd` is set, because clients pace the conversation on that signal; reshape it instead. Returning an error fails the whole invocation, which is the fail-closed behavior you want when a chunk cannot be shaped safely.
+
+Prefer `WithStateTransform` for custom state redaction. The runtime applies it before diffing, so the patch stream stays consistent; rewriting `CustomPatch` in a stream transform desyncs clients that rebuild custom state from the patch sequence.
 
 ## Custom state and artifacts
 
 Prompt-backed and custom agents can update state through the active session. Custom patches are streamed automatically when custom state changes. `AgentConnection.Receive` applies those patches and `AgentConnection.Custom()` returns the live custom state observed so far.
 
-Artifacts are named collections of parts. `Responder.SendArtifact` both streams the artifact and records it in the session, so the artifact is available in the final output or snapshot.
+An artifact is a named collection of parts:
+
+```go
+type Artifact struct {
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Name     string         `json:"name,omitempty"`
+	Parts    []*ai.Part     `json:"parts"`
+}
+```
+
+`Responder.SendArtifact` takes a pointer. It both streams the artifact and records it in the session, so the artifact is available in the final output or snapshot:
+
+```go
+resp.SendArtifact(&aix.Artifact{
+	Name:     "meal-plan",
+	Parts:    []*ai.Part{ai.NewTextPart(draft)},
+	Metadata: map[string]any{"contentType": "text/markdown"},
+})
+```
+
+Read them back from `out.Artifacts` on an `*aix.AgentOutput[State]`, from `snap.State.Artifacts` on a snapshot, or from `sess.Artifacts()` inside a run. `SendArtifact` appends and does not deduplicate names, so two sends with the same `Name` produce two entries. Call `sess.UpdateArtifacts` when you want to replace one instead.
+
+## Next steps
+
+- [Session stores](/docs/agents/session-stores) covers the built-in stores and the `SessionStore` interface a custom store implements.
+- [Background execution](/docs/agents/background) covers detached turns and pending snapshots.
 
 </Lang>
 

--- a/src/content/docs/docs/api-references.mdx
+++ b/src/content/docs/docs/api-references.mdx
@@ -38,12 +38,20 @@ The JavaScript API reference provides complete documentation for all Genkit modu
 
 ## Go API reference
 
-The Go API reference provides complete documentation for all Genkit packages, including:
+Genkit Go is one module, `github.com/firebase/genkit/go`, split across the packages below. Godoc for each is on pkg.go.dev; the guide column is the narrative page that explains when to reach for it.
 
-- **Core APIs**: Flow definitions, model configurations, and generation methods
-- **Plugin APIs**: Integration with AI providers and vector databases
-- **Context APIs**: Request context and lifecycle management
-- **Error Handling**: Comprehensive error types and handling patterns
+| Package | What's in it | Guide |
+| :------ | :----------- | :---- |
+| [`genkit`](https://pkg.go.dev/github.com/firebase/genkit/go/genkit) | `Init`, `DefineFlow`, `DefineStreamingFlow`, `DefineTool`, `Generate`, `GenerateData`, `GenerateDataStream`, `Handler`, `HandlerFunc`, and the `genkit.With*` options | [Flows](/docs/flows), [Serve flows over HTTP](/docs/backend-frameworks/overview) |
+| [`ai`](https://pkg.go.dev/github.com/firebase/genkit/go/ai) | The generation types (`Message`, `Part`, `ModelRequest`, `ModelResponse`), tool and prompt types (`ToolContext`, `Tool`, `Prompt`), retrievers, embedders, and the `ai.With*` request options | [Generating content](/docs/models), [Tool calling](/docs/tool-calling) |
+| [`core`](https://pkg.go.dev/github.com/firebase/genkit/go/core) | Action context: `ActionContext`, `WithActionContext`, `FromContext`, `ContextProvider`, `RequestData` | [Passing information through context](/docs/context) |
+| [`core/status`](https://pkg.go.dev/github.com/firebase/genkit/go/core/status) | Error classification: the status vocabulary, `Errorf`, `PublicErrorf`, `Of`, `HTTPCode` | [Error types](/docs/error-types) |
+| [`core/api`](https://pkg.go.dev/github.com/firebase/genkit/go/core/api) | The `Action`, `BidiAction`, and `Registry` interfaces that transports and plugins are written against | [Writing plugins](/docs/plugin-authoring/overview) |
+| [`ai/exp`](https://pkg.go.dev/github.com/firebase/genkit/go/ai/exp), [`genkit/exp`](https://pkg.go.dev/github.com/firebase/genkit/go/genkit/exp), [`ai/exp/localstore`](https://pkg.go.dev/github.com/firebase/genkit/go/ai/exp/localstore) | Preview: agents, sessions and snapshots, and the `context.Context` tool signature | [Agents](/docs/agents/overview), [API stability channels](/docs/api-stability) |
+| [`core/x/streaming`](https://pkg.go.dev/github.com/firebase/genkit/go/core/x/streaming) | Preview: `StreamManager` and the in-memory implementation | [Durable streaming](/docs/durable-streaming) |
+| [`plugins/...`](https://pkg.go.dev/github.com/firebase/genkit/go/plugins) | Model, vector store, and observability providers, one subpackage each | [Integrations](/docs/integrations/model-providers) |
+
+Deprecations are marked in godoc, so check the symbol page before you adopt an option: `ai.WithMiddleware`, for example, is marked `Deprecated: Use WithUse instead`.
 
 <LinkButton
   href="https://pkg.go.dev/github.com/firebase/genkit/go"
@@ -53,6 +61,13 @@ The Go API reference provides complete documentation for all Genkit packages, in
 >
   View Go API Reference
 </LinkButton>
+
+You can also read the same reference offline with `go doc`, which is often faster than the website:
+
+```bash
+go doc github.com/firebase/genkit/go/genkit Handler
+go doc -all github.com/firebase/genkit/go/ai | less
+```
 
 </Lang>
 

--- a/src/content/docs/docs/api-stability.mdx
+++ b/src/content/docs/docs/api-stability.mdx
@@ -72,13 +72,21 @@ for beta features. You can modify your existing dependency string by changing
 
 Genkit follows [semantic versioning](https://semver.org/) guidelines for version updates. Everything in `github.com/firebase/genkit/go` except the packages listed below is stable, and takes breaking changes only in a major release.
 
+## Versioning and pinning
+
+Genkit Go is in the v1 series. The module path stays `github.com/firebase/genkit/go` for the whole series; a v2 would take a `/v2` suffix, so a major bump can never break your build silently. The module requires **Go 1.25 or later**.
+
+In Go, pinning is what `go.mod` already does. `go get github.com/firebase/genkit/go@v1.9.0` records that exact version, and you only move off it by running `go get -u` or editing the requirement yourself. See the [release notes](https://github.com/genkit-ai/genkit/releases) for what changed between versions.
+
 ## Preview APIs
 
-A few features ship ahead of that guarantee so you can build on them and send feedback while their shape is still settling. Each lives in its own package, and each may take a breaking change in a minor release, so pin your Genkit version if you depend on one.
+A few features ship ahead of that guarantee so you can build on them and send feedback while their shape is still settling. **Preview** is the name for this channel throughout the docs, and a page that carries a `:::caution[Preview]` admonition is in it. In code, the channel shows up two ways: the package suffix `exp` (or `x`), and the `genkit.WithExperimental()` opt-in. Each preview API may take a breaking change in a minor release, so pin your Genkit version if you depend on one.
 
-- **Tools with a plain `context.Context` signature** (`ai/exp`, `ai/exp/tool`, `genkit/exp`): `genkitx.DefineTool` and `genkitx.DefineInterruptibleTool`, whose functions take a `context.Context` rather than an `*ai.ToolContext`, and whose interrupt payload is a typed value rather than a metadata map. They complement the stable [tool APIs](/docs/tool-calling) rather than replacing them.
-- **Agents** (`ai/exp`, `genkit/exp`, `plugins/middleware/exp`): the [agent](/docs/agents/overview) constructors, session stores, HTTP route builders, and the multi-agent and artifact middleware.
-- **[Durable streaming](/docs/durable-streaming)** (`core/x/streaming`, `plugins/firebase/exp`): the `StreamManager` API that lets a client reconnect to a stream by ID.
+Throughout these docs `genkitx` is an import alias for `github.com/firebase/genkit/go/genkit/exp`, and `aix` for `github.com/firebase/genkit/go/ai/exp`. Both packages declare themselves `exp`, so the aliases keep the two apart.
+
+- **Tools with a plain `context.Context` signature** (`github.com/firebase/genkit/go/ai/exp`, `.../ai/exp/tool`, `.../genkit/exp`): `genkitx.DefineTool` and `genkitx.DefineInterruptibleTool`, whose functions take a `context.Context` rather than an `*ai.ToolContext`, and whose interrupt payload is a typed value rather than a metadata map. They complement the stable [tool APIs](/docs/tool-calling) rather than replacing them.
+- **Agents** (`github.com/firebase/genkit/go/ai/exp`, `.../ai/exp/localstore`, `.../genkit/exp`, `.../plugins/middleware/exp`): the [agent](/docs/agents/overview) constructors, session stores, HTTP route builders, and the multi-agent and artifact middleware.
+- **[Durable streaming](/docs/durable-streaming)** (`github.com/firebase/genkit/go/core/x/streaming`, `.../plugins/firebase/exp`): the `StreamManager` API that lets a client reconnect to a stream by ID.
 
 The `genkit/exp` constructors require opting in. Pass `genkit.WithExperimental()` to `genkit.Init`, or they panic with a message pointing back to that option.
 

--- a/src/content/docs/docs/api-stability.mdx
+++ b/src/content/docs/docs/api-stability.mdx
@@ -72,15 +72,15 @@ for beta features. You can modify your existing dependency string by changing
 
 Genkit follows [semantic versioning](https://semver.org/) guidelines for version updates. Everything in `github.com/firebase/genkit/go` except the packages listed below is stable, and takes breaking changes only in a major release.
 
-## Versioning and pinning
+## Versioning
 
 Genkit Go is in the v1 series. The module path stays `github.com/firebase/genkit/go` for the whole series; a v2 would take a `/v2` suffix, so a major bump can never break your build silently. The module requires **Go 1.25 or later**.
 
-In Go, pinning is what `go.mod` already does. `go get github.com/firebase/genkit/go@v1.9.0` records that exact version, and you only move off it by running `go get -u` or editing the requirement yourself. See the [release notes](https://github.com/genkit-ai/genkit/releases) for what changed between versions.
+Running `go get github.com/firebase/genkit/go` records the dependency version in your `go.mod`. You can update to newer releases using `go get -u`. See the [release notes](https://github.com/genkit-ai/genkit/releases) for what changed between versions.
 
 ## Preview APIs
 
-A few features ship ahead of that guarantee so you can build on them and send feedback while their shape is still settling. **Preview** is the name for this channel throughout the docs, and a page that carries a `:::caution[Preview]` admonition is in it. In code, the channel shows up two ways: the package suffix `exp` (or `x`), and the `genkit.WithExperimental()` opt-in. Each preview API may take a breaking change in a minor release, so pin your Genkit version if you depend on one.
+A few features ship ahead of that guarantee so you can build on them and send feedback while their shape is still settling. **Preview** is the name for this channel throughout the docs, and a page that carries a `:::caution[Preview]` admonition is in it. In code, the channel shows up two ways: the package suffix `exp` (or `x`), and the `genkit.WithExperimental()` opt-in. Each preview API may experience breaking changes in minor releases while its shape is stabilizing.
 
 Throughout these docs `genkitx` is an import alias for `github.com/firebase/genkit/go/genkit/exp`, and `aix` for `github.com/firebase/genkit/go/ai/exp`. Both packages declare themselves `exp`, so the aliases keep the two apart.
 

--- a/src/content/docs/docs/backend-frameworks/chi.mdx
+++ b/src/content/docs/docs/backend-frameworks/chi.mdx
@@ -46,6 +46,7 @@ go get github.com/firebase/genkit/go
 go get github.com/firebase/genkit/go/plugins/googlegenai
 go get github.com/go-chi/chi/v5
 go get github.com/go-chi/cors
+go get google.golang.org/genai
 ```
 
 These packages include:
@@ -54,6 +55,7 @@ These packages include:
 - **`github.com/firebase/genkit/go/plugins/googlegenai`**: Plugin that connects Genkit to Google's Gemini models.
 - **`github.com/go-chi/chi/v5`**: Chi router.
 - **`github.com/go-chi/cors`**: CORS middleware for Chi.
+- **`google.golang.org/genai`**: Google's GenAI Go SDK. The `googlegenai` plugin takes this SDK's own `*genai.GenerateContentConfig` as its model configuration, so you import it directly to tune a request.
 
 ### Configure a model API key
 
@@ -235,6 +237,15 @@ A few details are worth noting:
 - **The `getIngredientsOnSale` tool:** The model decides when to call it based on the prompt, letting it reach outside its training data and into your code to fetch live sale prices before finalizing the recipe. The `SaleQuery` input struct forces the model to pass `dayType: "weekday"` or `"weekend"`; Genkit derives the JSON schema from the Go type, including the enum constraint declared in the `jsonschema` tag. In a real app, the tool would query a pricing database, inventory system, or third-party API.
 - **`sendChunk`:** `genkit.DefineStreamingFlow` registers a flow that accepts a `sendChunk` callback. Inside, `genkit.GenerateDataStream[Recipe]` yields typed partial recipes as the model produces them, and the loop forwards each chunk to the caller so a client UI can fill in field by field. When the iterator reports `Done`, the flow returns the validated final recipe so the HTTP request still resolves with a complete value.
 - **CORS:** `AllowedOrigins: []string{"*"}` allows **all origins**, so any browser frontend can call this endpoint during development. Before deploying, restrict it to the origins you actually serve.
+- **Request context:** The flow runs with the request's own `r.Context()`, so values attached by Chi middleware are visible to the flow, its tools, and its prompts. For request-scoped identity, prefer `genkit.WithContextProviders(...)` and `core.FromContext(ctx)` over a raw context key. See [Passing information through context](/docs/context), and [the `genkit.Handler` contract](/docs/backend-frameworks/overview) for the full option set and the error and timeout behavior.
+
+### Tidy the module
+
+Resolve the imports and record them in `go.mod`:
+
+```bash
+go mod tidy
+```
 
 ### Check the project layout
 
@@ -341,6 +352,8 @@ You now have a standalone Genkit backend on Chi that streams structured output f
 
 - [Creating flows](/docs/flows): Compose multi-step flows, branch on input, and chain model calls.
 - [Generating content](/docs/models): Swap Gemini for another provider, tune sampling parameters, and work with multimodal input.
+- [Error types](/docs/error-types): Classify failures so the handler returns the right HTTP status, and control which messages reach the caller.
+- [Passing information through context](/docs/context): Get the caller's identity to your flow and tools without putting it in the model's input.
 - [Connect an app framework](/docs/app-frameworks/overview): Add a full-stack UI that calls your flow.
 - [Connect a web frontend](/docs/client): Wire a standalone web client up to this backend.
 - [Connect a Flutter app](/docs/app-frameworks/flutter): Stream the recipe into a Flutter UI.

--- a/src/content/docs/docs/backend-frameworks/echo.mdx
+++ b/src/content/docs/docs/backend-frameworks/echo.mdx
@@ -44,6 +44,7 @@ Install the Go packages you'll need:
 go get github.com/firebase/genkit/go
 go get github.com/firebase/genkit/go/plugins/googlegenai
 go get github.com/labstack/echo/v4
+go get google.golang.org/genai
 ```
 
 These packages include:
@@ -51,6 +52,7 @@ These packages include:
 - **`github.com/firebase/genkit/go`**: Core Genkit SDK.
 - **`github.com/firebase/genkit/go/plugins/googlegenai`**: Plugin that connects Genkit to Google's Gemini models.
 - **`github.com/labstack/echo/v4`**: Echo web framework.
+- **`google.golang.org/genai`**: Google's GenAI Go SDK. The `googlegenai` plugin takes this SDK's own `*genai.GenerateContentConfig` as its model configuration, so you import it directly to tune a request.
 
 ### Configure a model API key
 
@@ -216,6 +218,16 @@ The file builds the flow in four parts:
 
 The Echo wiring at the bottom mounts the flow as a single HTTP route. `genkit.Handler` returns a standard `http.HandlerFunc`, and `echo.WrapHandler` adapts it to Echo's handler signature. The handler emits server-sent events when the client requests them and returns a regular JSON response otherwise. `middleware.CORS()` allows **all origins**, so any browser frontend can call this endpoint during development; before deploying, use `middleware.CORSWithConfig(...)` to restrict it to the origins you actually serve.
 
+The flow runs with the request's own `r.Context()`, so values attached by Echo middleware are visible to the flow, its tools, and its prompts. For request-scoped identity, prefer `genkit.WithContextProviders(...)` and `core.FromContext(ctx)` over a raw context key. See [Passing information through context](/docs/context), and [the `genkit.Handler` contract](/docs/backend-frameworks/overview) for the full option set and the error and timeout behavior. If you route errors through Echo's centralized error handler, use `genkit.HandlerFunc`, which returns the error instead of writing it.
+
+### Tidy the module
+
+Resolve the imports and record them in `go.mod`:
+
+```bash
+go mod tidy
+```
+
 ### Check the project layout
 
 Verify that your project layout matches the structure below:
@@ -325,6 +337,8 @@ You now have a standalone Genkit backend on Echo that streams structured output 
 
 - [Creating flows](/docs/flows): Compose multi-step flows, branch on input, and chain model calls.
 - [Generating content](/docs/models): Swap Gemini for another provider, tune sampling parameters, and work with multimodal input.
+- [Error types](/docs/error-types): Classify failures so the handler returns the right HTTP status, and control which messages reach the caller.
+- [Passing information through context](/docs/context): Get the caller's identity to your flow and tools without putting it in the model's input.
 - [Connect an app framework](/docs/app-frameworks/overview): Add a full-stack UI that calls your flow.
 - [Connect a web frontend](/docs/client): Wire a standalone web client up to this backend.
 - [Connect a Flutter app](/docs/app-frameworks/flutter): Stream the recipe into a Flutter UI.

--- a/src/content/docs/docs/backend-frameworks/gin.mdx
+++ b/src/content/docs/docs/backend-frameworks/gin.mdx
@@ -45,6 +45,7 @@ go get github.com/firebase/genkit/go
 go get github.com/firebase/genkit/go/plugins/googlegenai
 go get github.com/gin-gonic/gin
 go get github.com/gin-contrib/cors
+go get google.golang.org/genai
 ```
 
 These packages include:
@@ -53,6 +54,7 @@ These packages include:
 - **`github.com/firebase/genkit/go/plugins/googlegenai`**: Plugin that connects Genkit to Google's Gemini models.
 - **`github.com/gin-gonic/gin`**: The Gin web framework.
 - **`github.com/gin-contrib/cors`**: CORS middleware so a browser-based frontend can call the backend.
+- **`google.golang.org/genai`**: Google's GenAI Go SDK. The `googlegenai` plugin takes this SDK's own `*genai.GenerateContentConfig` as its model configuration, so you import it directly to tune a request.
 
 ### Configure a model API key
 
@@ -209,7 +211,16 @@ A few details are worth noting:
 - **Final output and streamed chunks:** `genkit.GenerateDataStream[Recipe]` uses the `Recipe` struct both to validate the model's final output and as the type for each streamed partial chunk, so fields can still be at their zero value in the in-progress chunks emitted during streaming. Asking for the value type rather than `*Recipe` means the loop never needs a nil check; ask for `*Recipe` instead and Genkit skips only the chunks that arrive before the model opens the JSON object.
 - **The `getIngredientsOnSale` tool:** The model decides when to call it based on the prompt, and the typed `IngredientsOnSaleInput` struct forces the model to pass `dayType: "weekday"` or `"weekend"`. The `jsonschema` tags describe the schema to the model. In a real app, the tool would query a pricing database, inventory system, or third-party API.
 - **`sendChunk`:** `genkit.DefineStreamingFlow` takes a function that receives a `sendChunk` callback. The flow calls `genkit.GenerateDataStream`, which yields chunks as the model produces them, and forwards each one through `sendChunk` so the caller fills in field by field. When the stream is `Done`, the flow returns the final validated recipe.
-- **The Gin handler:** The server wraps the flow with `gin.WrapH(genkit.Handler(bargainChefFlow))`. `genkit.Handler` returns a standard `http.Handler` that parses the `{"data": ...}` envelope, validates input against the flow's schema, runs the flow, and writes either a JSON response or a `text/event-stream` of chunks based on the request's `Accept` header. `gin.WrapH` adapts that handler into a `gin.HandlerFunc` so it slots into Gin's routing and middleware (including `cors.Default()`) like any other route. `cors.Default()` allows **all origins**, so any browser frontend can call this endpoint during development; before deploying, configure `cors.New(...)` with the origins you actually serve.
+- **The Gin handler:** The server wraps the flow with `gin.WrapH(genkit.Handler(bargainChefFlow))`. `genkit.Handler` returns an `http.HandlerFunc` that parses the `{"data": ...}` envelope, validates input against the flow's schema, runs the flow, and writes either a JSON response or a `text/event-stream` of chunks based on the request's `Accept` header. `gin.WrapH` adapts that handler into a `gin.HandlerFunc` so it slots into Gin's routing and middleware (including `cors.Default()`) like any other route. `cors.Default()` allows **all origins**, so any browser frontend can call this endpoint during development; before deploying, configure `cors.New(...)` with the origins you actually serve.
+- **Request context:** The flow runs with the request's own `r.Context()`, so values attached by Gin middleware are visible to the flow, its tools, and its prompts. For request-scoped identity, prefer `genkit.WithContextProviders(...)` and `core.FromContext(ctx)` over a raw context key. See [Passing information through context](/docs/context), and [the `genkit.Handler` contract](/docs/backend-frameworks/overview) for the full option set and the error and timeout behavior.
+
+### Tidy the module
+
+Resolve the imports and record them in `go.mod`:
+
+```bash
+go mod tidy
+```
 
 ### Check the project layout
 
@@ -324,6 +335,8 @@ You now have a standalone Genkit backend on Gin that streams structured output f
 
 - [Creating flows](/docs/flows): Compose multi-step flows, branch on input, and chain model calls.
 - [Generating content](/docs/models): Swap Gemini for another provider, tune sampling parameters, and work with multimodal input.
+- [Error types](/docs/error-types): Classify failures so the handler returns the right HTTP status, and control which messages reach the caller.
+- [Passing information through context](/docs/context): Get the caller's identity to your flow and tools without putting it in the model's input.
 - [Connect an app framework](/docs/app-frameworks/overview): Add a full-stack UI that calls your flow.
 - [Connect a web frontend](/docs/client): Wire a standalone web client up to this backend.
 - [Deploy your app](/docs/deployment/overview): Ship to Cloud Run, Vercel, Firebase, or your own infrastructure.

--- a/src/content/docs/docs/backend-frameworks/nethttp.mdx
+++ b/src/content/docs/docs/backend-frameworks/nethttp.mdx
@@ -9,7 +9,7 @@ import { Aside, FileTree, LinkButton } from '@astrojs/starlight/components';
 
 In this tutorial, you'll build **Bargain Chef**, a standalone Genkit backend on net/http that exposes a recipe-generating flow over HTTP. It uses two AI patterns Genkit simplifies: streaming structured output and tool calling.
 
-Because `genkit.Handler` returns a standard `http.Handler`, you can mount it directly on a `net/http` mux with no router or adapter.
+Because `genkit.Handler` returns an `http.HandlerFunc`, you can mount it directly on a `net/http` mux with no router or adapter.
 
 ## What you'll build
 
@@ -44,12 +44,14 @@ Then install the Go packages you need:
 ```bash
 go get github.com/firebase/genkit/go
 go get github.com/firebase/genkit/go/plugins/googlegenai
+go get google.golang.org/genai
 ```
 
 These packages include:
 
 - **`github.com/firebase/genkit/go`**: Core Genkit SDK.
 - **`github.com/firebase/genkit/go/plugins/googlegenai`**: Plugin that connects Genkit to Google's Gemini models.
+- **`google.golang.org/genai`**: Google's GenAI Go SDK. The `googlegenai` plugin takes this SDK's own `*genai.GenerateContentConfig` as its model configuration, so you import it directly to tune a request.
 
 No third-party web framework is required: the HTTP server is built entirely with the standard library.
 
@@ -208,7 +210,8 @@ func main() {
 	)
 
 	mux := http.NewServeMux()
-	mux.Handle("POST /bargainChefFlow", withCORS(genkit.Handler(bargainChefFlow)))
+	// Registered without a method prefix so the CORS wrapper sees OPTIONS too.
+	mux.Handle("/bargainChefFlow", withCORS(genkit.Handler(bargainChefFlow)))
 
 	log.Println("net/http server listening on http://localhost:8080")
 	if err := http.ListenAndServe(":8080", mux); err != nil {
@@ -227,6 +230,10 @@ func withCORS(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }
@@ -238,9 +245,20 @@ A few details are worth noting:
 - **Final output and streamed chunks:** The `Recipe` struct (with `json` tags) is the structure of the final response. Genkit reflects on the type passed to `GenerateDataStream[Recipe]` to derive a JSON schema, then validates the model's output against it. Because the parser handles partial JSON, the same struct describes both the final response and each in-progress chunk emitted during streaming. Asking for the value type rather than `*Recipe` means the loop never needs a nil check: an early chunk arrives with every field still at its zero value, and the fields fill in as more of the model's JSON parses. Ask for `*Recipe` instead and Genkit skips only the chunks that arrive before the model opens the JSON object; after that you still get a non-nil `*Recipe` with every field at its zero value.
 - **The `getIngredientsOnSale` tool:** The model decides when to call it based on the prompt, and the `SaleQuery` input struct forces the model to pass `dayType: "weekday"` or `"weekend"`. Genkit derives the JSON schema from the Go type, including the enum constraint declared in the `jsonschema` tag. In a real app, the tool would query a pricing database, inventory system, or third-party API.
 - **`sendChunk`:** `genkit.DefineStreamingFlow` registers a flow that accepts a `sendChunk` callback. Inside, `genkit.GenerateDataStream[Recipe]` yields typed partial recipes as the model produces them, and the loop forwards each chunk to the caller so a client UI can fill in field by field. When the iterator reports `Done`, the flow returns the validated final recipe so the HTTP request still resolves with a complete value.
-- **HTTP wiring:** The bottom of the file mounts the flow as a single route on a standard `http.ServeMux`. `genkit.Handler(bargainChefFlow)` returns an `http.Handler` that parses the `{"data": ...}` envelope, validates input against the flow's schema, runs the flow, and writes either a JSON response or a `text/event-stream` of chunks based on the request's `Accept` header. The `withCORS` wrapper is a small custom middleware that adds the CORS headers a browser frontend needs and handles preflight `OPTIONS` requests. It sets `Access-Control-Allow-Origin: *`, allowing **all origins** during development; before deploying, replace the `*` with the origins you actually serve. Method-prefixed routing (`POST /bargainChefFlow`) requires Go 1.22 or later.
+- **Model configuration:** `ai.WithConfig` takes the provider's own SDK config type, so the struct differs per plugin. For `googlegenai` that type is `*genai.GenerateContentConfig` from the Google GenAI Go SDK. Setting `ThinkingLevel: genai.ThinkingLevelMinimal` caps how much reasoning the model does before it answers, which lowers latency and cost on a task this simple.
+- **HTTP wiring:** The bottom of the file mounts the flow as a single route on a standard `http.ServeMux`. `genkit.Handler(bargainChefFlow)` returns an `http.HandlerFunc`, so it works with both `mux.Handle` and `mux.HandleFunc` and can be wrapped by any `http.Handler` middleware. It parses the `{"data": ...}` envelope, validates input against the flow's schema, runs the flow, and writes either a JSON response or a `text/event-stream` of chunks based on the request's `Accept` header. See [the `genkit.Handler` contract](/docs/backend-frameworks/overview) for the full option set.
+- **Request context:** The flow runs with the request's own `r.Context()`, so values attached by HTTP middleware are visible to the flow, its tools, and its prompts. For request-scoped identity, prefer `genkit.WithContextProviders(...)` and `core.FromContext(ctx)` over a raw context key. See [Passing information through context](/docs/context).
+- **CORS:** The `withCORS` wrapper is a small custom middleware that adds the CORS headers a browser frontend needs and handles the preflight `OPTIONS` request. It sets `Access-Control-Allow-Origin: *`, allowing **all origins** during development; before deploying, replace the `*` with the origins you actually serve. The route is registered as `/bargainChefFlow` with no method prefix on purpose. A method-prefixed pattern such as `POST /bargainChefFlow` makes `http.ServeMux` answer the browser's `OPTIONS` preflight itself with a 405 before the CORS wrapper runs, so the preflight fails and the browser never sends the real request. Because the pattern accepts every method, `withCORS` rejects anything other than `POST` and `OPTIONS` itself. The chi, Gin, and Echo tutorials do not need this because their CORS middleware runs ahead of routing.
 
 The [basic sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic) serves every registered flow the same way, looping over `genkit.ListFlows(g)` instead of naming one route.
+
+### Tidy the module
+
+Resolve the imports and record them in `go.mod`:
+
+```bash
+go mod tidy
+```
 
 ### Check the project layout
 
@@ -355,6 +373,8 @@ You now have a standalone Genkit backend on net/http that streams structured out
 
 - [Creating flows](/docs/flows): Compose multi-step flows, branch on input, and chain model calls.
 - [Generating content](/docs/models): Swap Gemini for another provider, tune sampling parameters, and work with multimodal input.
+- [Error types](/docs/error-types): Classify failures so the handler returns the right HTTP status, and control which messages reach the caller.
+- [Passing information through context](/docs/context): Get the caller's identity to your flow and tools without putting it in the model's input.
 - [Connect an app framework](/docs/app-frameworks/overview): Add a full-stack UI that calls your flow.
 - [Connect a web frontend](/docs/client): Wire a standalone web client up to this backend.
 - [Connect a Flutter app](/docs/app-frameworks/flutter): Drive your flow from a Flutter mobile or desktop app.

--- a/src/content/docs/docs/backend-frameworks/overview.mdx
+++ b/src/content/docs/docs/backend-frameworks/overview.mdx
@@ -74,6 +74,42 @@ Pick the server framework that matches your backend. Each guide is self-containe
   />
 </CardGrid>
 
+## The `genkit.Handler` contract
+
+Every guide above mounts a flow with the same two functions:
+
+```go
+func Handler(a api.Action, opts ...HandlerOption) http.HandlerFunc
+func HandlerFunc(a api.Action, opts ...HandlerOption) func(http.ResponseWriter, *http.Request) error
+```
+
+`Handler` returns an `http.HandlerFunc`, so it satisfies `http.Handler` and can be wrapped by any standard middleware. `HandlerFunc` returns an error instead of writing it, which suits frameworks with centralized error middleware.
+
+The argument is any `api.Action`: a flow from `genkit.DefineFlow` or `genkit.DefineStreamingFlow`, or an `*aix.Agent`, which implements `api.BidiAction` and is served one turn per request.
+
+What the handler does on the wire:
+
+| Concern | Behavior |
+| :------ | :------- |
+| Request body | `{"data": <flow input>}`. The input is validated against the flow's schema. |
+| Non-streaming response | `application/json` body of `{"result": <flow output>}`. |
+| Streaming response | `text/event-stream` when the request sends `Accept: text/event-stream` or `?stream=true`. Each event is `data: {"message": <chunk>}`, then a final `data: {"result": <output>}`. |
+| Options | Variadic `HandlerOption`. Today: `genkit.WithContextProviders` (see [Passing information through context](/docs/context)) and `genkit.WithStreamManager` (see [Durable streaming](/docs/durable-streaming)). An option that fails to apply **panics at construction**, not per request, so a misconfiguration fails at startup. |
+| Context | The action runs with the request's own `r.Context()`, so values attached by HTTP middleware reach the flow, its tools, and its prompts. A client disconnect cancels that context and therefore the in-flight model call. The one exception is a durable stream, which deliberately keeps running after the client goes away. |
+
+## Errors and timeouts
+
+The handler derives the HTTP status from the error the flow returns, using the same classification described in [Error types](/docs/error-types):
+
+- `status.Of(err).HTTPCode()` picks the status. An unclassified error, such as a bare `errors.New`, is `Internal` and becomes a 500.
+- The error's **message** is withheld from the client unless you built it with `status.PublicErrorf`. Everything else is replaced with a generic string derived from the status. The full error is always logged server-side.
+- On a streaming request the response has already committed a 200, so a mid-stream failure arrives as a terminal `data: {"error": {"status": ..., "message": ...}}` event instead of a status code. See [Errors on a streaming request](/docs/error-types#errors-on-a-streaming-request).
+
+Two deployment settings can truncate a stream that the code handles correctly:
+
+- An `http.Server` with a `WriteTimeout` cuts the response off at that deadline. Leave it unset, or set it longer than your slowest generation, for routes that stream.
+- A reverse proxy that buffers responses holds every event until the flow finishes. Disable response buffering on the streaming route.
+
 </Lang>
 
 <Lang lang="dart">

--- a/src/content/docs/docs/chat.mdx
+++ b/src/content/docs/docs/chat.mdx
@@ -260,6 +260,26 @@ const session = await ai.loadSession(sessionId, {
 
 <Lang lang="go">
 
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
+```
+
+```go
+// ChatTurn is one question plus the conversation it continues.
+type ChatTurn struct {
+	Question string        `json:"question"`
+	History  []*ai.Message `json:"history,omitempty"`
+}
+```
+
 :::note
 Genkit Go has no dedicated `Chat` type. A conversation is either a plain multi-turn `Generate` call whose history the caller carries, shown on this page, or an [agent](/docs/agents/overview), which owns the history, persists it in a session store, and streams each turn.
 :::
@@ -290,12 +310,6 @@ returns the messages you sent plus the model's reply, so a flow can hand that
 back to its caller and accept it again on the next turn:
 
 ```go
-// ChatTurn is one question plus the conversation it continues.
-type ChatTurn struct {
-	Question string        `json:"question"`
-	History  []*ai.Message `json:"history,omitempty"`
-}
-
 // ChatReply hands the updated conversation back to the caller.
 type ChatReply struct {
 	Answer  string        `json:"answer"`

--- a/src/content/docs/docs/client.mdx
+++ b/src/content/docs/docs/client.mdx
@@ -79,6 +79,69 @@ Future<void> callHelloFlow() async {
 
 </TabItem>
 
+<TabItem label="Go">
+
+There is no Genkit client library for Go. A Go caller, typically another service rather than a UI, speaks the same HTTP protocol with the standard library: `POST` a `{"data": ...}` body and decode `{"result": ...}`.
+
+```go
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type helloInput struct {
+	Name string `json:"name"`
+}
+
+type helloOutput struct {
+	Greeting string `json:"greeting"`
+}
+
+func callHelloFlow(ctx context.Context, url string, in helloInput) (helloOutput, error) {
+	body, err := json.Marshal(map[string]any{"data": in})
+	if err != nil {
+		return helloOutput{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return helloOutput{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// If the flow requires authentication, add the token here:
+	// req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return helloOutput{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return helloOutput{}, fmt.Errorf("flow returned %s: %s", resp.Status, msg)
+	}
+
+	var envelope struct {
+		Result helloOutput `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return helloOutput{}, err
+	}
+	return envelope.Result, nil
+}
+```
+
+Canceling `ctx` cancels the request, and the server cancels the flow's own context in turn.
+
+</TabItem>
+
 </Tabs>
 
 ### Streaming flow calls
@@ -148,6 +211,94 @@ Future<void> streamHelloFlow() async {
   }
 }
 ```
+
+</TabItem>
+
+<TabItem label="Go">
+
+Send `Accept: text/event-stream` and read the response line by line. Every event is one `data: <json>` line carrying exactly one of three shapes: `{"message": <chunk>}` for a chunk, `{"result": <output>}` for the final value, or `{"error": {"status": ..., "message": ...}}` if the flow failed after the response committed.
+
+```go
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// streamHelloFlow calls onChunk for each streamed chunk and returns the final result.
+func streamHelloFlow(ctx context.Context, url string, in helloInput, onChunk func(string)) (helloOutput, error) {
+	body, err := json.Marshal(map[string]any{"data": in})
+	if err != nil {
+		return helloOutput{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return helloOutput{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return helloOutput{}, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line, ok := strings.CutPrefix(scanner.Text(), "data: ")
+		if !ok {
+			continue
+		}
+
+		var frame struct {
+			Message json.RawMessage `json:"message"`
+			Result  json.RawMessage `json:"result"`
+			Error   *struct {
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &frame); err != nil {
+			return helloOutput{}, err
+		}
+
+		switch {
+		case frame.Error != nil:
+			return helloOutput{}, fmt.Errorf("flow failed (%s): %s", frame.Error.Status, frame.Error.Message)
+		case len(frame.Message) > 0:
+			var chunk string
+			if err := json.Unmarshal(frame.Message, &chunk); err != nil {
+				return helloOutput{}, err
+			}
+			onChunk(chunk)
+		case len(frame.Result) > 0:
+			var out helloOutput
+			if err := json.Unmarshal(frame.Result, &out); err != nil {
+				return helloOutput{}, err
+			}
+			return out, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return helloOutput{}, err
+	}
+	return helloOutput{}, errors.New("stream ended without a final result")
+}
+```
+
+The default `bufio.Scanner` buffer is 64 KiB per line, which one large chunk can exceed. Raise it, as above, or switch to a `bufio.Reader` if your chunks are large.
+
+If the server has a `StreamManager` configured, its response also carries an `X-Genkit-Stream-Id` header. Save it to resume the same stream after a dropped connection: see [Durable streaming](/docs/durable-streaming).
 
 </TabItem>
 
@@ -353,7 +504,10 @@ final streamResult = helloFlow.stream(
 
 ## When deploying to Cloud Functions for Firebase
 
-When deploying to [Cloud Functions for Firebase](/docs/deployment/firebase), use the Firebase callable functions client library.
+If your backend is deployed as [Cloud Functions for Firebase](/docs/js/deployment/firebase/)
+— a JavaScript-only deployment target — use the Firebase callable functions
+client library instead of the helpers above. A Go, Python, or Dart backend is
+reached over plain HTTP as shown earlier on this page.
 
 Detailed documentation can be found at https://firebase.google.com/docs/functions/callable?gen=2nd
 

--- a/src/content/docs/docs/client.mdx
+++ b/src/content/docs/docs/client.mdx
@@ -5,6 +5,7 @@ supportedLanguages:
   - js
   - go
   - dart
+  - python
 isLanguageAgnostic: true
 ---
 
@@ -31,7 +32,7 @@ You will see the term "action" being used. Genkit's core framework is built on t
 
 For a non-streaming response, use the `runFlow` function (in JS) or `await` the action (in Dart). This is suitable for flows that return a single, complete output.
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 
@@ -79,76 +80,13 @@ Future<void> callHelloFlow() async {
 
 </TabItem>
 
-<TabItem label="Go">
-
-There is no Genkit client library for Go. A Go caller, typically another service rather than a UI, speaks the same HTTP protocol with the standard library: `POST` a `{"data": ...}` body and decode `{"result": ...}`.
-
-```go
-package main
-
-import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-)
-
-type helloInput struct {
-	Name string `json:"name"`
-}
-
-type helloOutput struct {
-	Greeting string `json:"greeting"`
-}
-
-func callHelloFlow(ctx context.Context, url string, in helloInput) (helloOutput, error) {
-	body, err := json.Marshal(map[string]any{"data": in})
-	if err != nil {
-		return helloOutput{}, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return helloOutput{}, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	// If the flow requires authentication, add the token here:
-	// req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return helloOutput{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return helloOutput{}, fmt.Errorf("flow returned %s: %s", resp.Status, msg)
-	}
-
-	var envelope struct {
-		Result helloOutput `json:"result"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return helloOutput{}, err
-	}
-	return envelope.Result, nil
-}
-```
-
-Canceling `ctx` cancels the request, and the server cancels the flow's own context in turn.
-
-</TabItem>
-
 </Tabs>
 
 ### Streaming flow calls
 
 For flows that are designed to stream responses (e.g., for real-time updates or long-running operations), use the `streamFlow` function (in JS) or the `.stream()` method (in Dart).
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 
@@ -214,101 +152,13 @@ Future<void> streamHelloFlow() async {
 
 </TabItem>
 
-<TabItem label="Go">
-
-Send `Accept: text/event-stream` and read the response line by line. Every event is one `data: <json>` line carrying exactly one of three shapes: `{"message": <chunk>}` for a chunk, `{"result": <output>}` for the final value, or `{"error": {"status": ..., "message": ...}}` if the flow failed after the response committed.
-
-```go
-package main
-
-import (
-	"bufio"
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-	"strings"
-)
-
-// streamHelloFlow calls onChunk for each streamed chunk and returns the final result.
-func streamHelloFlow(ctx context.Context, url string, in helloInput, onChunk func(string)) (helloOutput, error) {
-	body, err := json.Marshal(map[string]any{"data": in})
-	if err != nil {
-		return helloOutput{}, err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return helloOutput{}, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return helloOutput{}, err
-	}
-	defer resp.Body.Close()
-
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line, ok := strings.CutPrefix(scanner.Text(), "data: ")
-		if !ok {
-			continue
-		}
-
-		var frame struct {
-			Message json.RawMessage `json:"message"`
-			Result  json.RawMessage `json:"result"`
-			Error   *struct {
-				Status  string `json:"status"`
-				Message string `json:"message"`
-			} `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &frame); err != nil {
-			return helloOutput{}, err
-		}
-
-		switch {
-		case frame.Error != nil:
-			return helloOutput{}, fmt.Errorf("flow failed (%s): %s", frame.Error.Status, frame.Error.Message)
-		case len(frame.Message) > 0:
-			var chunk string
-			if err := json.Unmarshal(frame.Message, &chunk); err != nil {
-				return helloOutput{}, err
-			}
-			onChunk(chunk)
-		case len(frame.Result) > 0:
-			var out helloOutput
-			if err := json.Unmarshal(frame.Result, &out); err != nil {
-				return helloOutput{}, err
-			}
-			return out, nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return helloOutput{}, err
-	}
-	return helloOutput{}, errors.New("stream ended without a final result")
-}
-```
-
-The default `bufio.Scanner` buffer is 64 KiB per line, which one large chunk can exceed. Raise it, as above, or switch to a `bufio.Reader` if your chunks are large.
-
-If the server has a `StreamManager` configured, its response also carries an `X-Genkit-Stream-Id` header. Save it to resume the same stream after a dropped connection: see [Durable streaming](/docs/durable-streaming).
-
-</TabItem>
-
 </Tabs>
 
 ### Custom object streaming
 
 You can also stream custom objects. For robust JSON serialization in Dart, it's recommended to use a code generation library like [`json_serializable`](https://pub.dev/packages/json_serializable). In TypeScript, you can use standard interfaces to define the shape of your data.
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 
@@ -393,7 +243,7 @@ try {
 
 When interacting with Genkit models, you'll often work with standardized data classes. The client libraries provide these classes for type-safe interaction.
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 
@@ -466,7 +316,7 @@ print('Final Response: ${finalResult.text}');
 
 If your deployed flow requires authentication, you can pass headers with your requests:
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 
@@ -504,14 +354,11 @@ final streamResult = helloFlow.stream(
 
 ## When deploying to Cloud Functions for Firebase
 
-If your backend is deployed as [Cloud Functions for Firebase](/docs/js/deployment/firebase/)
-— a JavaScript-only deployment target — use the Firebase callable functions
-client library instead of the helpers above. A Go, Python, or Dart backend is
-reached over plain HTTP as shown earlier on this page.
+When deploying to [Cloud Functions for Firebase](/docs/js/deployment/firebase/), use the Firebase callable functions client library.
 
 Detailed documentation can be found at https://firebase.google.com/docs/functions/callable?gen=2nd
 
-<Tabs>
+<Tabs syncKey="client-lang">
 
 <TabItem label="JavaScript">
 

--- a/src/content/docs/docs/concurrency.mdx
+++ b/src/content/docs/docs/concurrency.mdx
@@ -1,0 +1,198 @@
+---
+title: Concurrency, cancellation, and lifecycle
+description: What is safe to share across goroutines, how deadlines and cancellation propagate, when tool functions run in parallel, and how to shut a Genkit service down cleanly.
+supportedLanguages:
+  - go
+---
+
+import Lang from '../../../components/Lang.astro';
+
+<Lang lang="go">
+
+A Genkit service is an ordinary Go server: one process, many goroutines, one
+request each. This page states the contract that makes that safe, because the
+answers are not guessable from the API shape.
+
+## Share one Genkit instance
+
+Call `genkit.Init` **once per process** and share the returned `*genkit.Genkit`
+across every goroutine. It is safe for concurrent use: the registry behind it is
+guarded by a `sync.RWMutex`, and lookups on the hot path take a read lock.
+
+```go
+var g *genkit.Genkit // set once in main, read everywhere
+
+func main() {
+	ctx := context.Background()
+	g = genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+	// ... one handler per flow; Cloud Run will run many of them at once
+}
+```
+
+Do not create an instance per request. Each `Init` builds a fresh registry,
+re-initializes every plugin, and re-reads your prompt directory, so a
+per-request instance is both slow and a duplicate-registration hazard.
+
+The same values are safe to share: a flow returned by `genkit.DefineFlow`, a
+tool returned by `genkit.DefineTool`, a prompt, a retriever, and an
+`ai.Model`. They are handles onto registry entries, not per-call state.
+
+## Define at startup
+
+`genkit.Define*` is safe to call concurrently, but **defining the same name
+twice panics**. In practice that means:
+
+- Define everything during startup, before you start serving.
+- If you must define at runtime — one model per tenant, say — generate a unique
+  name and guard the call so a retry cannot register the same name twice.
+
+There is no `Undefine`, and no way to test-and-register atomically from outside
+the registry.
+
+## Tool functions can run in parallel
+
+When a model asks for several tool calls in one turn, Genkit runs them
+**concurrently**, one goroutine per call, and waits for all of them.
+
+That has a direct consequence: a tool function must be safe for concurrent use.
+Two invocations of the *same* tool can be in flight at once. Anything a tool
+closes over — a counter, a map, a cache, a batch buffer — needs a mutex or a
+channel, exactly as it would in any other handler.
+
+```go
+var mu sync.Mutex
+var seen = map[string]int{}
+
+recordLookup := genkit.DefineTool(g, "recordLookup", "…",
+	func(toolCtx *ai.ToolContext, in Query) (Result, error) {
+		mu.Lock()
+		seen[in.Key]++
+		mu.Unlock()
+		// ...
+	})
+```
+
+Genkit does not bound tool fan-out. A model that requests twenty tool calls gets
+twenty goroutines, so a tool that talks to a database should use a pooled client
+or its own semaphore.
+
+## Deadlines and cancellation
+
+Every Genkit entry point takes a `context.Context` and honors it. A deadline on
+the context bounds the whole call, including the provider request:
+
+```go
+ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+defer cancel()
+
+resp, err := genkit.Generate(ctx, g, ai.WithModelName(model), ai.WithPrompt(p))
+```
+
+There is no per-call timeout option; `context.WithTimeout` is the mechanism.
+Set one. A provider that stalls will otherwise hold the request until the client
+gives up, and on Cloud Run that means holding a concurrency slot too.
+
+A few specifics:
+
+- **Cancellation reaches the provider.** When the context is done, the in-flight
+  HTTP request to the model provider is cancelled and `Generate` returns
+  promptly rather than at the provider's own timeout.
+- **`ai.WithMaxTurns` bounds iterations, not time.** A tool loop with a slow
+  tool can run far longer than you expect within its turn budget. Use both.
+- **A cancelled request still emits its trace**, truncated at the point of
+  cancellation, so a timeout is visible in the Developer UI and in production
+  telemetry.
+
+## Abandoning a stream is safe
+
+The streaming iterators (`genkit.GenerateStream`,
+`genkit.GenerateDataStream[T]`, `Flow.Stream`) are range-over-func iterators.
+Breaking out early — because the HTTP client disconnected, or because you have
+seen enough — stops the iteration and releases the producer. It does not leak a
+goroutine.
+
+```go
+for chunk, err := range genkit.GenerateStream(ctx, g, opts...) {
+	if err != nil {
+		return err
+	}
+	if clientGone(w) {
+		break // safe
+	}
+	// ...
+}
+```
+
+Cancelling the context is still the better signal when the work upstream is
+expensive, because it stops the provider request as well as the iteration.
+
+## Shutting down
+
+`plugins/server` has a `Start` helper that handles the lifecycle Cloud Run
+expects: it listens, traps `SIGINT` and `SIGTERM`, and drains in-flight requests
+for up to five seconds before returning.
+
+```go
+import "github.com/firebase/genkit/go/plugins/server"
+
+mux := http.NewServeMux()
+mux.HandleFunc("POST /myFlow", genkit.Handler(myFlow))
+
+// Blocks until interrupted, then drains.
+log.Fatal(server.Start(ctx, "0.0.0.0:"+os.Getenv("PORT"), mux))
+```
+
+If you run your own `http.Server`, replicate that: `signal.NotifyContext` for
+`SIGTERM`, then `srv.Shutdown` with a fresh context, because the signal context
+is already cancelled by the time you get there.
+
+There is no `genkit.Shutdown` or `Close`. The instance holds no resources that
+need releasing at exit; plugin clients are HTTP clients that the runtime
+reclaims.
+
+### Flush telemetry before you exit
+
+Telemetry is the exception. The Google Cloud plugin batches metrics and exports
+them on an interval — 5 seconds in dev, 5 minutes in production — so a process
+that exits between ticks loses everything since the last one. Flush explicitly:
+
+```go
+import "github.com/firebase/genkit/go/plugins/googlecloud"
+
+defer func() {
+	flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := googlecloud.FlushMetrics(flushCtx); err != nil {
+		slog.Error("flush metrics", "error", err)
+	}
+}()
+```
+
+Put the flush after the server drain, not before it, so the requests that drained
+are included.
+
+## Health checks
+
+Genkit adds no health endpoint. Add your own, and keep it off the model path so
+a provider outage does not take your instance out of rotation:
+
+```go
+mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+```
+
+If you want readiness to reflect the provider, check it on a timer in the
+background and serve the cached result — never by calling the model inside the
+probe.
+
+## Learn more
+
+- [Deploy to Cloud Run](/docs/deployment/cloud-run) — the platform these rules
+  are written for
+- [Error types](/docs/error-types) — how a cancellation or deadline reaches a client
+- [Middleware](/docs/middleware) — where to put retries and per-call timeouts
+- [Testing your AI logic](/docs/testing) — the fake model these guarantees were
+  checked against, under `go test -race`
+
+</Lang>

--- a/src/content/docs/docs/concurrency.mdx
+++ b/src/content/docs/docs/concurrency.mdx
@@ -10,8 +10,8 @@ import Lang from '../../../components/Lang.astro';
 <Lang lang="go">
 
 A Genkit service is an ordinary Go server: one process, many goroutines, one
-request each. This page states the contract that makes that safe, because the
-answers are not guessable from the API shape.
+request each. This page details the concurrency model and execution guarantees
+of Genkit Go servers.
 
 ## Share one Genkit instance
 
@@ -88,9 +88,9 @@ defer cancel()
 resp, err := genkit.Generate(ctx, g, ai.WithModelName(model), ai.WithPrompt(p))
 ```
 
-There is no per-call timeout option; `context.WithTimeout` is the mechanism.
-Set one. A provider that stalls will otherwise hold the request until the client
-gives up, and on Cloud Run that means holding a concurrency slot too.
+There is no separate per-call timeout option; standard Go `context.WithTimeout`
+is the recommended mechanism. Without a deadline, a stalled provider request can
+hold execution until the client disconnects or times out.
 
 A few specifics:
 
@@ -192,7 +192,7 @@ probe.
   are written for
 - [Error types](/docs/error-types) — how a cancellation or deadline reaches a client
 - [Middleware](/docs/middleware) — where to put retries and per-call timeouts
-- [Testing your AI logic](/docs/testing) — the fake model these guarantees were
-  checked against, under `go test -race`
+- [Testing your AI logic](/docs/testing) — test models and verifying concurrency
+  guarantees under `go test -race`
 
 </Lang>

--- a/src/content/docs/docs/context.mdx
+++ b/src/content/docs/docs/context.mdx
@@ -3,6 +3,7 @@ title: Passing information through context
 description: Learn how Genkit's context object propagates generation and execution information throughout your application, making it available to flows, tools, and prompts.
 supportedLanguages:
   - js
+  - go
   - dart
 ---
 
@@ -336,5 +337,147 @@ final response = await ai.generate(
 By default, when you provide context it is automatically propagated to all
 actions called as a result of your original call. If your generation calls tools,
 the same context is provided.
+
+</Lang>
+
+<Lang lang="go">
+
+There are different categories of information a developer working with an LLM
+handles at the same time:
+
+- **Input:** information that guides the model's response for a particular call,
+  such as the text to summarize.
+- **Generation context:** information relevant to the model but not specific to
+  the call, such as the current date or the user's display name.
+- **Execution context:** information your code needs and the model must never
+  see, such as the caller's identity, tenant, or auth token.
+
+Genkit for Go carries the third category in the **action context**: a
+`map[string]any` attached to the Go `context.Context`, propagated to every flow,
+tool, and prompt in the call, and never sent to the model.
+
+```go
+import "github.com/firebase/genkit/go/core"
+
+// core.ActionContext is an alias for map[string]any.
+ctx = core.WithActionContext(ctx, core.ActionContext{"uid": "alice"})
+
+// Anywhere downstream:
+uid, _ := core.FromContext(ctx)["uid"].(string)
+```
+
+## Why this matters
+
+Give the model the minimum it needs. Two reasons:
+
+- The less extraneous information the model has, the better it does the task.
+- If a tool takes a user ID as an *input*, the model chooses that ID. A prompt
+  injection can then make it choose someone else's. An identity that arrives
+  through the action context cannot be chosen by the model at all.
+
+That second point is the whole reason to prefer action context over an extra
+field in a tool's input schema.
+
+## Read context in a tool
+
+`*ai.ToolContext` embeds the request's `context.Context` as its `Context` field,
+so a tool reads action context the same way anything else does:
+
+```go
+type empty struct{}
+
+listOrders := genkit.DefineTool(g, "listOrders",
+	"Lists the signed-in customer's orders.",
+	func(toolCtx *ai.ToolContext, _ empty) ([]string, error) {
+		uid, _ := core.FromContext(toolCtx.Context)["uid"].(string)
+		if uid == "" {
+			return nil, status.Errorf(status.ErrUnauthenticated, "no signed-in user")
+		}
+		return ordersFor(uid), nil
+	})
+```
+
+Note what the tool's input schema does **not** contain: a customer ID. The model
+can ask for "my orders" and nothing else.
+
+A flow reads the same map from its own `ctx`:
+
+```go
+flow := genkit.DefineFlow(g, "orders", func(ctx context.Context, q string) (string, error) {
+	uid, _ := core.FromContext(ctx)["uid"].(string)
+	if uid == "" {
+		return "", status.Errorf(status.ErrUnauthenticated, "no signed-in user")
+	}
+	// ...
+})
+```
+
+## Provide context at an HTTP boundary
+
+`genkit.Handler` and `genkit.HandlerFunc` take
+`genkit.WithContextProviders(...)`. Each provider receives the decoded request
+and returns the action context to merge in. This is where authentication belongs:
+
+```go
+h := genkit.Handler(flow, genkit.WithContextProviders(
+	func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+		token := strings.TrimPrefix(req.Headers["authorization"], "Bearer ")
+		if token == "" {
+			return nil, status.Errorf(status.ErrUnauthenticated, "missing bearer token")
+		}
+		claims, err := verify(ctx, token) // your verifier
+		if err != nil {
+			return nil, status.Errorf(status.ErrUnauthenticated, "invalid token: %w", err)
+		}
+		return core.ActionContext{"uid": claims.Subject, "tenant": claims.Tenant}, nil
+	}))
+
+mux.Handle("POST /orders", h)
+```
+
+Three details that decide whether this is actually secure:
+
+- **Header keys are lower-cased** before they reach `req.Headers`, and repeated
+  headers are joined with a space. Look up `"authorization"`, not
+  `"Authorization"`.
+- **A provider that returns an error rejects the request before the action
+  runs.** The HTTP status comes from the error's classification, so return
+  `status.Errorf(status.ErrUnauthenticated, ...)` to get a 401 and
+  `status.ErrPermissionDenied` to get a 403. A bare `errors.New` classifies as
+  internal and becomes a 500.
+- **The error message is not sent to the client** unless you built it with
+  `status.PublicErrorf`. It is always logged server-side. See
+  [Error types](/docs/error-types).
+
+Providers run in order and their maps are merged, so a later provider overwrites
+a key an earlier one set. `req.Input` holds the decoded request body if a
+provider needs to look at it.
+
+## Provide context for an in-process call
+
+Outside an HTTP handler — a worker, a cron job, a test — set it yourself before
+you call the flow:
+
+```go
+ctx = core.WithActionContext(ctx, core.ActionContext{"uid": "alice", "tenant": "acme"})
+out, err := flow.Run(ctx, input)
+```
+
+## Propagation
+
+Action context rides on the Go `context.Context`, so it propagates the way every
+other context value does: into nested flows, into `genkit.Run` steps, into
+prompts, and into tools called during the generation loop. Anything that takes
+`ctx` sees it. A goroutine that does **not** receive the request's `ctx` does
+not, which is the usual reason a background task cannot see the caller.
+
+## Learn more
+
+- [Error types](/docs/error-types) — the status codes a context provider should
+  return, and which messages reach the client
+- [Tool calling](/docs/tool-calling) — tool input schemas, and what the model
+  controls
+- [Serve flows over HTTP](/docs/backend-frameworks/overview) — where the
+  handler options go
 
 </Lang>

--- a/src/content/docs/docs/deployment/any-platform.mdx
+++ b/src/content/docs/docs/deployment/any-platform.mdx
@@ -297,7 +297,9 @@ binary. This page, as an example, walks you through the general process of
 deploying the default sample flow, and points out where you must take
 provider-specific actions.
 
-1.  Create a directory for the Genkit sample project:
+## 1. Set up your project
+
+Create a directory for the Genkit sample project:
 
 ```bash
 mkdir -p ~/tmp/genkit-cloud-project
@@ -305,9 +307,9 @@ mkdir -p ~/tmp/genkit-cloud-project
 cd ~/tmp/genkit-cloud-project
 ```
 
-    If you're going to use an IDE, open it to this directory.
+If you're going to use an IDE, open it to this directory.
 
-2.  Initialize a Go module in your project directory:
+Initialize a Go module in your project directory:
 
 ```bash
 go mod init example/cloudrun
@@ -315,7 +317,7 @@ go mod init example/cloudrun
 go get github.com/firebase/genkit/go
 ```
 
-3.  Create a sample app using Genkit:
+## 2. Configure your Genkit app
 
 ```go
 package main
@@ -336,7 +338,7 @@ import (
 func main() {
     ctx := context.Background()
 
-    // Initialize Genkit with the Google AI plugin and Gemini 2.0 Flash.
+    // Initialize Genkit with the Google AI plugin and the latest Gemini Flash model.
     // Alternatively, use &googlegenai.VertexAI{} and "vertexai/gemini-flash-latest"
     // to use Vertex AI as the provider instead.
     g := genkit.Init(ctx,
@@ -357,74 +359,89 @@ func main() {
 
     mux := http.NewServeMux()
     mux.HandleFunc("POST /jokesFlow", genkit.Handler(flow))
-    log.Fatal(server.Start(ctx, "127.0.0.1:"+os.Getenv("PORT"), mux))
+
+    // Bind 0.0.0.0, not 127.0.0.1: inside a container, a loopback-only
+    // listener is unreachable from the platform's health check and from any
+    // other container. Fall back to a port so `go run .` works locally.
+    port := os.Getenv("PORT")
+    if port == "" {
+        port = "8080"
+    }
+    // server.Start traps SIGINT and SIGTERM and drains in-flight requests
+    // before returning, which is what most platforms expect on a redeploy.
+    log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
 }
 ```
 
-4.  Implement some form of authentication and authorization to gate access to
-    the flows you plan to deploy.
+## 3. Gate access to the flow
 
-    Because most generative AI services are metered, you most likely do not want
-    to allow open access to any endpoints that call them. Some hosting services
-    provide an authentication layer as a frontend to apps deployed on them,
-    which you can use for this purpose.
+Implement some form of authentication and authorization before you deploy.
+Because most generative AI services are metered, you most likely do not want to
+allow open access to any endpoint that calls them, and `genkit.Handler` performs
+no check of its own.
 
-5.  Make API credentials available to your deployed function. Do one of the
-    following, depending on the model provider you chose:
+Some hosting services provide an authentication layer as a frontend to apps
+deployed on them, which you can use for this purpose. For a check inside your
+own binary, see
+[Securing your deployment](/docs/deployment/overview#securing-your-deployment).
+
+## 4. Make API credentials available
+
+Do one of the following, depending on the model provider you chose.
+
+**Gemini (Google AI)**
+
+1.  Make sure Google AI is [available in your
+    region](https://ai.google.dev/available_regions).
+
+2.  [Generate an API key](https://aistudio.google.com/app/apikey) for the
+    Gemini API using Google AI Studio.
+
+3.  Make the API key available in the deployed environment.
+
+Most app hosts provide some system for securely handling secrets such as
+API keys. Often, these secrets are available to your app in the form of
+environment variables. If you can assign your API key to the
+`GEMINI_API_KEY` variable, Genkit will use it automatically. Otherwise,
+you need to modify the `googlegenai.GoogleAI` plugin struct to explicitly
+set the key. (But don't embed the key directly in code! Use the secret
+management facilities provided by your hosting provider.)
+
+**Gemini (Vertex AI)**
+
+1.  In the Cloud console, [Enable the Vertex AI API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com?project=_)
+    for your project.
+
+2.  On the [IAM](https://console.cloud.google.com/iam-admin/iam?project=_)
+    page, create a service account for accessing the Vertex AI API if you
+    don't already have one.
+
+    Grant the account the **Vertex AI User** role.
+
+3.  [Set up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc#on-prem)
+    in your hosting environment.
+
+4.  Configure the plugin with your Google Cloud project ID and the Vertex
+    AI API location you want to use. You can do so either by setting the
+    `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` environment
+    variables in your hosting environment, or in your
+    `googlegenai.VertexAI{}` constructor.
+
+The only secret you need to set up for this tutorial is for the model
+provider, but in general, you must do something similar for each service
+your flow uses.
+
+## Optional: Try your flow in the developer UI
+
+1.  Set up your local environment for the model provider you chose.
 
     **Gemini (Google AI)**
-
-    1.  Make sure Google AI is [available in your
-        region](https://ai.google.dev/available_regions).
-
-    2.  [Generate an API key](https://aistudio.google.com/app/apikey) for the
-        Gemini API using Google AI Studio.
-
-    3.  Make the API key available in the deployed environment.
-
-    Most app hosts provide some system for securely handling secrets such as
-    API keys. Often, these secrets are available to your app in the form of
-    environment variables. If you can assign your API key to the
-    `GEMINI_API_KEY` variable, Genkit will use it automatically. Otherwise,
-    you need to modify the `googlegenai.GoogleAI` plugin struct to explicitly
-    set the key. (But don't embed the key directly in code! Use the secret
-    management facilities provided by your hosting provider.)
-
-    **Gemini (Vertex AI)**
-
-    1.  In the Cloud console, [Enable the Vertex AI API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com?project=_)
-        for your project.
-
-    2.  On the [IAM](https://console.cloud.google.com/iam-admin/iam?project=_)
-        page, create a service account for accessing the Vertex AI API if you
-        don't alreacy have one.
-
-        Grant the account the **Vertex AI User** role.
-
-    3.  [Set up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc#on-prem)
-        in your hosting environment.
-
-    4.  Configure the plugin with your Google Cloud project ID and the Vertex
-        AI API location you want to use. You can do so either by setting the
-        `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` environment
-        variables in your hosting environment, or in your
-        `googlegenai.VertexAI{}` constructor.
-
-        The only secret you need to set up for this tutorial is for the model
-        provider, but in general, you must do something similar for each
-        service your flow uses.
-
-6.  **Optional**: Try your flow in the developer UI:
-
-    1.  Set up your local environment for the model provider you chose:
-
-        **Gemini (Google AI)**
 
 ```bash
 export GEMINI_API_KEY=<your API key>
 ```
 
-        **Gemini (Vertex AI)**
+    **Gemini (Vertex AI)**
 
 ```bash
 export GOOGLE_CLOUD_PROJECT=<your project ID>
@@ -434,26 +451,124 @@ export GOOGLE_CLOUD_LOCATION=us-central1
 gcloud auth application-default login
 ```
 
-    2.  Start the UI:
+2.  Start the UI:
 
 ```bash
 genkit start -- go run .
 ```
 
-    3.  In the developer UI (`http://localhost:4000/`), run the flow:
+3.  In the developer UI (`http://localhost:4000/`), click **jokesFlow**.
 
-    4.  Click **jokesFlow**.
-
-    5.  On the **Input JSON** tab, provide a subject for the model:
+4.  On the **Input JSON** tab, provide a subject for the model:
 
 ```json
 "bananas"
 ```
 
-    6.  Click **Run**.
+5.  Click **Run**.
 
-7.  If everything's working as expected so far, you can build and deploy the
-    flow using your provider's tools.
+## 5. Build and deploy
+
+If everything's working as expected so far, you can build and deploy the flow
+using your provider's tools.
+
+## Running in production
+
+### What `server.Start` already does
+
+`server.Start` is not a development-only helper. It installs a
+`signal.NotifyContext` for `os.Interrupt` and `SIGTERM`, and on either signal it
+calls `http.Server.Shutdown`, which stops accepting connections and waits for
+in-flight requests to finish. It also stops intercepting signals at that point,
+so a second interrupt kills the process immediately instead of hanging.
+
+The drain window is fixed at five seconds. Requests still running when it
+expires are cut off.
+
+### When five seconds is not enough
+
+A single model turn frequently runs longer than five seconds, and a tool loop
+runs much longer. If your turns are long, run your own `http.Server` with a
+deadline you choose. This is also where you add health and readiness endpoints,
+which Genkit does not register for you:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/firebase/genkit/go/genkit"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	g := genkit.Init(ctx)
+	flow := genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		return topic, nil // Replace with the flow body from step 2.
+	})
+
+	// ready flips to false the moment shutdown begins, so the load balancer
+	// stops sending new requests while the old ones drain.
+	var ready atomic.Bool
+	ready.Store(true)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /jokesFlow", genkit.Handler(flow))
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "shutting down", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	srv := &http.Server{Addr: "0.0.0.0:" + port, Handler: mux}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop() // A second interrupt now kills the process immediately.
+	ready.Store(false)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("graceful shutdown failed: %v", err)
+	}
+}
+```
+
+Keep the deadline inside your platform's SIGTERM grace period. Cloud Run kills
+the container ten seconds after SIGTERM by default, so a 25-second drain there
+buys you nothing.
+
+### The reflection server is not exposed
+
+`genkit.Init` starts the Dev UI reflection server on port 3100 only when
+`GENKIT_ENV` is set to `dev`. In production, leave `GENKIT_ENV` unset and no
+extra listener is opened.
 
 </Lang>
 

--- a/src/content/docs/docs/deployment/authorization.mdx
+++ b/src/content/docs/docs/deployment/authorization.mdx
@@ -436,10 +436,10 @@ one mechanism for all three — [action context](/docs/context) — plus the
 [error classification](/docs/error-types) that turns a rejection into the right
 HTTP status.
 
-:::caution[Genkit does not authenticate for you]
-`genkit.Handler` serves whatever it is given. There is no default auth policy,
-no built-in identity provider, and no per-flow ACL. Everything below is
-something you must write.
+:::note[Authentication is application-managed]
+`genkit.Handler` executes flows with the context it is given. Authentication,
+identity verification, and access policies are configured at the application level
+using context providers and HTTP middleware.
 :::
 
 ## Authenticate at the handler
@@ -574,12 +574,11 @@ in the same context provider, as a second gate before the user check.
 
 - **Cloud Run.** Either let the platform authenticate (deploy without
   `--allow-unauthenticated` and require an ID token, which keeps unauthenticated
-  traffic off your container entirely), or accept public traffic and do all of
-  the above yourself. Do not do neither. See
+  traffic off your container entirely), or accept public traffic and configure
+  application-level authentication as described above. See
   [Deploy with Cloud Run](/docs/deployment/cloud-run).
 - **The Developer UI reflection server is not authenticated.** It only starts
-  when `GENKIT_ENV=dev`, which is never set in a production image, but do not
-  set it in one.
+  when `GENKIT_ENV=dev`. Ensure it is not enabled in production deployments.
 - **Agent HTTP routes** need the same treatment; see
   [Serve agents over HTTP](/docs/agents/http).
 

--- a/src/content/docs/docs/deployment/authorization.mdx
+++ b/src/content/docs/docs/deployment/authorization.mdx
@@ -3,6 +3,7 @@ title: Authorization and integrity
 description: This document explains how to manage authorization and integrity in Genkit applications, covering Firebase and non-Firebase HTTP authorization.
 supportedLanguages:
   - js
+  - go
   - dart
 ---
 
@@ -423,5 +424,171 @@ void main() async {
   await io.serve(handler, 'localhost', 3400);
 }
 ```
+
+</Lang>
+
+<Lang lang="go">
+
+When you put a flow behind a public HTTP endpoint, three things have to hold:
+the caller is who they claim to be, every tool call is scoped to that caller,
+and the model cannot talk its way into a wider scope. Genkit for Go gives you
+one mechanism for all three — [action context](/docs/context) — plus the
+[error classification](/docs/error-types) that turns a rejection into the right
+HTTP status.
+
+:::caution[Genkit does not authenticate for you]
+`genkit.Handler` serves whatever it is given. There is no default auth policy,
+no built-in identity provider, and no per-flow ACL. Everything below is
+something you must write.
+:::
+
+## Authenticate at the handler
+
+Attach a context provider to the handler. It runs before the flow, so a
+rejection never reaches your business logic:
+
+```go
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+func authProvider(verify func(context.Context, string) (*Claims, error)) core.ContextProvider {
+	return func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+		token := strings.TrimPrefix(req.Headers["authorization"], "Bearer ")
+		if token == "" {
+			return nil, status.Errorf(status.ErrUnauthenticated, "missing bearer token")
+		}
+		claims, err := verify(ctx, token)
+		if err != nil {
+			// The message stays server-side; the client gets a bare 401.
+			return nil, status.Errorf(status.ErrUnauthenticated, "token rejected: %w", err)
+		}
+		return core.ActionContext{
+			"uid":    claims.Subject,
+			"tenant": claims.Tenant,
+			"scopes": claims.Scopes,
+		}, nil
+	}
+}
+
+mux.Handle("POST /summarize", genkit.Handler(summarizeFlow,
+	genkit.WithContextProviders(authProvider(verifyIDToken))))
+```
+
+Header names in `req.Headers` are lower-cased, so match on `"authorization"`.
+
+## Map a rejection to the right status
+
+The HTTP status comes from the error's classification, not from the handler:
+
+| Return | Client sees |
+| :----- | :---------- |
+| `status.Errorf(status.ErrUnauthenticated, ...)` | `401` |
+| `status.Errorf(status.ErrPermissionDenied, ...)` | `403` |
+| `status.Errorf(status.ErrInvalidArgument, ...)` | `400` |
+| `errors.New(...)` or any unclassified error | `500` |
+
+Messages are withheld from the client unless you build them with
+`status.PublicErrorf`, which is the right default: an auth failure message is
+exactly the kind of text that leaks internal structure. The full error is
+always logged server-side.
+
+## Authorize inside the flow
+
+Authentication says who the caller is. Authorization says what this particular
+request may touch, and that usually depends on the input:
+
+```go
+summarizeFlow := genkit.DefineFlow(g, "summarize",
+	func(ctx context.Context, in SummarizeInput) (string, error) {
+		actx := core.FromContext(ctx)
+		uid, _ := actx["uid"].(string)
+		if uid == "" {
+			// Reachable when the flow is called in-process without context.
+			return "", status.Errorf(status.ErrUnauthenticated, "no caller identity")
+		}
+		doc, err := store.Get(ctx, in.DocID)
+		if err != nil {
+			return "", err
+		}
+		if doc.OwnerID != uid {
+			return "", status.Errorf(status.ErrPermissionDenied,
+				"user %s does not own document %s", uid, in.DocID)
+		}
+		// ...
+	})
+```
+
+Keep the check inside the flow, not only in the provider. The same flow runs
+from a worker, a test, and the Developer UI, and only the HTTP path goes through
+a context provider.
+
+## Scope tool calls to the caller
+
+This is the part that is specific to LLM applications. A tool that takes the
+user ID as an input field lets the **model** choose whose data to read, and a
+prompt injection in retrieved content or user text can make it choose someone
+else's. Take the identity from the action context instead:
+
+```go
+// Wrong: the model supplies customerID, so the model decides whose orders to read.
+type badInput struct {
+	CustomerID string `json:"customerId"`
+}
+
+// Right: the tool takes only what the model legitimately chooses. Identity comes
+// from the request, which the model cannot influence.
+type ordersInput struct {
+	Status string `json:"status" jsonschema:"enum=open,enum=shipped"`
+}
+
+listOrders := genkit.DefineTool(g, "listOrders",
+	"Lists the signed-in customer's orders.",
+	func(toolCtx *ai.ToolContext, in ordersInput) ([]Order, error) {
+		uid, _ := core.FromContext(toolCtx.Context)["uid"].(string)
+		if uid == "" {
+			return nil, status.Errorf(status.ErrUnauthenticated, "no signed-in user")
+		}
+		return store.OrdersFor(toolCtx.Context, uid, in.Status)
+	})
+```
+
+Apply the same rule to retrievers: filter by tenant inside the retriever, never
+by a filter value the model produced.
+
+## Verify the client, not just the user
+
+Authenticating the end user does not stop a scraper replaying your endpoint with
+a stolen token, and some deployments have no end user at all. For those, add a
+check on the calling *application*: a service-to-service identity token, a
+signed request from your own frontend, or App Check-style attestation. It goes
+in the same context provider, as a second gate before the user check.
+
+## Deployment notes
+
+- **Cloud Run.** Either let the platform authenticate (deploy without
+  `--allow-unauthenticated` and require an ID token, which keeps unauthenticated
+  traffic off your container entirely), or accept public traffic and do all of
+  the above yourself. Do not do neither. See
+  [Deploy with Cloud Run](/docs/deployment/cloud-run).
+- **The Developer UI reflection server is not authenticated.** It only starts
+  when `GENKIT_ENV=dev`, which is never set in a production image, but do not
+  set it in one.
+- **Agent HTTP routes** need the same treatment; see
+  [Serve agents over HTTP](/docs/agents/http).
+
+## Learn more
+
+- [Passing information through context](/docs/context) — the mechanism these
+  examples are built on
+- [Error types](/docs/error-types) — the full status set and what reaches a client
+- [Testing your AI logic](/docs/testing) — asserting that an unauthenticated
+  request really is rejected
 
 </Lang>

--- a/src/content/docs/docs/deployment/cloud-run.mdx
+++ b/src/content/docs/docs/deployment/cloud-run.mdx
@@ -233,15 +233,21 @@ You can deploy Genkit flows as web services using Cloud Run. This page,
 as an example, walks you through the process of deploying the default sample
 flow.
 
-1.  Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) if
-    you haven't already.
+## Before you begin
 
-2.  Create a new Google Cloud project using the
-    [Cloud console](https://console.cloud.google.com) or choose an existing one.
-    The project must be linked to a billing account.
+- Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) if
+  you haven't already.
+- You should be familiar with Genkit's concept of [flows](/docs/flows).
+- It would be helpful, but not required, if you've already used Google Cloud
+  and Cloud Run before.
 
-    After you create or choose a project, configure the Google Cloud CLI to use
-    it:
+## 1. Set up a Google Cloud project
+
+Create a new Google Cloud project using the
+[Cloud console](https://console.cloud.google.com) or choose an existing one.
+The project must be linked to a billing account.
+
+After you create or choose a project, configure the Google Cloud CLI to use it:
 
 ```bash
 gcloud auth login
@@ -249,7 +255,9 @@ gcloud auth login
 gcloud init
 ```
 
-3.  Create a directory for the Genkit sample project:
+## 2. Prepare your Go project for deployment
+
+### Create the project directory
 
 ```bash
 mkdir -p ~/tmp/genkit-cloud-project
@@ -257,17 +265,17 @@ mkdir -p ~/tmp/genkit-cloud-project
 cd ~/tmp/genkit-cloud-project
 ```
 
-    If you're going to use an IDE, open it to this directory.
+If you're going to use an IDE, open it to this directory.
 
-4.  Initialize a Go module in your project directory:
+Initialize a Go module in your project directory:
 
 ```bash
 go mod init example/cloudrun
 
-go mod get github.com/firebase/genkit/go
+go get github.com/firebase/genkit/go
 ```
 
-5.  Create a sample app using Genkit:
+### Add code to configure and start the flow server
 
 ```go
 package main
@@ -288,7 +296,7 @@ import (
 func main() {
     ctx := context.Background()
 
-    // Initialize Genkit with the Google AI plugin and Gemini 2.5 Flash.
+    // Initialize Genkit with the Google AI plugin and the latest Gemini Flash model.
     // Alternatively, use &googlegenai.VertexAI{} and "vertexai/gemini-flash-latest"
     // to use Vertex AI as the provider instead.
     g := genkit.Init(ctx,
@@ -309,61 +317,82 @@ func main() {
 
     mux := http.NewServeMux()
     mux.HandleFunc("POST /jokesFlow", genkit.Handler(flow))
-    log.Fatal(server.Start(ctx, "0.0.0.0:"+os.Getenv("PORT"), mux))
+
+    port := os.Getenv("PORT")
+    if port == "" {
+        port = "8080" // Cloud Run always sets PORT; this keeps `go run .` working.
+    }
+    // server.Start traps SIGINT and SIGTERM and drains in-flight requests for
+    // up to five seconds, which is the shutdown behavior Cloud Run expects.
+    log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
 }
 ```
 
-6.  Make API credentials available to your deployed function. Choose which
-    credentials you need based on your choice in the sample above:
+### Define an authorization policy
+
+`genkit.Handler` does no authentication. Anything you register on the mux is
+callable by anyone who can reach the service URL, and every call spends model
+quota. Decide now which of the two options you want:
+
+- **Cloud IAM.** Answer `N` in the deploy step below so Cloud Run rejects
+  unauthenticated callers before the request reaches your process.
+- **A check in your own code.** Wrap each flow handler in middleware that
+  validates the caller. See
+  [Securing your deployment](/docs/deployment/overview#securing-your-deployment)
+  for the pattern.
+
+### Make API credentials available to deployed flows
+
+Choose which credentials you need based on your choice in the sample above.
+
+**Gemini (Google AI)**
+
+1.  Make sure Google AI is
+    [available in your region](https://ai.google.dev/available_regions).
+
+2.  [Generate an API key](https://aistudio.google.com/app/apikey) for the
+    Gemini API using Google AI Studio.
+
+3.  Make the API key available in the Cloud Run environment:
+
+    1.  In the Cloud console, enable the
+        [Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com?project=_).
+    2.  On the
+        [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=_)
+        page, create a new secret containing your API key.
+    3.  After you create the secret, on the same page, grant your default
+        compute service account access to the secret with the
+        **Secret Manager Secret Accessor** role. (You can look up the name
+        of the default compute service account on the IAM page.)
+
+    In a later step, when you deploy your service, you will need to
+    reference the name of this secret.
+
+**Gemini (Vertex AI)**
+
+1.  In the Cloud console,
+    [Enable the Vertex AI API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com?project=_)
+    for your project.
+
+2.  On the [IAM](https://console.cloud.google.com/iam-admin/iam?project=_)
+    page, ensure that the **Default compute service account** is granted
+    the **Vertex AI User** role.
+
+The only secret you need to set up for this tutorial is for the model
+provider, but in general, you must do something similar for each service
+your flow uses.
+
+## Optional: Try your flow in the developer UI
+
+1.  Set up your local environment for the model provider you chose.
 
     **Gemini (Google AI)**
-
-    1.  Make sure Google AI is
-        [available in your region](https://ai.google.dev/available_regions).
-
-    2.  [Generate an API key](https://aistudio.google.com/app/apikey) for the
-        Gemini API using Google AI Studio.
-
-    3.  Make the API key available in the Cloud Run environment:
-
-        1.  In the Cloud console, enable the
-            [Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com?project=_).
-        2.  On the
-            [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=_)
-            page, create a new secret containing your API key.
-        3.  After you create the secret, on the same page, grant your default
-            compute service account access to the secret with the
-            **Secret Manager Secret Accessor** role. (You can look up the name
-            of the default compute service account on the IAM page.)
-
-        In a later step, when you deploy your service, you will need to
-        reference the name of this secret.
-
-    **Gemini (Vertex AI)**
-
-    1.  In the Cloud console,
-        [Enable the Vertex AI API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com?project=_)
-        for your project.
-
-    2.  On the [IAM](https://console.cloud.google.com/iam-admin/iam?project=_)
-        page, ensure that the **Default compute service account** is granted
-        the **Vertex AI User** role.
-
-    The only secret you need to set up for this tutorial is for the model
-    provider, but in general, you must do something similar for each service
-    your flow uses.
-
-7.  **Optional**: Try your flow in the developer UI:
-
-    1.  Set up your local environment for the model provider you chose:
-
-        **Gemini (Google AI)**
 
 ```bash
 export GEMINI_API_KEY=<your API key>
 ```
 
-        **Gemini (Vertex AI)**
+    **Gemini (Vertex AI)**
 
 ```bash
 export GOOGLE_CLOUD_PROJECT=<your project ID>
@@ -373,34 +402,34 @@ export GOOGLE_CLOUD_LOCATION=us-central1
 gcloud auth application-default login
 ```
 
-    2.  Start the UI:
+2.  Start the UI:
 
 ```bash
 genkit start -- go run .
 ```
 
-    3.  In the developer UI (`http://localhost:4000/`), run the flow:
-        1.  Click **jokesFlow**.
+3.  In the developer UI (`http://localhost:4000/`), click **jokesFlow**.
 
-        2.  On the **Input JSON** tab, provide a subject for the model:
+4.  On the **Input JSON** tab, provide a subject for the model:
 
 ```json
 "bananas"
 ```
 
-        3.  Click **Run**.
+5.  Click **Run**.
 
-8.  If everything's working as expected so far, you can build and deploy the
-    flow:
+## 3. Deploy to Cloud Run
 
-    **Gemini (Google AI)**
+If everything's working as expected so far, you can build and deploy the flow.
+
+**Gemini (Google AI)**
 
 ```bash
 gcloud run deploy --port 3400 \
   --update-secrets=GEMINI_API_KEY=<your-secret-name>:latest
 ```
 
-    **Gemini (Vertex AI)**
+**Gemini (Vertex AI)**
 
 ```bash
 gcloud run deploy --port 3400 \
@@ -408,13 +437,14 @@ gcloud run deploy --port 3400 \
   --set-env-vars GOOGLE_CLOUD_LOCATION=us-central1
 ```
 
-    (`GOOGLE_CLOUD_LOCATION` configures the Vertex API region you want to
-    use.)
+(`GOOGLE_CLOUD_LOCATION` configures the Vertex API region you want to use.)
 
-    Choose `N` when asked if you want to allow unauthenticated invocations.
-    Answering `N` will configure your service to require IAM credentials. See
-    [Authentication](https://cloud.google.com/run/docs/authenticating/overview)
-    in the Cloud Run docs for information on providing these credentials.
+Choose `N` when asked if you want to allow unauthenticated invocations.
+Answering `N` will configure your service to require IAM credentials. See
+[Authentication](https://cloud.google.com/run/docs/authenticating/overview)
+in the Cloud Run docs for information on providing these credentials.
+
+## Optional: Try the deployed flow
 
 After deployment finishes, the tool will print the service URL. You can test
 it with `curl`:

--- a/src/content/docs/docs/deployment/overview.mdx
+++ b/src/content/docs/docs/deployment/overview.mdx
@@ -51,6 +51,106 @@ Pick the platform you want to host your Genkit backend on. Each guide is self-co
 
 </Lang>
 
+<Lang lang="go">
+
+## Securing your deployment
+
+Genkit's HTTP handlers do no authentication of their own. `genkit.Handler`
+serves the flow to whoever sends the request, so a deployed flow is callable by
+anyone who can reach its URL. Because model calls are metered, an open endpoint
+is a billing risk as well as a data risk.
+
+Choose one of two approaches, or both:
+
+- **Platform authentication.** Deploy behind a layer that rejects unauthenticated
+  callers before they reach your process. On Cloud Run, answer `N` when `gcloud`
+  asks about unauthenticated invocations and let IAM check the caller's identity
+  token.
+- **Authentication in code.** Wrap each flow handler in middleware that validates
+  the caller before the flow runs.
+
+The code path looks like this:
+
+```go
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/server"
+)
+
+// requireAPIKey rejects any request that does not carry the expected key.
+func requireAPIKey(key string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("X-API-Key")
+		if subtle.ConstantTimeCompare([]byte(got), []byte(key)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func main() {
+	ctx := context.Background()
+
+	apiKey := os.Getenv("FLOW_API_KEY")
+	if apiKey == "" {
+		log.Fatal("FLOW_API_KEY is not set")
+	}
+
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
+	)
+
+	flow := genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Tell a short joke about %s.", topic))
+		if err != nil {
+			return "", fmt.Errorf("failed to generate joke: %w", err)
+		}
+		return resp.Text(), nil
+	})
+
+	mux := http.NewServeMux()
+	// Register every flow endpoint behind the check, not just this one.
+	mux.Handle("POST /jokesFlow", requireAPIKey(apiKey, genkit.Handler(flow)))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
+}
+```
+
+Replace the shared-key check with whatever your callers already carry: a Firebase
+ID token, an OIDC token, or a session cookie. To pass the verified identity into
+the flow, use `genkit.WithContextProviders` instead of, or in addition to, the
+wrapper:
+
+```go
+mux.Handle("POST /jokesFlow", requireAPIKey(apiKey, genkit.Handler(flow,
+	genkit.WithContextProviders(func(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+		return core.ActionContext{"uid": req.Headers["x-user-id"]}, nil
+	}),
+)))
+```
+
+`core` here is `github.com/firebase/genkit/go/core`. Inside the flow, read the
+value with `core.FromContext(ctx)`.
+
+</Lang>
+
 <Lang lang="js dart">
 
 ## Securing your deployment

--- a/src/content/docs/docs/develop-with-ai.mdx
+++ b/src/content/docs/docs/develop-with-ai.mdx
@@ -24,6 +24,14 @@ Currently available skills:
 
 </Lang>
 
+<Lang lang="go">
+
+Currently available skill:
+
+- **developing-genkit-go**: For developing Genkit applications with Go.
+
+</Lang>
+
 ### Installation
 
 Install skills into your project with [skills.sh](https://skills.sh):
@@ -50,3 +58,47 @@ The MCP server exposes tools that let an assistant:
 - Fetch execution traces for analysis and debugging.
 
 For setup instructions, see the [Genkit MCP server](/docs/mcp-server) documentation.
+
+## Retrieve docs as markdown
+
+Skills and the MCP server both need an install step. When you just want an agent
+to read a page, every URL on this site also answers with plain markdown, which
+costs far fewer tokens than the rendered HTML. Replace `<lang>` with `js`, `go`,
+`dart`, or `python`, and `<page>` with the docs slug:
+
+| URL | What you get |
+| :-- | :----------- |
+| `https://genkit.dev/docs/<lang>/<page>.md` | one page, rendered for one SDK |
+| `https://genkit.dev/docs/<page>.<lang>.md` | the same content, addressed from the neutral slug |
+| `https://genkit.dev/docs/<page>.md` | the unfiltered page, every SDK in one file |
+
+Larger bundles are indexed at
+[llms.txt](https://genkit.dev/llms.txt), which lists a whole-SDK bundle at
+`https://genkit.dev/llms-<lang>.txt`, per-topic bundles under
+`https://genkit.dev/_llms-txt/`, and condensed rules files at
+`https://genkit.dev/GENKIT.js.md` and `https://genkit.dev/GENKIT.go.md` that are
+sized to paste into a system prompt. `llms.txt` lists exactly what exists, so
+check it rather than guessing a URL.
+
+### Rules files
+
+Most assistants read a file checked into your repository: `AGENTS.md`,
+`CLAUDE.md`, `.cursor/rules/`, or `.github/copilot-instructions.md`. Whichever
+one your team uses, point it at the rules file and the markdown endpoints so the
+assistant can pull the page it needs.
+
+<Lang lang="go">
+
+```markdown title="AGENTS.md"
+## Genkit
+
+This project uses Genkit for Go.
+
+- Follow the API rules at https://genkit.dev/GENKIT.go.md.
+- For a single topic, fetch the page as markdown, for example
+  https://genkit.dev/docs/go/flows.md or https://genkit.dev/docs/go/tool-calling.md.
+- For the whole SDK in one file, fetch https://genkit.dev/llms-go.txt.
+- Do not guess API names. Check the page first.
+```
+
+</Lang>

--- a/src/content/docs/docs/dotprompt.mdx
+++ b/src/content/docs/docs/dotprompt.mdx
@@ -451,12 +451,25 @@ helloPrompt := genkit.LookupPrompt(g, "hello")
     section about [specifying input schemas](#input-and-output-schemas)), configuration, and more:
 
 ```go
+import (
+	"context"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"google.golang.org/genai"
+)
+
 resp, err := helloPrompt.Execute(context.Background(),
 	ai.WithModelName("googleai/gemini-flash-latest"),
 	ai.WithInput(map[string]any{"name": "John"}),
 	ai.WithConfig(&genai.GenerateContentConfig{Temperature: genai.Ptr[float32](0.5)}),
 )
 ```
+
+The value passed to `ai.WithConfig` is provider-specific and comes from the
+model plugin's own SDK, not from Genkit. For `googlegenai` that is
+`*genai.GenerateContentConfig` from `google.golang.org/genai`, the Google Gen AI
+Go SDK the plugin wraps. Other plugins take their own config type.
 
     #### Streaming prompt execution
 
@@ -475,6 +488,25 @@ for result, err := range stream {
 	}
 	// Process each chunk
 	fmt.Print(result.Chunk.Text())
+}
+```
+
+`ExecuteStream` yields the same `*ai.ModelStreamValue` as `genkit.GenerateStream`:
+`result.Chunk` is an `*ai.ModelResponseChunk` and `result.Done` marks the final
+value, whose `Response` holds the `*ai.ModelResponse`. So a chunk carries tool
+requests and tool responses the same way, and the same part-kind switch works on
+both paths:
+
+```go
+for _, part := range result.Chunk.Content {
+	switch {
+	case part.IsToolRequest():
+		fmt.Println("tool request:", part.ToolRequest.Name)
+	case part.IsToolResponse():
+		fmt.Println("tool response:", part.ToolResponse.Name)
+	case part.IsText():
+		fmt.Print(part.Text)
+	}
 }
 ```
 
@@ -773,12 +805,16 @@ const response3 = await helloPrompt(
 resp, err := helloPrompt.Execute(context.Background(),
     ai.WithConfig(&genai.GenerateContentConfig{
         Temperature:     genai.Ptr[float32](1.4),
-        TopK:            genai.Ptr[int32](50),
+        TopK:            genai.Ptr[float32](50),
         TopP:            genai.Ptr[float32](0.4),
-        MaxOutputTokens: genai.Ptr[int32](400),
+        MaxOutputTokens: 400,
         StopSequences:   []string{"<end>", "<fin>"},
     }))
 ```
+
+Two field types in `google.golang.org/genai` catch people out: `TopK` is a
+`*float32` even though top-k is conceptually an integer, and `MaxOutputTokens`
+is a plain `int32` rather than a pointer.
 
 </Lang>
 
@@ -835,8 +871,8 @@ fields that control how a prompt runs its model and tool loop:
   to `false`.
 - **`use`** attaches middleware to the prompt's model loop by name, with optional
   config. Each entry is either a bare middleware name or a map with a `name` and
-  a `config`. This mirrors the code API, where `use: [retry(maxRetries: 3)]`
-  passes a middleware name plus optional configuration.
+  a `config`. The code equivalent passes the middleware and its configuration
+  directly instead of naming it, so nothing has to be registered first.
 
 ```dotprompt
 ---
@@ -894,6 +930,11 @@ g := genkit.Init(context.Background(),
 	),
 )
 ```
+
+In Go, a `use:` entry must name the middleware in full, provider prefix
+included. An unregistered name is not skipped: the run fails with a `NOT_FOUND`
+error, `ai: middleware "<name>" not registered (is the providing plugin
+installed?)`, raised when the prompt executes rather than at `genkit.Init`.
 
 The built-in middleware are registered under the plugin's provider prefix, so a
 Go `.prompt` file names them `genkit-middleware/retry`,
@@ -1558,6 +1599,13 @@ resp, err := myPrompt.Execute(ctx,
 Tools passed at execution replace the ones the prompt was defined with rather
 than adding to them, so list every tool this run should have.
 
+Tool names in the front matter resolve when the prompt runs, not when it is
+loaded, so defining tools with `genkit.DefineTool` after `genkit.Init` is the
+normal and supported ordering. An unknown name fails the `Execute` call with
+`ai.ErrToolNotFound` (`NOT_FOUND`), never at startup. The panic `genkit.Init`
+can raise applies only to prompt files that fail to parse or that define an
+invalid prompt; it never looks up tool names.
+
 </Lang>
 
 <Lang lang="python">
@@ -2176,7 +2224,7 @@ type CountryList struct {
 
 geographyPrompt := genkit.DefineDataPrompt[GeoQuery, *CountryList](
     g, "GeographyPrompt",
-    ai.WithModel(googlegenai.GoogleAIModelRef("gemini-flash-latest", nil)),
+    ai.WithModel(googlegenai.ModelRef("googleai/gemini-flash-latest", nil)),
     ai.WithSystem("You are a geography teacher. Respond only when the user asks about geography."),
     ai.WithPrompt("Give me the {{countryCount}} biggest countries in the world by inhabitants."),
 )
@@ -2279,6 +2327,23 @@ func WithTextDocs(text ...string) DocumentOption
 func WithDocs(docs ...*Document) DocumentOption
 func WithDocsFn[In any](fn func(context.Context, In) ([]*Document, error)) PromptOption
 ```
+
+    The four return types are not interchangeable. Each one names the set of
+    calls that accepts the option:
+
+| Return type           | Accepted by                                                                   |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `PromptOption`        | `genkit.DefinePrompt` and `genkit.DefineDataPrompt` only                       |
+| `PromptingOption`     | `genkit.DefinePrompt`, `genkit.DefineDataPrompt`, and `genkit.Generate`        |
+| `CommonGenOption`     | all of the above plus `Prompt.Execute` and `ExecuteStream`                     |
+| `DocumentOption`      | all of the above plus `genkit.Embed` and `genkit.Retrieve`                     |
+
+    So `ai.WithMessagesTemplate` is definition-time only, while `ai.WithMessages`
+    can also be passed at execute time. `ai.WithInput` is the mirror case: it is
+    a `PromptExecuteOption`, accepted only by `Prompt.Execute` and
+    `ExecuteStream`. `DocumentOption` values construct the documents a call
+    carries; `ai.WithDocsFn` is a `PromptOption` instead, because it is a
+    definition-time hook rather than a document.
 
     The rule that decides between the two forms: **template text is yours, so it
     is compiled; what a function returns is content you already produced, so it is

--- a/src/content/docs/docs/durable-streaming.mdx
+++ b/src/content/docs/docs/durable-streaming.mdx
@@ -20,8 +20,8 @@ Report issues and feedback on [Github](https://github.com/genkit-ai/genkit/issue
 
 <Lang lang="go">
 
-:::note[Experimental]
-Durable streaming for Go is an experimental feature hosted in preview packages (`core/x/streaming` and `plugins/firebase/exp`). This means the API may receive breaking changes in a minor release, or may be elevated to stable and moved to the root package in the future.
+:::caution[Preview]
+Durable streaming for Go is in preview, hosted in the `core/x/streaming` and `plugins/firebase/exp` packages. It can take breaking changes in a minor release, or be promoted to stable and moved to the root package. See [API stability channels](/docs/api-stability).
 
 Report issues and feedback on [Github](https://github.com/genkit-ai/genkit/issues)
 :::
@@ -354,6 +354,30 @@ The subscription will:
 - Replay any buffered chunks that were already sent
 - Continue with live updates if the stream is still in progress
 - Return all chunks plus the final result if the stream has already completed
+
+**The request body is ignored on resume.** When `X-Genkit-Stream-Id` is present and a `StreamManager` is configured, the handler subscribes to the existing record and returns. The flow is never re-executed and never re-billed. The body still has to be valid JSON, so send `-d '{}'` if you have nothing to send.
+
+The flow also keeps running after the original client disconnects: it executes on a detached context, so the remaining chunks and the final result still reach durable storage. Several clients may subscribe to the same ID at once, and each receives the buffered chunks followed by the live ones.
+
+### Resume outcomes
+
+| Stream ID | Response |
+| :-------- | :------- |
+| Valid, run in progress or completed | `200` with `Content-Type: text/event-stream`, replaying buffered chunks and then the final `data: {"result": ...}` |
+| Unknown or TTL-expired | `204 No Content`, empty body. This is not an error, so check the status code rather than waiting for events. |
+| Valid, but the run failed | `200` with the chunks emitted before the failure, then a terminal error event |
+
+### Failed runs
+
+If the flow fails, the terminal error is written to the stream record, not just to the first client. Later subscribers get the chunks emitted before the failure, then the same `data: {"error": {...}}` frame described in [Errors on a streaming request](/docs/error-types#errors-on-a-streaming-request). The redaction rules are identical: only a message built with `status.PublicErrorf` reaches the wire, and the real error is logged server-side as `streaming flow failed`. The failed record is retained for the manager's TTL like any other.
+
+### Security
+
+:::caution[Stream IDs are bearer capabilities]
+`genkit.Handler` performs no authorization on resume. Any caller presenting a valid stream ID receives the full replay: every chunk, the final result, and any error frame. The IDs are random UUIDv4 values generated server-side, so they are not guessable, but nothing binds a stream to the caller who started it.
+
+To scope a stream to its owner, authenticate the request with [`genkit.WithContextProviders`](/docs/context) and record the owner for each ID you hand out, then reject an `X-Genkit-Stream-Id` the caller does not own in your own HTTP middleware before the Genkit handler runs.
+:::
 
 ### Stream errors
 

--- a/src/content/docs/docs/error-types.mdx
+++ b/src/content/docs/docs/error-types.mdx
@@ -111,14 +111,57 @@ case errors.Is(err, status.ErrResourceExhausted):
 ```
 
 The framework packages ship sentinels for the failures they raise, each a subtype of
-a base sentinel:
+a base sentinel.
 
-- `ai`: `ErrModelNotFound`, `ErrToolNotFound`, `ErrToolFailed`, `ErrMaxTurnsExceeded`,
-  `ErrUnsupportedByModel`, `ErrInvalidPart`, `ErrInputTypeMismatch`,
-  `ErrUnresolvedToolRequest`
-- `core/status`: `ErrInvalidSchema`, `ErrInvalidInput`, `ErrInvalidOutput`,
-  `ErrActionNotFound`, `ErrPanic`
-- `core`: `ErrConnectionClosed`, `ErrActionCompleted`
+From `ai`, for generation:
+
+| Sentinel                   | Base                       | Raised when                                                                                                                        |
+| -------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `ErrModelNotFound`         | `status.ErrNotFound`       | The named model is not registered. Usually the providing plugin is missing from `genkit.Init`.                                       |
+| `ErrToolNotFound`          | `status.ErrNotFound`       | The model called a tool that is on neither the request nor the registry.                                                             |
+| `ErrToolFailed`            | `status.ErrInternal`       | A tool returned an error, or its output did not match its declared schema.                                                           |
+| `ErrMaxTurnsExceeded`      | `status.ErrAborted`        | The tool loop hit its turn limit before the model produced a final response. Raise the limit with `ai.WithMaxTurns`.                 |
+| `ErrUnsupportedByModel`    | `status.ErrInvalidArgument` | The request used a capability the model does not advertise: media, tools, tool choice, a system role.                               |
+| `ErrInvalidPart`           | `status.ErrInvalidArgument` | A `Part` is malformed for the operation: the wrong kind, missing a required field, or carrying a field its kind does not allow.     |
+| `ErrInputTypeMismatch`     | `status.ErrInvalidArgument` | A prompt's input could not be interpreted as the type a content function declared, so the function never ran.                       |
+| `ErrUnresolvedToolRequest` | `status.ErrInvalidArgument` | A resumed generation left an interrupted tool request without a `Respond` or `Restart` directive.                                   |
+| `ErrGenerationBlocked`     | `status.ErrFailedPrecondition` | The provider refused to generate, usually a safety filter. Only the typed helpers report it; `ai.Generate` hands the response back so you can read `FinishReason`. |
+
+`ErrToolFailed` names the failing tool in its message (`tool "getWeather" failed: ...`)
+and wraps the tool's own error with `%w`, so `errors.Is` and `errors.As` still reach it.
+There is no structured tool-name field. To tell one tool's failure from another's,
+define a sentinel inside the tool and branch on that rather than on `ErrToolFailed`.
+
+From `core/status`, for the action machinery:
+
+| Sentinel            | Base                        | Raised when                                                                                                                                                     |
+| ------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ErrInvalidSchema`  | `status.ErrInvalidArgument` | A declared input or output schema could not be resolved or compiled. The schema is wrong, not the value, so a retry will not help; fix the Go type or the schema.   |
+| `ErrInvalidInput`   | `status.ErrInvalidArgument` | A value failed validation against an action's input schema, for example a model producing malformed tool arguments.                                                 |
+| `ErrInvalidOutput`  | `status.ErrInternal`        | An action or model produced a value that does not match the declared output schema: unparseable JSON, an enum reply outside the set, an action output failing validation. |
+| `ErrActionNotFound` | `status.ErrNotFound`        | No action is registered under the requested key.                                                                                                                    |
+| `ErrPanic`          | `status.ErrInternal`        | The framework recovered a panic at one of the two boundaries that recover. See [Panics](#panics).                                                                   |
+
+`ErrInvalidOutput` is the one to branch on when a model's structured output is
+unusable and the generation is worth retrying:
+
+```go
+recipe, _, err := genkit.GenerateData[Recipe](ctx, g, ai.WithPrompt("Suggest a recipe."))
+if errors.Is(err, status.ErrInvalidOutput) {
+	// The model answered, but not in the shape we asked for. Retry.
+}
+```
+
+One gap: `ModelResponse.Output(v)` on a response with no format handler falls back to
+a plain `json.Unmarshal`, whose error carries no sentinel. Request structured output
+through `ai.WithOutputType` or `genkit.GenerateData` and you get the classified error.
+
+From `core`, for bidirectional actions:
+
+| Sentinel              | Base                           | Raised when                                                                                                     |
+| --------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `ErrConnectionClosed` | `status.ErrFailedPrecondition` | `Send` on a connection whose input side was closed with `BidiConnection.Close`.                                     |
+| `ErrActionCompleted`  | `status.ErrFailedPrecondition` | `Send` on a connection whose action already returned. Its result is available from `BidiConnection.Output`.         |
 
 Three functions inspect an error without unwrapping it by hand. Together they are
 everything a transport needs (`logger` here is `github.com/firebase/genkit/go/core/logger`):
@@ -147,6 +190,35 @@ deliberate reclassification at a boundary wins. It maps a cancelled context to
 `INTERNAL`. `status.Classified` returns the same status plus whether anything in the
 chain really carried one. That second bit is what middleware needs, so an unclassified
 failure is not mistaken for a deliberate `INTERNAL`.
+
+### Which provider errors arrive classified
+
+The first-party model plugins classify provider HTTP failures into canonical
+statuses, so a 429 reaches you as `status.ErrResourceExhausted` rather than as an
+opaque SDK error: `googlegenai`, `compat_oai` and the providers built on it, and the
+Anthropic plugins all do this. `googlegenai` also records the delay the service asked
+for, readable with `googlegenai.RetryDelay(err)`.
+
+The same wrapping covers embedders. An input longer than the embedder's token limit
+comes back as HTTP 400, so `errors.Is(err, status.ErrInvalidArgument)`. Batching is
+handled for you (100 inputs per call on the Gemini API, up to 250 on Vertex AI), so an
+invalid-argument failure from an embed call points at one oversized document, not at
+the batch size.
+
+A plugin that does not classify leaves its errors unclassified, and an unclassified
+error reports `INTERNAL`. Check which you have with `status.Classified(err)`: the
+second result is false when nothing in the chain carried a status.
+
+### Panics
+
+Genkit does not recover panics at the ordinary action boundary. A panic in a flow, a
+tool, or middleware unwinds normally; under `net/http` the connection is dropped with
+no response body. `status.ErrPanic` is raised only where the framework does recover:
+bidirectional actions and the experimental agent runtime, which turn the recovered
+value into a classified `INTERNAL` error such as `panic in bidi action "name": ...`.
+
+If you want a panic in your own code to reach a client as a status, recover it
+yourself and return a classified error, or wrap your mux in a recovery middleware.
 
 ## The status vocabulary
 
@@ -209,10 +281,48 @@ for _, a := range genkit.ListFlows(g) {
 }
 ```
 
-`genkit.HandlerFunc` returns the error to you instead of writing a response, for
-frameworks that handle errors centrally. Apply the same two rules there yourself, with
-`status.Of` for the code and `status.PublicMessage` for the body, as in the snippet
-above.
+### Custom error bodies
+
+`genkit.Handler` always writes plain text. To return machine-readable failure detail,
+mount `genkit.HandlerFunc` instead: it runs the action and hands the error back rather
+than writing a response, so you render the body.
+
+```go
+func errorJSON(h func(http.ResponseWriter, *http.Request) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := h(w, r)
+		if err == nil {
+			return
+		}
+
+		// Only a PublicErrorf message is safe to echo. Anything else gets the
+		// generic string PublicMessage derives from the status.
+		msg, public := status.PublicMessage(err)
+		if !public {
+			logger.Error(r.Context(), "flow failed", "error", err)
+		}
+
+		// status.Name is a string type, so it encodes as "INVALID_ARGUMENT".
+		body := map[string]any{"status": status.Of(err), "message": msg}
+
+		// Classified reports whether anything in the chain really carried a
+		// status, so an unclassified failure is not read as a deliberate INTERNAL.
+		if _, ok := status.Classified(err); !ok {
+			body["classified"] = false
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status.Of(err).HTTPCode())
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": body})
+	}
+}
+
+mux.Handle("POST /cookbookFlow", errorJSON(genkit.HandlerFunc(flow)))
+```
+
+Write the response before the handler streams, or not at all: on a streaming request
+the headers are already sent, and a failure has to arrive in the body as described in
+[Errors on a streaming request](#errors-on-a-streaming-request).
 
 The redaction is environment-gated. With `GENKIT_ENV=dev` the real `err.Error()` text
 is returned instead of the generic string, so the developer causing the failure can
@@ -258,9 +368,9 @@ if errors.As(err, &ge) {
 }
 ```
 
-**Deprecated but working.** These keep their behavior, including `UserFacingError`,
-whose message still reaches clients and whose status still picks the response code.
-Move at your own pace.
+**Deprecated but working.** These keep their behavior, with one difference noted below
+the table. `UserFacingError`'s message still reaches clients and its status still picks
+the response code. Move at your own pace.
 
 | Deprecated                                | Use instead                                                  |
 | ----------------------------------------- | ------------------------------------------------------------ |
@@ -273,6 +383,12 @@ Move at your own pace.
 | `core.StatusNameToCode[name]`             | `name.Code()`                                                 |
 | `core.Status`, `core.NewStatus`           | `status.Error`, `status.Errorf`                               |
 | `core.INVALID_ARGUMENT` and the other SCREAMING_SNAKE constants | `status.InvalidArgument` and the other Go-cased names |
+
+The one difference is the details payload: `status.PublicErrorf` takes a format string
+and arguments, and has no details parameter. Nothing is lost on the wire, because
+`UserFacingError.Details` was never serialized by `genkit.Handler`, which writes a
+plain-text body. If a custom handler was reading `Details` through `errors.As`, move
+that payload into the flow's own output type, or fold it into the public message.
 
 On `status.Error` itself, the `HTTPCode` and `Source` fields are deprecated as well.
 Use `Status.HTTPCode()` instead of the first; the second is never populated.

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -926,23 +926,82 @@ provided externally.
 
 ### Genkit evaluators
 
-Genkit includes a small number of built-in evaluators, ported from
-the [JS evaluators plugin](https://js.api.genkit.dev/enums/_genkit-ai_evaluator.GenkitMetric.html),
-to help you get started:
+Genkit includes a small number of built-in evaluators to help you get started.
+The Go constant you configure the plugin with and the name the evaluator is
+registered under are different strings, and both matter: the constant goes in
+`MetricConfig`, the registered name goes to `--evaluators` and appears in the
+Dev UI.
 
-- EvaluatorDeepEqual -- Checks if the generated output is deep-equal to the
-  reference output provided.
-- EvaluatorRegex -- Checks if the generated output matches the regular
-  expression provided in the reference field.
-- EvaluatorJsonata -- Checks if the generated output matches the
-  [JSONATA](https://jsonata.org/) expression provided in the
-  reference field.
+| Go constant                   | Registered name          | Checks that                                                                         |
+| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------- |
+| `evaluators.EvaluatorDeepEqual` | `genkitEval/deep_equal` | The output is deep-equal to the reference.                                              |
+| `evaluators.EvaluatorRegex`     | `genkitEval/regex`      | The output matches the regular expression in the reference.                             |
+| `evaluators.EvaluatorJsonata`   | `genkitEval/jsonata`    | The output matches the [JSONata](https://jsonata.org/) expression in the reference.     |
+
+All three require a reference: without one the metric errors with
+`reference was not provided`.
+
+`genkitEval/regex` matches strings only. The reference must be a string regular
+expression, and the output must be a string too. A non-string output, an object
+or an array, is not serialized and is not matched: the metric scores `false` with
+status `FAIL`. For structured outputs use `deep_equal`, or write a custom
+evaluator that marshals the output first.
+
+The Dev UI's Evaluate page lists every registered evaluator name, including the
+custom ones you define.
 
 ### Custom evaluators
 
 You can extend Genkit to support custom evaluation by defining your own evaluator functions. An evaluator can use an LLM as a judge, perform programmatic (heuristic) checks, or call external APIs to assess the quality of a response.
 
 You define a custom evaluator using the `genkit.DefineEvaluatorAction` function. The callback function for the evaluator can contain any logic you need. Its last parameter is the evaluator's config: Genkit infers a JSON schema from that type, validates each request against it, and hands you the deserialized value, so an evaluator that takes no options declares it as `struct{}`.
+
+#### The data point you receive
+
+`req.Input` is one `ai.Example`, the row under evaluation:
+
+```go
+type Example struct {
+	TestCaseId string   `json:"testCaseId,omitempty"`
+	Input      any      `json:"input"`
+	Output     any      `json:"output,omitempty"`
+	Context    []any    `json:"context,omitempty"`
+	Reference  any      `json:"reference,omitempty"`
+	TraceIds   []string `json:"traceIds,omitempty"`
+}
+```
+
+`Input`, `Output` and `Reference` are `any`, holding decoded JSON: a
+`map[string]any` for an object, a `float64` for any number, a `string` for a
+string. `Context` is `[]any` of the same. Reading a structured value therefore
+takes a type assertion, or a round trip through `json.Marshal` into your own
+struct. `Reference` is the field the built-in `deep_equal` and `regex`
+evaluators compare against; it is passed through verbatim from the dataset and
+never touched by inference.
+
+#### The score you return
+
+Each entry in the `Evaluation` slice is an `ai.Score`:
+
+```go
+type Score struct {
+	Id      string         `json:"id,omitempty"`
+	Score   any            `json:"score,omitempty"`
+	Status  string         `json:"status,omitempty"` // UNKNOWN, FAIL, or PASS
+	Error   string         `json:"error,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+```
+
+`Score` is `any`, so a number, a boolean, or a string are all valid; the
+built-in evaluators store a boolean. `Status` is what the Dev UI keys pass/fail
+highlighting on, so set it with `ai.ScoreStatusPass.String()`,
+`ai.ScoreStatusFail.String()`, or `ai.ScoreStatusUnknown.String()` rather than a
+bare string. `Details` is free-form and displayed alongside the score, which is
+where the reasoning behind a judgement belongs. `Error` carries a per-score
+failure message when one score failed but the others are still usable. `Id`
+labels a score, so one evaluator may return several distinct scores in a single
+`Evaluation` slice.
 
 Here's an example of a custom evaluator that uses an LLM to check for "deliciousness":
 
@@ -951,6 +1010,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/api"
@@ -992,9 +1052,25 @@ func NewFoodEvaluator(g *genkit.Genkit) ai.Evaluator {
 			//      Value: outputStr,
 			// })
 
+			// Turn the judge's verdict into a numeric score and a status the
+			// Dev UI can highlight on, and keep its wording as the reasoning.
+			verdict := strings.ToLower(strings.TrimSpace(resp.Text()))
+			score, statusName := 0.0, ai.ScoreStatusFail
+			switch {
+			case strings.HasPrefix(verdict, "yes"):
+				score, statusName = 1.0, ai.ScoreStatusPass
+			case strings.HasPrefix(verdict, "maybe"):
+				score, statusName = 0.5, ai.ScoreStatusUnknown
+			}
+
 			return &ai.EvaluatorCallbackResponse{
 				TestCaseId: req.Input.TestCaseId,
-				Evaluation: []ai.Score{{Score: resp.Text()}},
+				Evaluation: []ai.Score{{
+					Id:      "deliciousness",
+					Score:   score,
+					Status:  statusName.String(),
+					Details: map[string]any{"reasoning": resp.Text()},
+				}},
 			}, nil
 		},
 	)
@@ -1013,6 +1089,47 @@ genkit eval:flow myFlow --input myDataset.json --evaluators=custom/foodEvaluator
 
 Along with its basic functionality, Genkit also provides advanced support for
 certain evaluation use cases.
+
+### Evaluation comparison
+
+The Developer UI can show several evaluation runs side by side, so you can see
+what a prompt or model change did to output quality. One run is designated the
+_Baseline_, and every other run in the comparison is judged improved or
+regressed against it.
+
+<ThemeImage
+  lightSrc="/src/assets/evals_compare_light.png"
+  darkSrc="/src/assets/evals_compare_dark.png"
+  alt="Evaluation comparison with metric highlighting"
+/>
+
+Comparison has three prerequisites:
+
+- The evaluations must come from a dataset source. Runs from a file are not
+  comparable.
+- Every evaluation compared must be from the same dataset.
+- For metric highlighting, they must share at least one metric that produces a
+  number or a boolean score.
+
+To compare runs:
+
+1.  Perform at least two evaluation runs on the same dataset, as described in
+    [Run evaluation and view results](#run-evaluation-and-view-results).
+
+2.  In the Developer UI, go to the **Datasets** page, select the dataset, and
+    open its **Evaluations** tab.
+
+3.  Open the run you want as the baseline and click **+ Comparison**. A disabled
+    button means no other comparable run exists for this dataset.
+
+4.  Pick another run from the dropdown in the new column. Up to three runs can
+    be compared at once.
+
+To color-code the difference, choose a metric from the **Choose a metric to
+compare** menu. Improvements are green and regressions red. By default lower
+numeric scores and `false` boolean values count as improvements; tick the
+checkbox in the menu to reverse that. Highlighting works on numeric and boolean
+metrics only, and the metric has to be present in every run being compared.
 
 ### Evaluation using the CLI
 
@@ -1048,15 +1165,43 @@ field and an optional `reference` field, like below:
   {
     "input": "What green vegetable looks like cauliflower?",
     "reference": "Broccoli"
+  },
+  {
+    "input": { "query": "Which animals did dogs evolve from?", "locale": "en" },
+    "reference": "(?i)wolf|wolves"
   }
 ]
 ```
+
+`input` is handed to the flow as its input value verbatim, and it can be any
+JSON type. The strings in the first two rows are only because the sample
+`qaFlow` takes a `string`; a flow whose input is a struct takes an object, as in
+the third row. Nothing stringifies it on the way in.
 
 If your flow requires auth, you may specify it using the `--context` argument:
 
 ```bash
 genkit eval:flow qaFlow --input testInputs.json --context '{"auth": {"email_verified": true}}' -- go run main.go
 ```
+
+That JSON object becomes the flow's runtime context. Read it inside the flow
+with `core.FromContext`, which returns a `core.ActionContext`, an alias for
+`map[string]any`:
+
+```go
+import "github.com/firebase/genkit/go/core"
+
+genkit.DefineFlow(g, "qaFlow", func(ctx context.Context, query string) (string, error) {
+	auth, _ := core.FromContext(ctx)["auth"].(map[string]any)
+	if verified, _ := auth["email_verified"].(bool); !verified {
+		return "", status.PublicErrorf(status.ErrPermissionDenied, "verified email required")
+	}
+	// ...
+})
+```
+
+In production the same map is populated by `genkit.WithContextProviders`, so the
+flow reads context identically whether it was invoked by the CLI or over HTTP.
 
 By default, the `eval:flow` and `eval:run` commands use all available metrics
 for evaluation. To run on a subset of the configured evaluators, use the
@@ -1086,10 +1231,11 @@ Run your flow over your test inputs:
 genkit flow:batchRun qaFlow testInputs.json -- go run main.go
 ```
 
-Extract the evaluation data:
+Extract the evaluation data. `--maxRows` defaults to 100; the dataset built
+earlier in this guide has 3 examples:
 
 ```bash
-genkit eval:extractData qaFlow --maxRows 2 --output factsEvalDataset.json
+genkit eval:extractData qaFlow --maxRows 3 --output factsEvalDataset.json -- go run main.go
 ```
 
 The exported data has a format different from the dataset format presented
@@ -1112,12 +1258,215 @@ to the context array. You can run evaluation metrics on this extracted dataset
 using the `eval:run` command.
 
 ```bash
-genkit eval:run factsEvalDataset.json
+genkit eval:run factsEvalDataset.json -- go run main.go
 ```
+
+Like every other command on this page, `eval:extractData` and `eval:run` attach
+to a running runtime, so pass one after `--`.
 
 By default, `eval:run` runs against all configured evaluators, and as with
 `eval:flow`, results for `eval:run` appear in the evaluation page of Developer
 UI, located at `localhost:4000/evaluate`.
+
+### Evaluation in CI
+
+Both `eval:flow` and `eval:run` can write the run to disk instead of leaving it
+in the Dev UI. `--output-format` accepts `json` (the default) or `csv`:
+
+```bash
+genkit eval:flow qaFlow --input testInputs.json -o results.json --output-format json -- go run main.go
+```
+
+`eval:run` takes the same pair of flags, spelled `--output` (it has no `-o`
+short form).
+
+:::caution[The CLI does not gate on scores]
+Genkit implements no per-metric thresholds and no baseline comparison at the CLI
+level. `eval:flow` and `eval:run` exit non-zero when the run itself fails, and
+exit 0 whether or not a metric scored badly. A passing exit code says nothing
+about the scores.
+:::
+
+The JSON file is an array of results, one per test case, each carrying the
+extracted `input`, `output` and `context` plus a `metrics` array whose entries
+look like this:
+
+```json
+{
+  "evaluator": "genkitEval/regex",
+  "scoreId": "deliciousness",
+  "score": true,
+  "status": "PASS",
+  "rationale": "...",
+  "error": null,
+  "traceId": "..."
+}
+```
+
+To gate a build, read that file and assert on it yourself:
+
+```yaml
+- name: Run evals
+  run: genkit eval:flow qaFlow --input testInputs.json -o results.json -- go run main.go
+
+- name: Fail below threshold
+  run: |
+    rate=$(jq '[.[].metrics[]? | select(.evaluator == "genkitEval/regex") | .status]
+               | (map(select(. == "PASS")) | length) / length' results.json)
+    echo "pass rate: $rate"
+    awk -v r="$rate" 'BEGIN { exit (r >= 0.8 ? 0 : 1) }'
+```
+
+A small Go program reading the same file works just as well, and is easier to
+maintain once the assertion covers more than one metric.
+
+### Custom extractors
+
+Genkit's tooling has default logic for pulling the `input`, `output` and
+`context` fields out of a trace. When you need something else, override it with
+an extractor. Extractors apply to the `eval:extractData` and `eval:flow`
+commands.
+
+Extraction works off named steps, so give the step you want to read from a name
+with `genkit.Run`:
+
+```go
+genkit.DefineFlow(g, "qaFlow", func(ctx context.Context, query string) (string, error) {
+	factDocs, err := genkit.Retrieve(ctx, g, ai.WithRetriever(factsRetriever), ai.WithTextDocs(query))
+	if err != nil {
+		return "", err
+	}
+
+	// Keep only the facts worth answering from; isSillyFact is your own
+	// predicate. Any step you name here can be referenced by an extractor.
+	factDocsModified, err := genkit.Run(ctx, "factModified", func() ([]*ai.Document, error) {
+		var kept []*ai.Document
+		for _, d := range factDocs.Documents {
+			if isSillyFact(d.Content[0].Text) {
+				kept = append(kept, d)
+			}
+		}
+		return kept, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithPrompt("Answer this question with the given context: %s", query),
+		ai.WithDocs(factDocsModified...),
+	)
+	if err != nil {
+		return "", err
+	}
+	return resp.Text(), nil
+})
+```
+
+Extractors are configured in `genkit-tools.conf.js` at your project root. That
+file belongs to the Genkit CLI, not to any one SDK, so it is a JavaScript file
+even in a Go project and it needs no Node dependencies:
+
+```bash
+cd /path/to/your/genkit/app
+touch genkit-tools.conf.js
+```
+
+```js
+module.exports = {
+  evaluators: [
+    {
+      actionRef: '/flow/qaFlow',
+      extractors: {
+        context: { outputOf: 'factModified' },
+      },
+    },
+  ],
+};
+```
+
+Run the evaluation again and `context` is now the output of the `factModified`
+step rather than the retriever's raw result:
+
+```bash
+genkit eval:flow qaFlow --input testInputs.json -- go run main.go
+```
+
+The config takes:
+
+- `evaluators`: an array of entries, each scoped to one action by `actionRef`.
+- `extractors`: the overrides for that action. The supported keys are `input`,
+  `output` and `context`. A value can be:
+  - a string, read as a step name, whose output is extracted;
+  - `{ inputOf: 'step' }` or `{ outputOf: 'step' }`, to pick one side of a step;
+  - a function taking the trace and returning any value, for anything more
+    involved. The trace schema is in
+    `genkit-tools/common/src/types/trace.ts`.
+
+The extracted value keeps the type the step produced. If `factModified` returns
+an array of documents, the extracted `context` is an array of documents.
+
+### Synthesizing test data using an LLM
+
+A dataset is easier to build if a model drafts it. This flow reads a PDF and
+turns each chunk into a candidate question. It uses the same two libraries as
+the [RAG guide](/docs/rag): `github.com/ledongthuc/pdf` to read the file and
+`github.com/tmc/langchaingo/textsplitter` to chunk it.
+
+```bash
+go get github.com/tmc/langchaingo/textsplitter
+go get github.com/ledongthuc/pdf
+```
+
+```go
+type QuestionSet struct {
+	Questions []string `json:"questions"`
+}
+
+splitter := textsplitter.NewRecursiveCharacter(
+	textsplitter.WithChunkSize(2000),
+	textsplitter.WithChunkOverlap(100),
+)
+
+genkit.DefineFlow(g, "synthesizeQuestions", func(ctx context.Context, path string) (*QuestionSet, error) {
+	// readPDF extracts the file's text; see the RAG guide for its body.
+	text, err := genkit.Run(ctx, "extract-text", func() (string, error) {
+		return readPDF(path)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	chunks, err := genkit.Run(ctx, "chunk-it", func() ([]string, error) {
+		return splitter.SplitText(text)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := &QuestionSet{}
+	for _, chunk := range chunks {
+		resp, err := genkit.Generate(ctx, g,
+			ai.WithPrompt("Generate one question about the following text: %s", chunk),
+		)
+		if err != nil {
+			return nil, err
+		}
+		out.Questions = append(out.Questions, resp.Text())
+	}
+	return out, nil
+})
+```
+
+Run it and write the questions to a file:
+
+```bash
+genkit flow:run synthesizeQuestions '"my_input.pdf"' --output synthesizedQuestions.json -- go run main.go
+```
+
+Reshape that file into the `[{"input": ...}]` dataset format before passing it
+to `eval:flow`, and read the questions before you trust them: a model drafting
+its own test set will happily write questions the source text does not answer.
 
 ## Next steps
 

--- a/src/content/docs/docs/evaluation.mdx
+++ b/src/content/docs/docs/evaluation.mdx
@@ -1280,11 +1280,8 @@ genkit eval:flow qaFlow --input testInputs.json -o results.json --output-format 
 `eval:run` takes the same pair of flags, spelled `--output` (it has no `-o`
 short form).
 
-:::caution[The CLI does not gate on scores]
-Genkit implements no per-metric thresholds and no baseline comparison at the CLI
-level. `eval:flow` and `eval:run` exit non-zero when the run itself fails, and
-exit 0 whether or not a metric scored badly. A passing exit code says nothing
-about the scores.
+:::note[Score assertions in CI]
+`eval:flow` and `eval:run` exit with a non-zero code if the evaluation process encounters an error. To enforce custom quality thresholds in automated pipelines, read the output JSON file and assert on the `metrics` array (for example, verifying that required metrics meet your target pass rate).
 :::
 
 The JSON file is an array of results, one per test case, each carrying the
@@ -1302,23 +1299,6 @@ look like this:
   "traceId": "..."
 }
 ```
-
-To gate a build, read that file and assert on it yourself:
-
-```yaml
-- name: Run evals
-  run: genkit eval:flow qaFlow --input testInputs.json -o results.json -- go run main.go
-
-- name: Fail below threshold
-  run: |
-    rate=$(jq '[.[].metrics[]? | select(.evaluator == "genkitEval/regex") | .status]
-               | (map(select(. == "PASS")) | length) / length' results.json)
-    echo "pass rate: $rate"
-    awk -v r="$rate" 'BEGIN { exit (r >= 0.8 ? 0 : 1) }'
-```
-
-A small Go program reading the same file works just as well, and is easier to
-maintain once the assertion covers more than one metric.
 
 ### Custom extractors
 

--- a/src/content/docs/docs/flows.mdx
+++ b/src/content/docs/docs/flows.mdx
@@ -128,6 +128,10 @@ func main() {
 }
 ```
 
+`genkit.Init` returns a `*genkit.Genkit`, and that is the value every other
+Genkit call takes. When your flows live in other files, pass it in:
+`func defineMenuFlows(g *genkit.Genkit)`.
+
 </Lang>
 
 <Lang lang="dart">
@@ -334,6 +338,11 @@ something other than text, such as a tool request or an interrupt, so inspect
 what to do. The
 [basic-structured sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-structured)
 works through typed output, including the nested and streaming cases.
+
+`status.Errorf` comes from `github.com/firebase/genkit/go/core/status`. It
+classifies the failure as `INTERNAL` so the HTTP boundary can pick a response
+code without re-reading the message; see
+[Handling errors in flows](#handling-errors-in-flows) below.
 
 </Lang>
 
@@ -704,6 +713,24 @@ shows the forwarding shape, and the
 [basic-structured sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-structured)
 has both shapes side by side.
 
+The snippets in this section assume these imports:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+)
+```
+
+`core.StreamCallback[T]` is a type alias for `func(context.Context, T) error`,
+so writing the function type out longhand is the same declaration.
+`ai.ModelStreamCallback` is that alias with `T` set to `*ai.ModelResponseChunk`.
+
 #### Forwarding the model's chunks
 
 When the flow passes the model's output straight through, `ai.WithStreaming` is
@@ -774,6 +801,22 @@ does not have to be the same type as the flow's complete output (`Menu` here).
 `chunk.Text()` is the text that just arrived rather than the message so far, so
 forwarding it gives a client something to append.
 
+`genkit.DefineFlow` returns `*core.Flow[In, Out, struct{}]` and
+`genkit.DefineStreamingFlow` returns `*core.Flow[In, Out, Stream]`, so a flow
+that lives in its own file is declared with its concrete type:
+
+```go
+func newMenuSuggestionFlow(g *genkit.Genkit) *core.Flow[MenuSuggestionInput, Menu, string] {
+	return genkit.DefineStreamingFlow(g, "menuSuggestionFlow",
+		func(ctx context.Context, input MenuSuggestionInput, sendChunk core.StreamCallback[string]) (Menu, error) {
+			// ...
+			return Menu{}, nil
+		})
+}
+```
+
+`genkit.DefineTool` returns `*ai.ToolAction[In, Out]` on the same principle.
+
 #### Acting on the chunks
 
 When the flow has to inspect, filter, or accumulate what arrives, range over
@@ -808,31 +851,33 @@ inferred from `T`:
 
 ```go
 menuSuggestionFlow := genkit.DefineStreamingFlow(g, "menuSuggestionFlow",
-	func(ctx context.Context, input MenuSuggestionInput, sendChunk core.StreamCallback[*MenuItem]) (*MenuItem, error) {
-		for result, err := range genkit.GenerateDataStream[*MenuItem](ctx, g,
+	func(ctx context.Context, input MenuSuggestionInput, sendChunk core.StreamCallback[MenuItem]) (MenuItem, error) {
+		for result, err := range genkit.GenerateDataStream[MenuItem](ctx, g,
 			ai.WithPrompt("Invent a menu item for a %s themed restaurant.", input.Theme),
 		) {
 			if err != nil {
-				return nil, fmt.Errorf("could not invent a menu item: %w", err)
+				return MenuItem{}, fmt.Errorf("could not invent a menu item: %w", err)
 			}
 			if result.Done {
-				// result.Output is strongly typed as *MenuItem.
+				// result.Output is strongly typed as MenuItem.
 				return result.Output, nil
 			}
 			// result.Chunk is the whole MenuItem parsed so far.
 			sendChunk(ctx, result.Chunk)
 		}
 
-		return nil, status.Errorf(status.ErrInternal, "the stream ended without a final result")
+		return MenuItem{}, status.Errorf(status.ErrInternal, "the stream ended without a final result")
 	})
 ```
 
 With the default JSON format each chunk replaces the previous one rather than
 adding to it: the whole value is reparsed from everything received so far, so
-fields fill in as the model writes them. A chunk that has not parsed into
-anything yet is skipped when the type parameter is a pointer, so `result.Chunk`
-is never nil here. With a value type such as `MenuItem` those chunks arrive as
-the zero value instead.
+fields fill in as the model writes them. Guard on a field you care about rather
+than assuming every chunk carries something new. Use the pointer form,
+`GenerateDataStream[*MenuItem]`, only when you want chunks that have not parsed
+into anything yet dropped instead of delivered as a zero value;
+[Generating content](/docs/models#streaming-structured-output) has the full
+rationale.
 
 The values a flow streams are often coupled to the values the generation call
 inside it streams, but they do not have to be. You can call `sendChunk` as often
@@ -1199,8 +1244,15 @@ UI.
 
 The developer UI relies on the Go app continuing to run, even if the logic has
 completed. If you are just getting started and Genkit is not part of a broader
-app, add `select {}` as the last line of `main()` to prevent the app from
-shutting down so that you can inspect it in the UI.
+app, end `main()` by starting a server instead of returning:
+
+```go
+log.Fatal(server.Start(ctx, "127.0.0.1:3400", http.NewServeMux()))
+```
+
+That keeps the process alive, serves whatever you mount on the mux, and still
+exits on Ctrl-C. A bare `select {}` also keeps the process alive, but it ignores
+`SIGINT`, so you have to kill the process to stop it.
 
 </Lang>
 
@@ -1608,6 +1660,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core/status"
@@ -1647,13 +1700,27 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /menuSuggestionFlow", genkit.Handler(menuSuggestionFlow))
-	log.Fatal(server.Start(ctx, "127.0.0.1:3400", mux))
+
+	// Bind 0.0.0.0 and honor $PORT: Cloud Run and most other hosts inject the
+	// port and health-check the container from outside, so a loopback bind
+	// fails to start.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3400"
+	}
+	log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
 }
 ```
 
-`server.Start()` is an optional helper function that starts the server and
-manages its lifecycle, including capturing interrupt signals to ease local
-development, but you may use your own method.
+`server.Start()` is optional, but it is more than a local-development
+convenience: it traps `SIGINT` and `SIGTERM`, stops accepting new connections,
+and calls `http.Server.Shutdown` with a fixed 5-second budget to drain
+in-flight requests. That budget is not configurable. If a single flow can
+legitimately run longer than five seconds, which a multi-turn model call often
+does, construct your own `http.Server` and drain it on your own schedule.
+
+Bind `127.0.0.1` only when you mean local-only, such as while running under the
+Developer UI.
 
 To serve all the flows defined in your codebase, you can use
 `genkit.ListFlows()`:
@@ -1663,8 +1730,121 @@ mux := http.NewServeMux()
 for _, flow := range genkit.ListFlows(g) {
     mux.HandleFunc("POST /"+flow.Name(), genkit.Handler(flow))
 }
-log.Fatal(server.Start(ctx, "127.0.0.1:3400", mux))
+log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
 ```
+
+This mounts every registered flow, including any you did not mean to expose.
+Mount flows one at a time, or filter the list, when the process defines internal
+flows as well as public ones.
+
+### Handling flow errors centrally
+
+`genkit.Handler` writes the error itself. When your framework already has one
+place that turns an error into a response, use `genkit.HandlerFunc` instead:
+
+```go
+func HandlerFunc(a api.Action, opts ...HandlerOption) func(http.ResponseWriter, *http.Request) error
+```
+
+It takes the action, not the `*genkit.Genkit` (`api.Action` is the interface a
+flow, tool, or prompt satisfies), accepts the same `HandlerOption`s as
+`genkit.Handler`, and panics if an option fails to apply.
+The returned function runs the flow and hands you its error, so your own
+middleware decides the status and the body:
+
+```go
+func withErrors(h func(http.ResponseWriter, *http.Request) error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := h(w, r)
+		if err == nil {
+			return
+		}
+		log.Printf("flow %s failed: %v", r.URL.Path, err)
+		// PublicMessage substitutes a generic string unless the error was
+		// built with status.PublicErrorf, so internal detail stays server-side.
+		msg, _ := status.PublicMessage(err)
+		http.Error(w, msg, status.Of(err).HTTPCode())
+	})
+}
+
+mux.Handle("POST /menuSuggestionFlow", withErrors(genkit.HandlerFunc(menuSuggestionFlow)))
+```
+
+### Protecting deployed flows
+
+`genkit.Handler` performs no authentication. It decodes the request, applies the
+`HandlerOption`s you passed, and runs the flow. A flow you mount is open to
+anyone who can reach the port, so put your own middleware in front of it. The
+fragments below add `strings` and `github.com/firebase/genkit/go/core` to the
+imports of the program above:
+
+```go
+func requireBearerToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if _, err := verifyToken(r.Context(), token); err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+`verifyToken` is yours to write against whatever issues your tokens; Genkit does
+not supply one.
+
+To let the flow itself see who is calling, pass a context provider. It runs per
+request and its result becomes the flow's action context:
+
+```go
+func callerFromRequest(ctx context.Context, req core.RequestData) (core.ActionContext, error) {
+	// req.Headers keys are lowercased.
+	uid, err := verifyToken(ctx, strings.TrimPrefix(req.Headers["authorization"], "Bearer "))
+	if err != nil {
+		return nil, err
+	}
+	return core.ActionContext{"uid": uid}, nil
+}
+
+mux.Handle("POST /menuSuggestionFlow", requireBearerToken(
+	genkit.Handler(menuSuggestionFlow, genkit.WithContextProviders(callerFromRequest)),
+))
+```
+
+Inside the flow, read it back with `core.FromContext`:
+
+```go
+uid, _ := core.FromContext(ctx)["uid"].(string)
+```
+
+Verify the credential in the middleware, not only in the context provider, so an
+unauthenticated request never reaches the flow.
+
+### Concurrency, timeouts, and lifetime
+
+A `*genkit.Genkit`, and the flow, tool, and prompt values the `Define*`
+functions return, are safe for concurrent use by many goroutines; the registry
+behind them is mutex-guarded. Create one instance in `main()`, define every
+flow, tool, and schema during startup before the server begins serving, and
+share that instance across all request handlers. Constructing a `*genkit.Genkit`
+per request re-runs plugin initialization and is never correct.
+
+Genkit has no timeout option. Bound a flow or a generate call with the standard
+library:
+
+```go
+ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+defer cancel()
+```
+
+The deadline propagates to the model client and to any tool the turn calls. An
+expired deadline surfaces as `DEADLINE_EXCEEDED`, which retry middleware treats
+as retryable; an explicit cancellation surfaces as `CANCELLED` and stops
+retries.
+
+[Concurrency, cancellation, and lifecycle](/docs/concurrency) has the rest:
+parallel tool fan-out, abandoning a stream, and flushing telemetry on shutdown.
 
 ### Other server frameworks
 

--- a/src/content/docs/docs/get-started.mdx
+++ b/src/content/docs/docs/get-started.mdx
@@ -166,6 +166,131 @@ If you're not ready to choose a framework yet, explore [Creating flows](/docs/fl
 
 <Lang lang="go">
 
+## Hello, Genkit
+
+Before picking a framework, get one model call running. This takes about two
+minutes and needs nothing but the Go toolchain and an API key.
+
+**1. Create a module and add Genkit.**
+
+```bash
+mkdir hello-genkit && cd hello-genkit
+go mod init example/hello-genkit
+go get github.com/firebase/genkit/go
+```
+
+Genkit for Go needs **Go 1.25 or later**. The plugins live in the same module,
+so a single `go get` is enough; run `go mod tidy` after you paste the code below
+to pull in the provider SDK it needs.
+
+**2. Get a Gemini API key** from [Google AI Studio](https://aistudio.google.com/apikey)
+and put it in your environment:
+
+```bash
+export GEMINI_API_KEY=<your API key>
+```
+
+**3. Write `main.go`.**
+
+```go title="main.go"
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Init registers the plugin's models and returns the handle every other
+	// Genkit call takes. It returns one value, not (value, error): a plugin
+	// that cannot start panics here, so a missing API key fails at startup
+	// rather than on the first request.
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
+	)
+
+	// A flow is an ordinary Go function that Genkit traces, validates against
+	// the input and output types you declared, and exposes to the Developer UI
+	// and to HTTP.
+	jokeFlow := genkit.DefineFlow(g, "jokeFlow",
+		func(ctx context.Context, topic string) (string, error) {
+			resp, err := genkit.Generate(ctx, g,
+				ai.WithSystem("You are a stand-up comedian. One line, no preamble."),
+				ai.WithPrompt("Tell a joke about %s.", topic),
+			)
+			if err != nil {
+				return "", err
+			}
+			return resp.Text(), nil
+		})
+
+	joke, err := jokeFlow.Run(ctx, "gophers")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(joke)
+}
+```
+
+**4. Run it.**
+
+```bash
+go mod tidy
+go run .
+```
+
+You should see a one-line joke. If you see a panic mentioning `GEMINI_API_KEY`,
+step 2 did not take effect in this shell.
+
+**5. Optional: open the Developer UI.** Install the CLI, then run your program
+under it to get a visual flow runner and a trace for every model call:
+
+```bash
+curl -sL cli.genkit.dev | bash
+genkit start -- go run .
+```
+
+The UI opens at `http://localhost:4000`. See
+[Developer tools](/docs/devtools) for what it can do.
+
+That is the whole core loop: initialize, define a flow, generate, run. Everything
+below builds on it.
+
+### What `Init` gives you
+
+```go
+func Init(ctx context.Context, opts ...GenkitOption) *Genkit
+```
+
+`Init` returns one value and no error. Configuration problems fail loudly at
+startup instead of on the first request: a plugin with a missing API key, two
+plugins claiming the same name, or a prompt directory you named that does not
+exist all panic inside `Init`. There is no error-returning variant, so validate
+anything you need to choose at runtime before you call it.
+
+The `*genkit.Genkit` it returns is the handle every other Genkit call takes.
+Pass it to functions that define flows, tools, or prompts, such as
+`func defineTools(g *genkit.Genkit)`. Create exactly one per process in
+`main()`: it is safe for concurrent use by many goroutines, and so are the
+flow, tool, and prompt values the `Define*` functions return. Define everything
+during startup, before you serve traffic, and share the one instance across all
+request handlers.
+
+There is no default per-request timeout, and retries and provider fallback are
+opt-in [middleware](/docs/middleware) rather than defaults. See
+[Concurrency, cancellation, and lifecycle](/docs/concurrency) before you put
+this behind a server.
+
+## Serve it over HTTP
+
 With Genkit for Go, your AI logic runs in a standalone backend. You'll get there in two steps:
 
 1. **Build a backend.** Pick a backend framework below and follow its guide to expose your Genkit flows over HTTP. This is where your model calls, tools, and flows live.
@@ -264,6 +389,12 @@ Pair a Go Genkit backend with any of these frontends. Each guide shows how to ca
 </CardGrid>
 
 If you're not ready to choose a framework yet, explore [Creating flows](/docs/flows) and [Generating content](/docs/models) to learn the core concepts first. For a runnable version of each of those concepts, the [Go sample programs](https://github.com/genkit-ai/genkit/tree/main/go/samples) are one self-documenting program per topic, starting with [basic](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic).
+
+Two more pages pay off early:
+[Testing your AI logic](/docs/testing), which runs flows in-process against a
+fake model so CI needs no API key, and
+[Concurrency, cancellation, and lifecycle](/docs/concurrency), which states what
+is safe to share and how deadlines propagate.
 
 </Lang>
 

--- a/src/content/docs/docs/integrations/alloydb.mdx
+++ b/src/content/docs/docs/integrations/alloydb.mdx
@@ -5,7 +5,68 @@ supportedLanguages:
   - go
 ---
 
-The AlloyDB plugin provides provides the retriever implementation to search a [AlloyDB](https://cloud.google.com/alloydb/docs) database using the [pgvector](https://github.com/pgvector/pgvector) extension.
+The AlloyDB plugin provides the retriever implementation to search an [AlloyDB](https://cloud.google.com/alloydb/docs) database using the [pgvector](https://github.com/pgvector/pgvector) extension.
+
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/alloydb"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+```
+
+## Prerequisites
+
+### Google Cloud access
+
+The account or service account that runs your application needs:
+
+- `roles/alloydb.client` to connect through the AlloyDB connector.
+- `roles/serviceusage.serviceUsageConsumer` on the project.
+- The AlloyDB API enabled: `gcloud services enable alloydb.googleapis.com`.
+
+`alloydb.WithIAMAccountEmail` uses IAM database authentication, which also requires the account to
+exist as a database user on the cluster.
+
+### The pgvector extension and the table
+
+The plugin reads and writes an existing table. `PostgresEngine.InitVectorstoreTable` creates it, and
+runs `CREATE EXTENSION IF NOT EXISTS vector` first. Once you have a `pEngine` (step 2 of
+[Configuration](#configuration)), call it once, before `genkit.Init`:
+
+```go
+err = pEngine.InitVectorstoreTable(ctx, alloydb.VectorstoreTableOptions{
+	TableName:          "documents",
+	SchemaName:         "public",
+	VectorSize:         768,
+	ContentColumnName:  "content",
+	EmbeddingColumn:    "embedding",
+	IDColumn:           alloydb.Column{Name: "custom_id", DataType: "TEXT"},
+	MetadataColumns:    []alloydb.Column{{Name: "source", DataType: "TEXT", Nullable: true}},
+	MetadataJSONColumn: "custom_metadata",
+	StoreMetadata:      true,
+})
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+That produces an id column, a `content TEXT NOT NULL` column, an `embedding vector(768) NOT NULL`
+column, one column per entry in `MetadataColumns`, and a JSON column when `StoreMetadata` is true.
+
+`VectorSize` must equal the output dimension of the embedder you configure later; 768 is the size
+`text-embedding-004` produces. A mismatch is not caught until the first write fails in Postgres.
+
+:::caution
+`OverwriteExisting: true` drops the table before recreating it. Leave it false against any database
+that holds data you want to keep.
+:::
 
 ## Configuration
 
@@ -37,12 +98,12 @@ pEngine, err := alloydb.NewPostgresEngine(ctx,
 	alloydb.WithIAMAccountEmail("mail@company.com"))
 ```
 
-- Using custom pool
+- Using custom pool (add `github.com/jackc/pgx/v5/pgxpool` to the imports)
 
 ```go
 pool, err := pgxpool.New(ctx, "add_your_connection_string")
 if err != nil {
-	return err
+	log.Fatal(err)
 }
 
 pEngine, err := alloydb.NewPostgresEngine(ctx,
@@ -61,81 +122,122 @@ postgres := &alloydb.Postgres{
 g := genkit.Init(ctx, genkit.WithPlugins(postgres))
 ```
 
+:::danger
+`alloydb.Postgres` keeps its engine in an unexported field and the package exports no constructor or
+setter for it, so this snippet does not compile outside the plugin's own package and there is no
+spelling that does. Until the field is exported, use
+[Cloud SQL for PostgreSQL](/docs/integrations/cloud-sql-postgresql), whose `postgresql.Postgres`
+exposes `Engine *PostgresEngine` and is otherwise identical.
+:::
+
 ## Usage
 
-To add documents to a AlloyDB index, first create an index definition that specifies the features of the table:
+To add documents to an AlloyDB index, first create a document store that specifies the features of
+the table:
 
 ```go
+embedder := googlegenai.VertexAIEmbedder(g, "text-embedding-004")
+
 cfg := &alloydb.Config{
-	TableName:             "documents",
-	SchemaName:            "public",
-	ContentColumn:         "content",
-	EmbeddingColumn:       "embedding",
-	MetadataColumns:       []string{"source", "category"},
-	IDColumn:              "custom_id",
-	MetadataJSONColumn:    "custom_metadata",
-	Embedder:              embedder,
-	EmbedderOptions:       nil,
+	TableName:          "documents",
+	SchemaName:         "public",
+	ContentColumn:      "content",
+	EmbeddingColumn:    "embedding",
+	MetadataColumns:    []string{"source", "category"},
+	IDColumn:           "custom_id",
+	MetadataJSONColumn: "custom_metadata",
+	Embedder:           embedder,
+	EmbedderOptions:    nil,
 }
 
-doc, retriever, err := alloydb.DefineRetriever(ctx, g, postgres, cfg)
+docStore, retriever, err := alloydb.DefineRetriever(ctx, g, postgres, cfg)
 if err != nil {
-  return err
+	log.Fatal(err)
 }
 
 docs := []*ai.Document{{
-        Content: []*ai.Part{{
-        Kind:        ai.PartText,
-        ContentType: "text/plain",
-        Text:        "The product features include...",
-        }},
-      Metadata: map[string]any{"source": "website", "category": "product-docs", "custom_id": "doc-123"},
-  }}
+	Content: []*ai.Part{{
+		Kind:        ai.PartText,
+		ContentType: "text/plain",
+		Text:        "The product features include...",
+	}},
+	Metadata: map[string]any{"source": "website", "category": "product-docs", "custom_id": "doc-123"},
+}}
 
-if err := doc.Index(ctx, docs); err != nil {
-    return err
+if err := docStore.Index(ctx, docs); err != nil {
+	log.Fatal(err)
 }
 ```
+
+`DefineRetriever` returns an `*alloydb.DocStore` as its first value, the handle used for writes. It
+has two methods: `Index(ctx, docs []*ai.Document) error` and
+`Retrieve(ctx, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error)`. Its second value is the
+`ai.Retriever` registered with Genkit, which is what you pass to `genkit.Retrieve`. Call
+`DefineRetriever` once per table and keep both values.
 
 Similarly, to retrieve documents from an index, use the retriever
 method:
 
 ```go
-doc,  retriever, err := alloydb.DefineRetriever(ctx, g, postgres, cfg)
-if err != nil {
-  return err
-}
-
 d2 := ai.DocumentFromText("The product features include...", nil)
 
 resp, err := retriever.Retrieve(ctx, &ai.RetrieverRequest{
-    Query: d2,
-    Options: &alloydb.RetrieverOptions{
-        K: 5,
-        Filter: "source='website' AND category='product-docs'",
-    },
+	Query: d2,
+	Options: &alloydb.RetrieverOptions{
+		K:      5,
+		Filter: "source = 'website' AND category = 'product-docs'",
+	},
 })
-
 if err != nil {
-    return err
+	log.Fatal(err)
 }
 ```
 
-It's also possible to use the Retrieve method from genkit
+It's also possible to use the Retrieve method from genkit:
 
 ```go
 d2 := ai.DocumentFromText("The product features include...", nil)
 
 retrieverOptions := &alloydb.RetrieverOptions{
 	K:      5,
-	Filter: "source='website' AND category='product-docs'",
+	Filter: "source = 'website' AND category = 'product-docs'",
 }
 
 resp, err := genkit.Retrieve(ctx, g, ai.WithRetriever(retriever), ai.WithDocs(d2), ai.WithConfig(retrieverOptions))
 if err != nil {
-    return err
+	log.Fatal(err)
 }
 ```
+
+### Retriever options
+
+`alloydb.RetrieverOptions` has three fields:
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `Filter` | `any` | `nil` | Predicate for the query's `WHERE` clause. |
+| `K` | `int` | 4 | Number of documents to return. |
+| `DistanceStrategy` | `DistanceStrategy` | `alloydb.CosineDistance{}` | Vector similarity operator. The others are `alloydb.Euclidean{}` and `alloydb.InnerProduct{}`. |
+
+Any predicate legal in a `WHERE` clause against your table is accepted, including JSON operators on
+`MetadataJSONColumn`, for example `custom_metadata->>'tenant' = 'acme'`.
+
+:::danger
+`Filter` is formatted straight into the `WHERE` clause with `fmt.Sprintf`. It is not parameterised.
+Never build this value from untrusted input. To filter on a user-supplied value, validate it against
+an allowlist first, or map the user's choice onto a fixed predicate you wrote yourself.
+:::
+
+## Production notes
+
+`PostgresEngine` wraps a `*pgxpool.Pool`, so the engine, the `*DocStore` and the `ai.Retriever` it
+produces are safe to share across request goroutines. Build them once at startup, not per request.
+
+- Call `defer pEngine.Close()` on shutdown. `Close` closes the pool unconditionally, including a pool
+  you supplied with `WithPool`, so do not share that pool with code that outlives the engine.
+- To control pool sizing and connection limits, build the pool yourself from a `pgxpool.Config` and
+  pass it in with `WithPool`. `pEngine.GetClient()` returns the pool if you need to reach it later.
+- Per-request `context` deadlines pass through to pgx. Cancelling a request context aborts its query.
 
 See the [Retrieval-augmented generation](/docs/rag) page for a general
 discussion on using retrievers for RAG.

--- a/src/content/docs/docs/integrations/anthropic.mdx
+++ b/src/content/docs/docs/integrations/anthropic.mdx
@@ -893,6 +893,35 @@ resp, err := genkit.Generate(ctx, g,
 
 The compatible plugin reads `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL`, defaulting to `https://api.anthropic.com/v1`; a base URL without the `/v1` segment gets it appended. Unlike the rest of the `compat_oai` family, it does not panic when no key is configured. It registers 16 models at `Init`, keyed mostly by dated snapshot: `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`, `claude-opus-4-1-20250805`, `claude-3-7-sonnet-20250219`, `claude-3-5-haiku-20241022`, `claude-3-5-sonnet-20240620`, `claude-3-opus-20240229`, and `claude-3-haiku-20240307`. Dateless aliases ride along as versions of the dated entries, and any other Claude ID still resolves on demand. The Claude 3 Opus, Claude 3 Haiku, and Claude 3.5 Sonnet entries are marked as not supporting the system role.
 
+### Generation config for the compatible plugin
+
+`compat_oai/anthropic.ChatConfig` carries only the fields Anthropic's OpenAI-compatible endpoint honors:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Temperature` | `*float64` | Randomness of token selection, 0 to 1. The endpoint caps a larger value at 1 rather than honoring it, so the schema stops where the behavior does. |
+| `MaxOutputTokens` | `int` | Sent as the API's `max_tokens`. Minimum 1. |
+| `TopP` | `*float64` | Nucleus sampling threshold. Anthropic documents no range, so the schema declares none. |
+| `StopSequences` | `[]string` | Stop generation when produced by the model. The endpoint rejects whitespace-only sequences. |
+| `Thinking` | `*anthropic.ThinkingConfig` | Extended thinking controls. See the next table. |
+
+`anthropic.ThinkingConfig`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Type` | `string` | `"enabled"` or `"disabled"`. Not a closed enum in the schema: Anthropic documents no fixed set, and the native API's set has grown, so a list here would reject a value the endpoint accepts. |
+| `BudgetTokens` | `int` | Sent as the API's `budget_tokens`. At least 1024, and below `MaxOutputTokens`. |
+
+`ChatConfig` also embeds `compat_oai.RequestConfig`, which every plugin in the family shares:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `APIKey` | `string` | Overrides the plugin's key for this request alone. It never serializes, so it stays out of the advertised schema, recorded traces, and the outgoing body, and it can only be set from a typed config in code. |
+| `Version` | `string` | Pins the exact model version the request is served by, for example `claude-sonnet-4-5-20250929`. Overrides the model ID the request would otherwise carry. |
+| `Extra` | `map[string]any` | Request body fields sent verbatim, keyed by the provider's wire names (usually snake_case). A colliding key wins over the declared field. Fields Genkit builds from the request, such as `messages` and `tools`, are rejected. |
+
+Penalties, log probabilities, seed, and `response_format` are deliberately absent, because Anthropic documents the [OpenAI-compatible endpoint](https://platform.claude.com/docs/en/api/openai-sdk) as ignoring them.
+
 The two samples are written to the same shape so the difference is the plugin and its config: [go/samples/anthropic](https://github.com/genkit-ai/genkit/tree/main/go/samples/anthropic) and [go/samples/compat_oai/anthropic](https://github.com/genkit-ai/genkit/tree/main/go/samples/compat_oai/anthropic).
 
 :::caution[Both plugins claim the provider name `anthropic`]

--- a/src/content/docs/docs/integrations/aws-bedrock.mdx
+++ b/src/content/docs/docs/integrations/aws-bedrock.mdx
@@ -203,6 +203,10 @@ This plugin supports all currently available **Chat/Completion** and **Embedding
 
 An [AWS Bedrock](https://aws.amazon.com/bedrock/) plugin for Genkit Go that provides text generation, image generation, and embedding capabilities using AWS Bedrock foundation models via the Converse API.
 
+:::caution[Community-maintained plugin]
+This plugin is not part of the `github.com/firebase/genkit/go` module, and it is not maintained or supported by the Genkit team. Maintainer: Xavier Portilla Edo ([@xavidop](https://github.com/xavidop)). Report issues at [xavidop/genkit-aws-bedrock-go/issues](https://github.com/xavidop/genkit-aws-bedrock-go/issues). The current release builds against Genkit Go v1.11.0 and Go 1.25.
+:::
+
 ## Installation
 
 ```bash
@@ -211,14 +215,7 @@ go get github.com/xavidop/genkit-aws-bedrock-go
 
 ## Features
 
-- **Text Generation**: Support for multiple foundation models via AWS Bedrock Converse API
-- **Image Generation**: Support for image generation models like Amazon Titan Image Generator
-- **Embeddings**: Support for text embedding models from Amazon Titan and Cohere
-- **Streaming**: Full streaming support for real-time responses
-- **Tool Calling**: Complete function calling capabilities with schema validation and type conversion
-- **Multimodal Support**: Support for text + image inputs (vision models)
-- **Schema Management**: Automatic conversion between Genkit and AWS Bedrock schemas
-- **Type Safety**: Robust type conversion for tool parameters (handles AWS document.Number types)
+The plugin covers text generation through the Converse API, streaming, tool calling, multimodal input, image generation, embeddings, and reranking. This page covers text generation, custom models, and prompt caching; for the rest, see the [examples directory](https://github.com/xavidop/genkit-aws-bedrock-go/tree/main/examples) in the plugin's repository, which has one runnable program per capability.
 
 ## Quick Start
 
@@ -243,10 +240,12 @@ func main() {
 	// Initialize Genkit
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(bedrockPlugin),
-		genkit.WithDefaultModel("bedrock/anthropic.claude-sonnet-4-6"), // Set default model
+		genkit.WithDefaultModel("bedrock/anthropic.claude-sonnet-4-20250514-v1:0"),
 	)
 
-    bedrock.DefineCommonModels(bedrockPlugin, g) // Optional: Define common models for easy access
+	// Required: the plugin registers nothing at Init, so the default model
+	// above does not resolve until something defines it.
+	bedrock.DefineCommonModels(bedrockPlugin, g)
 
 	log.Println("Starting basic Bedrock example...")
 
@@ -263,6 +262,38 @@ func main() {
 	log.Println("Basic Bedrock example completed")
 }
 ```
+
+## Models
+
+Nothing is registered at `Init`, and the plugin has no dynamic resolver. Every model you generate with has to be defined first, either one at a time with `DefineModel` or in bulk with `DefineCommonModels`. A model name that was never defined fails to resolve at `Generate` time.
+
+`DefineCommonModels(b *bedrock.Bedrock, g *genkit.Genkit) map[string]ai.Model` registers 17 models. Note the argument order: the plugin comes first, unlike the `g`-first order used elsewhere in Genkit Go.
+
+| Model ID | Type |
+| --- | --- |
+| `anthropic.claude-3-haiku-20240307-v1:0` | chat |
+| `anthropic.claude-3-5-sonnet-20241022-v2:0` | chat |
+| `anthropic.claude-3-7-sonnet-20250219-v1:0` | chat |
+| `anthropic.claude-opus-4-20250514-v1:0` | chat |
+| `anthropic.claude-sonnet-4-20250514-v1:0` | chat |
+| `amazon.nova-micro-v1:0` | chat |
+| `amazon.nova-lite-v1:0` | chat |
+| `amazon.nova-pro-v1:0` | chat |
+| `amazon.titan-text-premier-v1:0` | chat |
+| `meta.llama3-8b-instruct-v1:0` | chat |
+| `meta.llama3-1-8b-instruct-v1:0` | chat |
+| `meta.llama3-2-3b-instruct-v1:0` | chat |
+| `meta.llama4-maverick-17b-instruct-v1:0` | chat |
+| `meta.llama4-scout-17b-instruct-v1:0` | chat |
+| `deepseek.r1-v1:0` | chat |
+| `amazon.titan-image-generator-v1` | image |
+| `amazon.nova-canvas-v1:0` | image |
+
+Anything else, including newer Claude, Mistral, Cohere, AI21, and Writer models, goes through `DefineModel`. See the [AWS list of supported foundation models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) for the IDs Bedrock serves in your region.
+
+:::caution
+Many Bedrock models are only reachable through a cross-region inference profile, whose ID carries a region prefix (`us.`, `eu.`, `apac.`, `jp.`, `au.`, `us-gov.`, or `global.`), for example `us.anthropic.claude-sonnet-4-20250514-v1:0`. Calling the bare foundation-model ID for such a model fails at AWS with a validation error. The plugin strips the prefix before looking up capabilities, so a prefixed ID keeps the right ones.
+:::
 
 ## Using Custom Models
 
@@ -293,8 +324,8 @@ func main() {
 
     // Define a Claude model
     claudeModel := bedrockPlugin.DefineModel(g, bedrock.ModelDefinition{
-        Name: "anthropic.claude-sonnet-4-6",
-        Type: "text",
+        Name: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        Type: "chat",
     }, nil)
 
     // Generate text
@@ -311,6 +342,38 @@ func main() {
 
     log.Println(response.Text())
 }
+```
+
+### Model definitions
+
+`ModelDefinition` describes one model:
+
+| Field  | Type     | Description                                                              |
+| ------ | -------- | ------------------------------------------------------------------------ |
+| `Name` | `string` | The model ID as AWS Bedrock spells it, including any inference-profile prefix. |
+| `Type` | `string` | `"chat"`, `"text"`, `"image"`, or `"embedding"`.                          |
+
+`Type` decides how the plugin describes the model and, for `"image"`, which API it calls. `"chat"` and `"text"` behave identically: both go through the Converse API and get multiturn, system-role, and tool support. `"image"` gets media output, no tools, and an open config schema, because image config shapes differ per model family. `"embedding"` gets no tools, no media, and no multiturn.
+
+:::note
+The [Azure AI Foundry plugin](/docs/integrations/azure-foundry) has a `ModelDefinition` with the same name but a different `Type` vocabulary, and its `Type` also routes the request. The two are not interchangeable.
+:::
+
+`DefineModel`'s third parameter is an `*ai.ModelInfo`, the model's capabilities. Pass `nil` to let the plugin infer them from the model ID and `Type`. An ID the plugin's capability registry does not know is inferred as multimodal and tool-capable, and marked unstable, so pass a value instead when the inference would be wrong:
+
+```go
+model := bedrockPlugin.DefineModel(g, bedrock.ModelDefinition{
+    Name: "us.example.some-text-only-model-v1:0",
+    Type: "chat",
+}, &ai.ModelInfo{
+    Label: "Some text-only model",
+    Supports: &ai.ModelSupports{
+        Multiturn:  true,
+        Tools:      true,
+        SystemRole: true,
+        Media:      false,
+    },
+})
 ```
 
 ## Configuration Options
@@ -376,11 +439,16 @@ Create an IAM policy with these permissions:
         "bedrock:InvokeModel",
         "bedrock:InvokeModelWithResponseStream"
       ],
-      "Resource": ["arn:aws:bedrock:*::foundation-model/*"]
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
     }
   ]
 }
 ```
+
+The `inference-profile` entry is what lets a `us.`, `eu.`, or `apac.` prefixed model ID through. Without it, a cross-region inference profile is denied even though the underlying foundation model is allowed.
 
 ### Prompt Caching
 
@@ -399,6 +467,12 @@ response, err := genkit.Generate(ctx, g,
     ),
 )
 ```
+
+## Learn more
+
+- [Generating content with AI models](/docs/models)
+- [Tool calling](/docs/tool-calling)
+- [Middleware](/docs/middleware) for retry and fallback around a Bedrock model
 
 </Lang>
 

--- a/src/content/docs/docs/integrations/aws-bedrock.mdx
+++ b/src/content/docs/docs/integrations/aws-bedrock.mdx
@@ -201,11 +201,7 @@ This plugin supports all currently available **Chat/Completion** and **Embedding
 
 <Lang lang="go">
 
-An [AWS Bedrock](https://aws.amazon.com/bedrock/) plugin for Genkit Go that provides text generation, image generation, and embedding capabilities using AWS Bedrock foundation models via the Converse API.
-
-:::caution[Community-maintained plugin]
-This plugin is not part of the `github.com/firebase/genkit/go` module, and it is not maintained or supported by the Genkit team. Maintainer: Xavier Portilla Edo ([@xavidop](https://github.com/xavidop)). Report issues at [xavidop/genkit-aws-bedrock-go/issues](https://github.com/xavidop/genkit-aws-bedrock-go/issues). The current release builds against Genkit Go v1.11.0 and Go 1.25.
-:::
+An [AWS Bedrock](https://aws.amazon.com/bedrock/) plugin for Genkit Go that provides text generation, image generation, and embedding capabilities using AWS Bedrock foundation models via the Converse API. The plugin is maintained in the [aws-bedrock-go-plugin](https://github.com/genkit-ai/aws-bedrock-go-plugin) repository.
 
 ## Installation
 
@@ -215,7 +211,7 @@ go get github.com/xavidop/genkit-aws-bedrock-go
 
 ## Features
 
-The plugin covers text generation through the Converse API, streaming, tool calling, multimodal input, image generation, embeddings, and reranking. This page covers text generation, custom models, and prompt caching; for the rest, see the [examples directory](https://github.com/xavidop/genkit-aws-bedrock-go/tree/main/examples) in the plugin's repository, which has one runnable program per capability.
+The plugin covers text generation through the Converse API, streaming, tool calling, multimodal input, image generation, embeddings, and reranking. This page covers text generation, custom models, and prompt caching; for the rest, see the [examples directory](https://github.com/genkit-ai/aws-bedrock-go-plugin/tree/main/examples) in the plugin's repository, which has one runnable program per capability.
 
 ## Quick Start
 

--- a/src/content/docs/docs/integrations/azure-foundry.mdx
+++ b/src/content/docs/docs/integrations/azure-foundry.mdx
@@ -104,11 +104,7 @@ For more Genkit features like embeddings, structured output, and flows, refer to
 
 <Lang lang="go">
 
-Azure AI Foundry plugin for Genkit Go that provides text generation and chat capabilities using Azure OpenAI and other models available through Azure AI Foundry.
-
-:::caution[Community-maintained plugin]
-This plugin is not part of the `github.com/firebase/genkit/go` module, and it is not maintained or supported by the Genkit team. Maintainer: Xavier Portilla Edo ([@xavidop](https://github.com/xavidop)). Report issues at [xavidop/genkit-azure-foundry-go/issues](https://github.com/xavidop/genkit-azure-foundry-go/issues). The current release builds against Genkit Go v1.11.0 and Go 1.25.
-:::
+Azure AI Foundry plugin for Genkit Go that provides text generation and chat capabilities using Azure OpenAI and other models available through Azure AI Foundry. The plugin is maintained in the [azure-foundry-go-plugin](https://github.com/genkit-ai/azure-foundry-go-plugin) repository.
 
 ## Installation
 

--- a/src/content/docs/docs/integrations/azure-foundry.mdx
+++ b/src/content/docs/docs/integrations/azure-foundry.mdx
@@ -106,6 +106,10 @@ For more Genkit features like embeddings, structured output, and flows, refer to
 
 Azure AI Foundry plugin for Genkit Go that provides text generation and chat capabilities using Azure OpenAI and other models available through Azure AI Foundry.
 
+:::caution[Community-maintained plugin]
+This plugin is not part of the `github.com/firebase/genkit/go` module, and it is not maintained or supported by the Genkit team. Maintainer: Xavier Portilla Edo ([@xavidop](https://github.com/xavidop)). Report issues at [xavidop/genkit-azure-foundry-go/issues](https://github.com/xavidop/genkit-azure-foundry-go/issues). The current release builds against Genkit Go v1.11.0 and Go 1.25.
+:::
+
 ## Installation
 
 ```bash
@@ -127,6 +131,10 @@ go get github.com/xavidop/genkit-azure-foundry-go
 - **Flexible Authentication**: Support for API keys, Azure Default Credential, and custom token credentials
 
 ### Initialize the Plugin
+
+:::caution[Azure addresses models by deployment name]
+Use your Azure deployment name, not the model name, in `ModelDefinition.Name` and in the provider-prefixed string you pass to `genkit.WithDefaultModel` (`azureaifoundry/<deployment-name>`). If you deployed `gpt-5` under the deployment name `my-gpt5-deployment`, that is the string both places want. A wrong name fails at Azure with a 404, not locally.
+:::
 
 ```go
 package main
@@ -153,18 +161,17 @@ func main() {
 	// Initialize Genkit
 	g := genkit.Init(ctx,
 		genkit.WithPlugins(azurePlugin),
-		genkit.WithDefaultModel("azureaifoundry/gpt-5"),
+		genkit.WithDefaultModel("azureaifoundry/my-gpt5-deployment"),
 	)
-
-	// Optional: Define common models for easy access
-	azureaifoundry.DefineCommonModels(azurePlugin, g)
 
 	log.Println("Starting basic Azure AI Foundry example...")
 
-	// Define a GPT-5 model (use your deployment name)
+	// Define your GPT-5 deployment. The plugin registers nothing at Init and
+	// has no dynamic resolver, so a name that was never defined does not
+	// resolve at Generate time.
 	gpt5Model := azurePlugin.DefineModel(g, azureaifoundry.ModelDefinition{
-		Name:          "gpt-5", // Your deployment name in Azure
-		Type:          "chat",
+		Name:          "my-gpt5-deployment", // Your deployment name in Azure
+		Type:          azureaifoundry.ModelTypeChat,
 		SupportsMedia: true,
 	}, nil)
 
@@ -392,12 +399,40 @@ func main() {
 
 ### Model Deployments
 
-Important: The `Name` in `ModelDefinition` should match your **deployment name** in Azure, not the model name. For example:
+Every model you generate with has to be defined first: the plugin registers nothing at `Init` and has no dynamic resolver. `ModelDefinition` describes one deployment.
 
-- If you deployed `gpt-5` with deployment name `my-gpt5-deployment`, use `"my-gpt5-deployment"`
-- If you deployed `gpt-5.5` with deployment name `gpt-5.5`, use `"gpt-5.5"`
+| Field           | Type     | Description                                                                                     |
+| --------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `Name`          | `string` | Your **deployment name** in Azure, not the model name. If you deployed `gpt-5` as `my-gpt5-deployment`, use `"my-gpt5-deployment"`. |
+| `Type`          | `string` | One of the `ModelType` constants below. Left empty, the type is inferred from `Name`.            |
+| `MaxTokens`     | `int32`  | Default maximum output tokens. A per-call value wins.                                             |
+| `SupportsMedia` | `bool`   | Whether the deployment takes images or audio as input. Required for a model you send media to.    |
+
+`Type` decides which Azure API the request goes to, so it has to match the deployment:
+
+| Constant                              | Value               | Use for                    |
+| ------------------------------------- | ------------------- | -------------------------- |
+| `azureaifoundry.ModelTypeChat`        | `"chat"`            | Chat and text deployments  |
+| `azureaifoundry.ModelTypeText`        | `"text"`            | Same path as chat          |
+| `azureaifoundry.ModelTypeImage`       | `"image"`           | DALL-E, GPT Image          |
+| `azureaifoundry.ModelTypeTextToSpeech`| `"text-to-speech"`  | TTS deployments            |
+| `azureaifoundry.ModelTypeSpeechToText`| `"speech-to-text"`  | Whisper, transcription     |
+
+:::caution
+An explicit `Type` overrides the name-based inference. Setting `Type: azureaifoundry.ModelTypeChat` on a DALL-E or Whisper deployment sends the request to the chat completions API and fails. Either name the right constant, or leave `Type` empty and let the plugin infer it from the deployment name (`dall-e`/`gpt-image` to image, `tts` to text-to-speech, `whisper`/`transcribe` to speech-to-text, everything else to chat).
+:::
+
+:::note
+The [AWS Bedrock plugin](/docs/integrations/aws-bedrock) also has a `ModelDefinition` with a `Type` field, but its vocabulary is `"chat"`, `"text"`, `"image"`, `"embedding"`. The two plugins are not interchangeable.
+:::
+
+`azureaifoundry.DefineCommonModels(azurePlugin, g)` registers chat deployments named `gpt-5`, `gpt-5-mini`, `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4`, and `gpt-35-turbo`, and `DefineCommonEmbedders(azurePlugin, g)` does the same for `text-embedding-ada-002`, `text-embedding-3-small`, and `text-embedding-3-large`. Both take the plugin first and `g` second, unlike the `g`-first order used elsewhere in Genkit Go. They only help if your deployment names happen to match those model names.
 
 For more Genkit features like embeddings, structured output, and flows, refer to the [Genkit documentation](https://genkit.dev/docs).
+
+### Non-chat configuration
+
+Image, text-to-speech, and speech-to-text requests take an untyped `map[string]any` config. Unlike the typed configs on the first-party provider pages, these keys go to Azure verbatim and are not validated against a schema, so a misspelled key or an out-of-range value fails at Azure rather than locally. The keys are Azure OpenAI's own wire names; the tables below list what the plugin forwards, and the linked REST references are authoritative on the accepted values.
 
 ### Image Generation
 
@@ -407,14 +442,14 @@ Generate images with DALL-E models using the standard `genkit.Generate()` method
 // Define DALL-E model
 dallE3 := azurePlugin.DefineModel(g, azureaifoundry.ModelDefinition{
 	Name: azureaifoundry.ModelDallE3,
-	Type: "chat",
+	Type: azureaifoundry.ModelTypeImage,
 }, nil)
 
 // Generate image
 response, err := genkit.Generate(ctx, g,
 	ai.WithModel(dallE3),
 	ai.WithPrompt("A serene landscape with mountains at sunset"),
-	ai.WithConfig(map[string]interface{}{
+	ai.WithConfig(map[string]any{
 		"quality": "hd",
 		"size":    "1024x1024",
 		"style":   "vivid",
@@ -425,34 +460,44 @@ if err != nil {
 	log.Fatal(err)
 }
 
-log.Printf("Image URL: %s", response.Text())
+for _, part := range response.MediaParts() {
+	log.Printf("%s: %s", part.ContentType, part.Text)
+}
 ```
 
-The Configuration options for image generation depends on the model used. Common options include:
+Generated images come back as media parts with content type `image/png`, one per image. `part.Text` holds either the Azure URL or a `data:image/png;base64,...` URL, depending on `response_format`.
+
+Configuration keys, per the [image generation REST reference](https://learn.microsoft.com/azure/ai-services/openai/reference#image-generation):
+
 | Option | Type | Description |
 | ------------ | -------- | ---------------------------------------- |
-| `quality` | `string` | Image quality: `standard`, `hd` |
-| `size` | `string` | Image size: `256x256`, `512x512`, `1024x1024` |
-| `style` | `string` | Image style: `vivid`, `photorealistic`, `cartoon` |
+| `n` | `int` | Number of images, 1 to 10. Default `1`. |
+| `size` | `string` | `256x256`, `512x512`, `1024x1024`, `1792x1024`, `1024x1792`. Default `1024x1024`. |
+| `quality` | `string` | `standard` or `hd`. DALL-E 3 only. Default `standard`. |
+| `style` | `string` | `vivid` or `natural`. DALL-E 3 only. Default `vivid`. |
+| `response_format` | `string` | `url` or `b64_json`. Default `url`. |
 
 ### Text-to-Speech
 
 Convert text to speech using the standard `genkit.Generate()` method:
 
 ```go
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"strings"
+)
 
 // Define TTS model
 ttsModel := azurePlugin.DefineModel(g, azureaifoundry.ModelDefinition{
 	Name: azureaifoundry.ModelTTS1HD,
-	Type: "chat",
+	Type: azureaifoundry.ModelTypeTextToSpeech,
 }, nil)
 
 // Generate speech
 response, err := genkit.Generate(ctx, g,
 	ai.WithModel(ttsModel),
 	ai.WithPrompt("Hello! Welcome to Azure AI Foundry."),
-	ai.WithConfig(map[string]interface{}{
+	ai.WithConfig(map[string]any{
 		"voice":           "nova",
 		"response_format": "mp3",
 		"speed":           1.5,
@@ -463,10 +508,22 @@ if err != nil {
 	log.Fatal(err)
 }
 
-// Decode base64 audio and save file
-audioData, _ := base64.StdEncoding.DecodeString(response.Text())
+// The audio arrives as a media part holding a data URL.
+_, encoded, _ := strings.Cut(response.Media(), ",")
+audioData, err := base64.StdEncoding.DecodeString(encoded)
+if err != nil {
+	log.Fatal(err)
+}
 os.WriteFile("output.mp3", audioData, 0644)
 ```
+
+Configuration keys, per the [audio generation REST reference](https://learn.microsoft.com/azure/ai-services/openai/reference#text-to-speech):
+
+| Option | Type | Description |
+| ------------ | -------- | ---------------------------------------- |
+| `voice` | `string` | `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`. Default `alloy`. |
+| `response_format` | `string` | `mp3`, `opus`, `aac`, `flac`, `wav`, `pcm`. Default `mp3`. The media part's content type follows this. |
+| `speed` | `float` | 0.25 to 4.0. Default `1.0`. |
 
 ### Speech-to-Text
 
@@ -478,7 +535,7 @@ import "encoding/base64"
 // Define Whisper model with media support (required for audio input)
 whisperModel := azurePlugin.DefineModel(g, azureaifoundry.ModelDefinition{
 	Name:          azureaifoundry.ModelWhisper1,
-	Type:          "chat",
+	Type:          azureaifoundry.ModelTypeSpeechToText,
 	SupportsMedia: true, // Required for media parts (audio)
 }, nil)
 
@@ -492,7 +549,7 @@ response, err := genkit.Generate(ctx, g,
 	ai.WithMessages(ai.NewUserMessage(
 		ai.NewMediaPart("audio/mp3", "data:audio/mp3;base64,"+base64Audio),
 	)),
-	ai.WithConfig(map[string]interface{}{
+	ai.WithConfig(map[string]any{
 		"language": "en",
 	}),
 )
@@ -503,5 +560,16 @@ if err != nil {
 
 log.Printf("Transcription: %s", response.Text())
 ```
+
+The transcript is the one modality that does come back as text, so `response.Text()` is right here.
+
+Configuration keys, per the [audio transcription REST reference](https://learn.microsoft.com/azure/ai-services/openai/reference#transcriptions):
+
+| Option | Type | Description |
+| ------------ | -------- | ---------------------------------------- |
+| `language` | `string` | Input language code, for example `en` or `es`. Improves accuracy when you know it. |
+| `prompt` | `string` | Free text that guides the model's style and spelling. |
+| `response_format` | `string` | `json`, `text`, `srt`, `verbose_json`, `vtt`. Default `json`. |
+| `temperature` | `float` | 0 to 1. |
 
 </Lang>

--- a/src/content/docs/docs/integrations/cloud-firestore.mdx
+++ b/src/content/docs/docs/integrations/cloud-firestore.mdx
@@ -350,21 +350,49 @@ firebasePlugin := &firebase.Firebase{
 The primary use case for the Firebase plugin is creating retrievers for RAG applications:
 
 ```go
-// Define a Firestore retriever
-retrieverOptions := firebase.RetrieverOptions{
-	Name:         "my-documents",
-	Collection:   "documents",
-	VectorField:  "embedding",
-	Embedder:     openaiPlugin.Embedder(g, "text-embedding-3-small"),
-	ContentField: "content",
-	Limit:        10,
-}
+package main
 
-retriever, err := firebase.DefineRetriever(ctx, g, retrieverOptions)
-if err != nil {
-	log.Fatal(err)
+import (
+	"context"
+	"log"
+	"os"
+
+	"cloud.google.com/go/firestore"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/compat_oai/openai"
+	"github.com/firebase/genkit/go/plugins/firebase"
+)
+
+func main() {
+	ctx := context.Background()
+
+	firebasePlugin := &firebase.Firebase{ProjectId: "your-firebase-project-id"}
+	openaiPlugin := &openai.OpenAI{APIKey: os.Getenv("OPENAI_API_KEY")}
+
+	g := genkit.Init(ctx, genkit.WithPlugins(firebasePlugin, openaiPlugin))
+
+	retriever, err := firebase.DefineRetriever(ctx, g, firebase.RetrieverOptions{
+		Name:            "my-documents",
+		Collection:      "documents",
+		VectorField:     "embedding",
+		ContentField:    "content",
+		MetadataFields:  []string{"title", "category"},
+		Embedder:        openaiPlugin.Embedder(g, "text-embedding-3-small"),
+		Limit:           10,
+		DistanceMeasure: firestore.DistanceMeasureCosine,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_ = retriever
 }
 ```
+
+`DistanceMeasure` is `firestore.DistanceMeasure` from `cloud.google.com/go/firestore`, not from
+`firebase.google.com/go/v4`. Set it explicitly: the plugin passes the field straight to Firestore
+without substituting a default, so leaving it at its zero value sends an unspecified measure. It must
+also match the measure the vector index was created with.
 
 ### Using Retrievers in RAG Workflows
 
@@ -427,11 +455,11 @@ func main() {
 
 	// Define retriever for knowledge base
 	retriever, err := firebase.DefineRetriever(ctx, g, firebase.RetrieverOptions{
-		Name:         "knowledge-base",
-		Collection:   "documents",
-		VectorField:  "embedding",
-		EmbedderName: "text-embedding-3-small",
-		TopK:         5,
+		Name:        "knowledge-base",
+		Collection:  "documents",
+		VectorField: "embedding",
+		Embedder:    openaiPlugin.Embedder(g, "text-embedding-3-small"),
+		Limit:       5,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -497,6 +525,30 @@ Your Firestore documents should follow this structure for optimal retrieval:
 }
 ```
 
+The `embedding` field must hold a Firestore **vector value**, not a plain array of numbers. In Go,
+write it with `firestore.Vector32(...)` from `cloud.google.com/go/firestore`.
+
+### Create the vector index
+
+The retriever runs a Firestore `FindNearest` query against `VectorField`. That query needs a KNN
+vector index on the field, and Firestore does not create one for you. Run this before you index any
+documents:
+
+```bash
+gcloud firestore indexes composite create \
+  --project=your-firebase-project-id \
+  --collection-group=documents \
+  --query-scope=COLLECTION \
+  --field-config=field-path=embedding,vector-config='{"dimension":"1536","flat":"{}"}'
+```
+
+`dimension` must equal the output size of the embedder you configure. `text-embedding-3-small`
+produces 1536 values; change the number if you use a different model. Create the index with the same
+distance measure you pass in `RetrieverOptions.DistanceMeasure`.
+
+If the index is missing, the first `genkit.Retrieve` call fails with a `FAILED_PRECONDITION` error
+from Firestore whose message contains a ready-to-run creation command.
+
 ### Indexing Documents
 
 To add documents to your Firestore collection with embeddings:
@@ -505,13 +557,18 @@ To add documents to your Firestore collection with embeddings:
 // Example of adding documents with embeddings
 embedder := openaiPlugin.Embedder(g, "text-embedding-3-small")
 
+firestoreClient, err := firebasePlugin.Firestore(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
 documents := []struct {
     Content  string
-    Metadata map[string]interface{}
+    Metadata map[string]any
 }{
     {
         Content: "Machine learning is a subset of artificial intelligence...",
-        Metadata: map[string]interface{}{
+        Metadata: map[string]any{
             "title":    "Introduction to ML",
             "category": "Technology",
         },
@@ -524,16 +581,17 @@ for _, doc := range documents {
     embeddingResp, err := genkit.Embed(ctx, g,
         ai.WithEmbedder(embedder),
         ai.WithTextDocs(doc.Content),
-  	)
+    )
     if err != nil {
         log.Fatal(err)
     }
 
-    // Store in Firestore
-    firestoreClient, _ := firebasePlugin.App.Firestore(ctx)
-    _, err = firestoreClient.Collection("documents").Doc().Set(ctx, map[string]interface{}{
+    // Store in Firestore. The embedding must be written as a Firestore vector
+    // value; a bare []float32 is stored as a plain array and FindNearest will
+    // never match it.
+    _, err = firestoreClient.Collection("documents").NewDoc().Set(ctx, map[string]any{
         "content":   doc.Content,
-        "embedding": embeddingResp.Embeddings[0].Embedding,
+        "embedding": firestore.Vector32(embeddingResp.Embeddings[0].Embedding),
         "metadata":  doc.Metadata,
     })
     if err != nil {
@@ -541,6 +599,8 @@ for _, doc := range documents {
     }
 }
 ```
+
+This snippet needs `cloud.google.com/go/firestore` in the import block shown above.
 
 ## Configuration Options
 
@@ -557,6 +617,10 @@ type Firebase struct {
     App *firebasev4.App
 }
 ```
+
+When you set `ProjectId`, the plugin builds the Firebase app during `genkit.Init` and stores it in
+`App`, so `App` is safe to read afterwards. Prefer `firebasePlugin.Firestore(ctx)` over
+`firebasePlugin.App.Firestore(ctx)`: it caches one client and shares it with the retrievers.
 
 ### RetrieverOptions
 
@@ -590,6 +654,11 @@ type RetrieverOptions struct {
 	DistanceMeasure firestore.DistanceMeasure
 }
 ```
+
+`firestore` here is `cloud.google.com/go/firestore`. The legal values are
+`firestore.DistanceMeasureEuclidean`, `firestore.DistanceMeasureCosine` and
+`firestore.DistanceMeasureDotProduct`. The plugin applies no default, so the zero value reaches
+`FindNearest` as an unspecified measure. Set the same measure the vector index was created with.
 
 ## Authentication
 
@@ -632,15 +701,27 @@ Or use the metadata server on Google Cloud Platform.
 
 ## Error Handling
 
-Handle Firebase-specific errors appropriately:
+Genkit classifies its own failures with the sentinels in
+`github.com/firebase/genkit/go/core/status` and you branch on them with `errors.Is`. Never branch on
+the text of `err.Error()`. See [Error types](/docs/error-types) for the full set.
 
 ```go
+import (
+	"errors"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/firebase"
+)
+
 retriever, err := firebase.DefineRetriever(ctx, g, options)
 if err != nil {
-    if strings.Contains(err.Error(), "plugin not found") {
-        log.Fatal("Firebase plugin not initialized. Make sure to include it in genkit.Init()")
-    }
-    log.Fatalf("Failed to create retriever: %v", err)
+    // The plugin returns unclassified errors here. The two setup mistakes it
+    // reports are "plugin not found" (the plugin never reached genkit.Init)
+    // and a Firestore client that could not be built from your credentials.
+    log.Fatalf("firebase.DefineRetriever: %v", err)
 }
 
 // Handle retrieval errors
@@ -649,17 +730,38 @@ results, err := genkit.Retrieve(ctx, g,
 	ai.WithTextDocs(query),
 )
 if err != nil {
+    if errors.Is(err, status.ErrInvalidArgument) {
+        log.Fatalf("bad retrieval request: %v", err)
+    }
     log.Printf("Retrieval failed: %v", err)
     // Implement fallback logic
 }
 ```
+
+:::caution
+The Firebase plugin's own failures are plain `fmt.Errorf` values that carry no status code, and the
+retrieval path formats its cause with `%v`, which flattens the Firestore error into a string.
+Neither a Genkit sentinel nor `status.FromError` from `google.golang.org/grpc/status` will classify
+them. Treat a failure from this plugin as opaque: log the message and fall back.
+:::
+
+The message still names the cause. The three you will hit:
+
+| Cause | What the message says | Retry? |
+| --- | --- | --- |
+| No vector index on `VectorField` | `FailedPrecondition`, with a `gcloud` command to create the index | No. Create the index. |
+| Credentials cannot read the collection | `PermissionDenied` | No. Fix IAM or the Firestore rules. |
+| Query vector length differs from the index dimension | `InvalidArgument` | No. Re-index with the embedder you query with. |
+
+Those three are configuration errors and fail the same way every time. `DeadlineExceeded` and
+`Unavailable` from Firestore are the transient ones, and are worth a bounded retry with backoff.
 
 ## Best Practices
 
 ### Performance Optimization
 
 - **Batch Operations**: Use Firestore batch writes when adding multiple documents
-- **Index Configuration**: Set up appropriate Firestore indexes for your queries
+- **Index Configuration**: Create a KNN vector index on every field you query. See [Create the vector index](#create-the-vector-index)
 - **Caching**: Implement caching for frequently accessed documents
 - **Pagination**: Use pagination for large result sets
 
@@ -682,21 +784,32 @@ if err != nil {
 ```go
 // Use different embedders for different types of content
 technicalRetriever, err := firebase.DefineRetriever(ctx, g, firebase.RetrieverOptions{
-    Name:         "technical-docs",
-    Collection:   "technical_documents",
-    VectorField:  "embedding",
-    EmbedderName: "text-embedding-3-large", // More accurate for technical content
-    TopK:         5,
+    Name:        "technical-docs",
+    Collection:  "technical_documents",
+    VectorField: "embedding",
+    // More accurate for technical content
+    Embedder: openaiPlugin.Embedder(g, "text-embedding-3-large"),
+    Limit:    5,
 })
+if err != nil {
+    log.Fatal(err)
+}
 
 generalRetriever, err := firebase.DefineRetriever(ctx, g, firebase.RetrieverOptions{
-    Name:         "general-knowledge",
-    Collection:   "general_documents",
-    VectorField:  "embedding",
-    EmbedderName: "text-embedding-3-small", // Faster for general content
-    TopK:         10,
+    Name:        "general-knowledge",
+    Collection:  "general_documents",
+    VectorField: "embedding",
+    // Faster for general content
+    Embedder: openaiPlugin.Embedder(g, "text-embedding-3-small"),
+    Limit:    10,
 })
+if err != nil {
+    log.Fatal(err)
+}
 ```
+
+Each collection needs its own vector index, and the dimension of each index must match the embedder
+that writes to it: 3072 for `text-embedding-3-large`, 1536 for `text-embedding-3-small`.
 
 ### With Flows
 

--- a/src/content/docs/docs/integrations/cloud-sql-postgresql.mdx
+++ b/src/content/docs/docs/integrations/cloud-sql-postgresql.mdx
@@ -277,15 +277,75 @@ The Postgresql plugin provides the retriever implementation to search a [Cloud S
 
 Google Cloud SQL for PostgreSQL with the pgvector extension provides a fully managed PostgreSQL database with vector search capabilities. It combines the reliability and scalability of Google Cloud with the power of PostgreSQL and pgvector, making it ideal for production AI applications that need managed vector storage with enterprise-grade features.
 
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/postgresql"
+)
+```
+
+## Prerequisites
+
+### Google Cloud access
+
+The account or service account that runs your application needs:
+
+- `roles/cloudsql.client` to connect through the Cloud SQL connector.
+- `roles/cloudsql.instanceUser` in addition, when you connect with
+  `postgresql.WithIAMAccountEmail` instead of a password.
+- The Cloud SQL Admin API enabled on the project:
+  `gcloud services enable sqladmin.googleapis.com`.
+
+`postgresql.WithCloudSQLInstance(projectID, region, instance)` names the instance; the connector
+resolves its IP, so the instance needs no public address.
+
+### The pgvector extension and the table
+
+The plugin reads and writes an existing table. `PostgresEngine.InitVectorstoreTable` creates it, and
+runs `CREATE EXTENSION IF NOT EXISTS vector` first. Once you have a `pEngine` (step 2 of
+[Configuration](#configuration)), call it once, before `genkit.Init`:
+
+```go
+err = pEngine.InitVectorstoreTable(ctx, postgresql.VectorstoreTableOptions{
+	TableName:          "documents",
+	SchemaName:         "public",
+	VectorSize:         768,
+	ContentColumnName:  "content",
+	EmbeddingColumn:    "embedding",
+	IDColumn:           postgresql.Column{Name: "custom_id", DataType: "TEXT"},
+	MetadataColumns:    []postgresql.Column{{Name: "source", DataType: "TEXT", Nullable: true}},
+	MetadataJSONColumn: "custom_metadata",
+	StoreMetadata:      true,
+})
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+That produces an id column, a `content TEXT NOT NULL` column, an `embedding vector(768) NOT NULL`
+column, one column per entry in `MetadataColumns`, and a JSON column when `StoreMetadata` is true.
+
+`VectorSize` must equal the output dimension of the embedder you configure later; 768 is the size
+`text-embedding-004` produces. A mismatch is not caught until the first write fails in Postgres.
+
+:::caution
+`OverwriteExisting: true` drops the table before recreating it. Leave it false against any database
+that holds data you want to keep.
+:::
+
 ## Configuration
 
 To use this plugin, follow these steps:
 
-1. Import the plugin
-
-```go
-import "github.com/firebase/genkit/go/plugins/postgresql"
-```
+1. Import `github.com/firebase/genkit/go/plugins/postgresql`
 
 2. Create a `PostgresEngine` instance:
    - Using basic authentication
@@ -307,12 +367,12 @@ pEngine, err := postgresql.NewPostgresEngine(ctx,
 	postgresql.WithIAMAccountEmail("mail@company.com"))
 ```
 
-- Using custom pool
+- Using custom pool (add `github.com/jackc/pgx/v5/pgxpool` to the imports)
 
 ```go
 pool, err := pgxpool.New(ctx, "add_your_connection_string")
 if err != nil {
-	return err
+	log.Fatal(err)
 }
 
 pEngine, err := postgresql.NewPostgresEngine(ctx,
@@ -333,78 +393,212 @@ g := genkit.Init(ctx, genkit.WithPlugins(postgres))
 
 ## Usage
 
-To add documents to a Postgresql index, first create a retrieve definition that specifies the features of the table:
+To add documents to a Postgresql index, first create a document store that specifies the features of
+the table:
 
 ```go
+embedder := googlegenai.VertexAIEmbedder(g, "text-embedding-004")
+
 cfg := &postgresql.Config{
-	TableName:             "documents",
-	SchemaName:            "public",
-	ContentColumn:         "content",
-	EmbeddingColumn:       "embedding",
-	MetadataColumns:       []string{"source", "category"},
-	IDColumn:              "custom_id",
-	MetadataJSONColumn:    "custom_metadata",
-	Embedder:              embedder,
-	EmbedderOptions:       nil,
+	TableName:          "documents",
+	SchemaName:         "public",
+	ContentColumn:      "content",
+	EmbeddingColumn:    "embedding",
+	MetadataColumns:    []string{"source", "category"},
+	IDColumn:           "custom_id",
+	MetadataJSONColumn: "custom_metadata",
+	Embedder:           embedder,
+	EmbedderOptions:    nil,
 }
 
-doc, retriever, err := postgresql.DefineRetriever(ctx, g, postgres, cfg)
+docStore, retriever, err := postgresql.DefineRetriever(ctx, g, postgres, cfg)
 if err != nil {
-  return err
+	log.Fatal(err)
 }
 
 docs := []*ai.Document{{
-        Content: []*ai.Part{{
-        Kind:        ai.PartText,
-        ContentType: "text/plain",
-        Text:        "The product features include...",
-        }},
-      Metadata: map[string]any{"source": "website", "category": "product-docs", "custom_id": "doc-123"},
-  }}
+	Content: []*ai.Part{{
+		Kind:        ai.PartText,
+		ContentType: "text/plain",
+		Text:        "The product features include...",
+	}},
+	Metadata: map[string]any{"source": "website", "category": "product-docs", "custom_id": "doc-123"},
+}}
 
-if err := doc.Index(ctx, docs); err != nil {
-    return err
+if err := docStore.Index(ctx, docs); err != nil {
+	log.Fatal(err)
 }
 ```
+
+`DefineRetriever` returns a `*postgresql.DocStore` as its first value, the handle used for writes. It
+has two methods: `Index(ctx, docs []*ai.Document) error` and
+`Retrieve(ctx, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error)`. Its second value is the
+`ai.Retriever` registered with Genkit, which is what you pass to `genkit.Retrieve`. Call
+`DefineRetriever` once per table and keep both values.
 
 Similarly, to retrieve documents from an index, use the retrieve method:
 
 ```go
-d2 := ai.DocumentFromText( "The product features include..." , nil)
+d2 := ai.DocumentFromText("The product features include...", nil)
 
 resp, err := retriever.Retrieve(ctx, &ai.RetrieverRequest{
-    Query: d2,
-    Options: &postgresql.RetrieverOptions{
-        K: 5,
-        Filter: "source='website' AND category='product-docs'",
-    },
+	Query: d2,
+	Options: &postgresql.RetrieverOptions{
+		K:      5,
+		Filter: "source = 'website' AND category = 'product-docs'",
+	},
 })
-
 if err != nil {
-    return err
+	log.Fatal(err)
 }
 ```
 
-It's also possible to use the Retrieve method from Retriever
+It's also possible to use the Retrieve method from Genkit:
 
 ```go
-_, retriever, err := postgresql.DefineRetriever(ctx, g, postgres, cfg)
-if err != nil {
-  return err
-}
-
-d2 := ai.DocumentFromText( "The product features include..." , nil)
+d2 := ai.DocumentFromText("The product features include...", nil)
 
 retrieverOptions := &postgresql.RetrieverOptions{
-    K: 5,
-    Filter: "source='website' AND category='product-docs'",
+	K:      5,
+	Filter: "source = 'website' AND category = 'product-docs'",
 }
 
 resp, err := genkit.Retrieve(ctx, g, ai.WithRetriever(retriever), ai.WithDocs(d2), ai.WithConfig(retrieverOptions))
 if err != nil {
-    return err
+	log.Fatal(err)
 }
 ```
+
+### Retriever options
+
+`postgresql.RetrieverOptions` has three fields:
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `Filter` | `any` | `nil` | Predicate for the query's `WHERE` clause. |
+| `K` | `int` | 4 | Number of documents to return. |
+| `DistanceStrategy` | `DistanceStrategy` | `postgresql.CosineDistance{}` | Vector similarity operator. The others are `postgresql.Euclidean{}` and `postgresql.InnerProduct{}`. |
+
+Any predicate legal in a `WHERE` clause against your table is accepted, including JSON operators on
+`MetadataJSONColumn`, for example `custom_metadata->>'tenant' = 'acme'`.
+
+:::danger
+`Filter` is formatted straight into the `WHERE` clause with `fmt.Sprintf`. It is not parameterised.
+Never build this value from untrusted input. To filter on a user-supplied value, validate it against
+an allowlist first, or map the user's choice onto a fixed predicate you wrote yourself.
+:::
+
+## Complete example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/postgresql"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// 1. Connect to the instance.
+	pEngine, err := postgresql.NewPostgresEngine(ctx,
+		postgresql.WithCloudSQLInstance("my-project", "us-central1", "my-instance"),
+		postgresql.WithDatabase("my-database"),
+		postgresql.WithIAMAccountEmail("mail@company.com"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer pEngine.Close()
+
+	// 2. Create the pgvector extension and the table. Once, not on every start.
+	err = pEngine.InitVectorstoreTable(ctx, postgresql.VectorstoreTableOptions{
+		TableName:          "documents",
+		SchemaName:         "public",
+		VectorSize:         768,
+		ContentColumnName:  "content",
+		EmbeddingColumn:    "embedding",
+		IDColumn:           postgresql.Column{Name: "custom_id", DataType: "TEXT"},
+		MetadataColumns:    []postgresql.Column{{Name: "source", DataType: "TEXT", Nullable: true}, {Name: "category", DataType: "TEXT", Nullable: true}},
+		MetadataJSONColumn: "custom_metadata",
+		StoreMetadata:      true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 3. Register the plugins.
+	postgres := &postgresql.Postgres{Engine: pEngine}
+	g := genkit.Init(ctx, genkit.WithPlugins(postgres, &googlegenai.VertexAI{}))
+
+	var embedder ai.Embedder = googlegenai.VertexAIEmbedder(g, "text-embedding-004")
+
+	// 4. Create the document store and the retriever.
+	cfg := &postgresql.Config{
+		TableName:          "documents",
+		SchemaName:         "public",
+		ContentColumn:      "content",
+		EmbeddingColumn:    "embedding",
+		MetadataColumns:    []string{"source", "category"},
+		IDColumn:           "custom_id",
+		MetadataJSONColumn: "custom_metadata",
+		Embedder:           embedder,
+	}
+
+	docStore, retriever, err := postgresql.DefineRetriever(ctx, g, postgres, cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 5. Write.
+	docs := []*ai.Document{{
+		Content: []*ai.Part{{
+			Kind:        ai.PartText,
+			ContentType: "text/plain",
+			Text:        "The product features include...",
+		}},
+		Metadata: map[string]any{"source": "website", "category": "product-docs", "custom_id": "doc-123"},
+	}}
+	if err := docStore.Index(ctx, docs); err != nil {
+		log.Fatal(err)
+	}
+
+	// 6. Read.
+	resp, err := genkit.Retrieve(ctx, g,
+		ai.WithRetriever(retriever),
+		ai.WithDocs(ai.DocumentFromText("What are the key features of the product?", nil)),
+		ai.WithConfig(&postgresql.RetrieverOptions{
+			K:                5,
+			Filter:           "source = 'website'",
+			DistanceStrategy: postgresql.CosineDistance{},
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, d := range resp.Documents {
+		fmt.Println(d.Content[0].Text)
+	}
+}
+```
+
+## Production notes
+
+`PostgresEngine` wraps a `*pgxpool.Pool`, so the engine, the `*DocStore` and the `ai.Retriever` it
+produces are safe to share across request goroutines. Build them once at startup, not per request.
+
+- Call `defer pEngine.Close()` on shutdown. `Close` closes the pool unconditionally, including a pool
+  you supplied with `WithPool`, so do not share that pool with code that outlives the engine.
+- To control pool sizing and connection limits, build the pool yourself from a `pgxpool.Config` and
+  pass it in with `WithPool`. `pEngine.GetClient()` returns the pool if you need to reach it later.
+- Per-request `context` deadlines pass through to pgx. Cancelling a request context aborts its query.
 
 See the [Retrieval-augmented generation](/docs/rag) page for a general
 discussion on using retrievers for RAG.

--- a/src/content/docs/docs/integrations/dev-local-vectorstore.mdx
+++ b/src/content/docs/docs/integrations/dev-local-vectorstore.mdx
@@ -120,86 +120,178 @@ import "github.com/firebase/genkit/go/plugins/localvec"
 To use the local vector store, initialize it and define a retriever with an embedder:
 
 ```go
+package main
+
 import (
 	"context"
 	"log"
 
-	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/localvec"
 )
 
-ctx := context.Background()
+func main() {
+	ctx := context.Background()
 
-g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
 
-if err := localvec.Init(); err != nil {
-	log.Fatal(err)
-}
+	if err := localvec.Init(); err != nil {
+		log.Fatal(err)
+	}
 
-myDocStore, myRetriever, err := localvec.DefineRetriever(
-	g, "my_vectorstore", localvec.Config{
-		Embedder: googlegenai.VertexAIEmbedder(g, "text-embedding-004"),
-	},
-	nil,
-)
-if err != nil {
-	log.Fatal(err)
+	embedder := genkit.LookupEmbedder(g, "vertexai/text-embedding-004")
+	if embedder == nil {
+		log.Fatal("embedder vertexai/text-embedding-004 is not registered")
+	}
+
+	myDocStore, myRetriever, err := localvec.DefineRetriever(
+		g, "my_vectorstore", localvec.Config{
+			Dir:      ".genkit/localvec",
+			Embedder: embedder,
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The Usage examples below continue from here: myDocStore for indexing,
+	// myRetriever for queries. They also need "fmt" and
+	// "github.com/firebase/genkit/go/ai".
+	_, _ = myDocStore, myRetriever
 }
 ```
 
-### Configuration Options
+`genkit.LookupEmbedder(g, name)` returns `nil` if no embedder with that
+identifier is registered, and the name must carry the provider prefix
+(`vertexai/`, `googleai/`). Check for `nil` before you hand the result to
+`localvec.Config`; a nil embedder panics on the first index or query.
+
+### Function signature
+
+```go
+func DefineRetriever(
+	g *genkit.Genkit,
+	name string,
+	cfg Config,
+	opts *ai.RetrieverOptions,
+) (*DocStore, ai.Retriever, error)
+```
+
+Hold the first result as a `*localvec.DocStore` if you need it later; it is the
+value you pass to `localvec.Index`. The retriever is registered under
+`devLocalVectorStore/<name>`, which is the identifier to use with
+`ai.WithRetrieverName`.
+
+### Configuration options
 
 - **name** (string): A unique name for this vector store instance. This is used as the retriever reference.
+- **Dir** (string): Directory for the database file. Defaults to `os.TempDir()`.
 - **Embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
+- **EmbedderOptions** (`any`): Options passed through to the embedder on every call, for example `&genai.EmbedContentConfig{TaskType: "RETRIEVAL_DOCUMENT"}`.
+- **opts** (`*ai.RetrieverOptions`): Action metadata for the retriever this call defines: `Label`, `ConfigSchema`, `Supports`, `Metadata`. Pass `nil` to accept the defaults.
+
+`ai.RetrieverOptions` describes the action. It is not the per-query options
+struct: that is `localvec.RetrieverOptions`, covered under
+[Retrieving documents](#retrieving-documents).
+
+:::caution
+The store applies the same `EmbedderOptions` to indexing and to queries, so it
+cannot do asymmetric `RETRIEVAL_DOCUMENT` / `RETRIEVAL_QUERY` embedding. If you
+need that, define two `DocStore`s over the same `Dir` (one per task type), index
+with the document one and query with the other, or move to a store whose
+retriever accepts separate query options.
+:::
+
+### Where the data lives
+
+The store writes one JSON file per retriever at `<Dir>/__db_<name>.json`,
+rewritten through a `.tmp` file on every `Index` call. The index survives a
+process restart as long as that directory does, so the default `os.TempDir()`
+outlives a restart but not necessarily a reboot or a temp sweep. Set `Dir` to a
+project path such as `.genkit/localvec` if you want it stable, and add that path
+to `.gitignore`. To reset the store, delete the `__db_*.json` file.
 
 ## Usage
 
-### Indexing Documents
+### Indexing documents
 
-The Dev Local Vector Store automatically creates indexes. To populate with data, you need to implement your own indexing logic using the [`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document) format:
+The Dev Local Vector Store automatically creates indexes. To populate one, build
+[`ai.Document`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Document)
+values and pass them to `localvec.Index` with the doc store:
 
 ```go
-import (
-    "github.com/firebase/genkit/go/ai"
-)
-
-// Create documents from text
 data := []string{
-    "This is the first document.",
-    "This is the second document.",
-    "This is the third document.",
-    "This is the fourth document.",
+	"This is the first document.",
+	"This is the second document.",
+	"This is the third document.",
+	"This is the fourth document.",
 }
 
 var docs []*ai.Document
-for _, text := range data {
-	docs = append(docs, ai.DocumentFromText(text, nil))
+for i, text := range data {
+	docs = append(docs, ai.DocumentFromText(text, map[string]any{
+		"id":     fmt.Sprintf("doc-%d", i),
+		"source": "handbook.md",
+	}))
 }
 
 // Index the documents using the DocStore returned by DefineRetriever
-err := localvec.Index(ctx, docs, myDocStore)
-if err != nil {
-    log.Fatal(err)
+if err := localvec.Index(ctx, docs, myDocStore); err != nil {
+	log.Fatal(err)
 }
 ```
 
-### Retrieving Documents
+The store persists the whole `ai.Document` as JSON, so metadata you attach at
+index time comes back on every retrieved document. Use it for IDs, titles and
+source paths. Because it round-trips through JSON, numeric metadata values come
+back as `float64` even if you stored an `int`.
 
-Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+### Concurrency and re-indexing
+
+`localvec.Index` is not safe for concurrent use on the same `DocStore`. It
+mutates an unsynchronized map and rewrites the whole database file, so
+concurrent calls race and can lose writes. Call it from one goroutine at a time.
+Reads through the retriever run against that same unsynchronized map, so do not
+index while you are serving queries.
+
+Indexing is keyed by a hash of the document content, so re-running ingestion
+over unchanged text is a no-op and does not duplicate chunks. Editing a document
+adds a new entry and leaves the old one in place. There is no delete or clear
+API; reset the store by deleting `<Dir>/__db_<name>.json`.
+
+### Retrieving documents
+
+Use [`genkit.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/genkit#Retrieve)
+with the retriever you defined. Pass `&localvec.RetrieverOptions{K: n}` to
+control how many documents come back; the default is 3.
 
 ```go
-// Retrieve documents relevant to a query
-resp, err := ai.Retrieve(ctx, myRetriever, ai.WithTextDocs("search query"))
+resp, err := genkit.Retrieve(ctx, g,
+	ai.WithRetriever(myRetriever),
+	ai.WithConfig(&localvec.RetrieverOptions{K: 5}),
+	ai.WithTextDocs("search query"))
 if err != nil {
 	log.Fatal(err)
 }
 
 // Process the retrieved documents
 for _, doc := range resp.Documents {
-	fmt.Println(doc.Content)
+	fmt.Println(doc.Metadata["source"], doc.Content[0].Text)
 }
 ```
+
+If you do not have the `ai.Retriever` value at hand, name it instead:
+
+```go
+resp, err := genkit.Retrieve(ctx, g,
+	ai.WithRetrieverName("devLocalVectorStore/my_vectorstore"),
+	ai.WithTextDocs("search query"))
+```
+
+`ai.RetrieverResponse` carries only `Documents`. The store ranks by cosine
+similarity internally but does not return the scores, so `K` is its only
+relevance control.
 
 </Lang>

--- a/src/content/docs/docs/integrations/google-cloud.mdx
+++ b/src/content/docs/docs/integrations/google-cloud.mdx
@@ -132,6 +132,25 @@ of logs is done via a dedicated Google Cloud exporter.
 If you want to locally run flows that use this plugin, you need the
 [Google Cloud CLI tool](https://cloud.google.com/sdk/docs/install) installed.
 
+## Installation
+
+```bash
+go get github.com/firebase/genkit/go/plugins/googlecloud
+```
+
+:::note[This plugin and the Firebase telemetry plugin are the same code]
+`firebase.EnableFirebaseTelemetry` copies its options into a
+`googlecloud.GoogleCloudTelemetryOptions` and calls
+`googlecloud.EnableGoogleCloudTelemetry`. The two option structs are field for
+field identical. The only behavioral difference is project-ID resolution: the
+Firebase entry point checks `FIREBASE_PROJECT_ID` before `GOOGLE_CLOUD_PROJECT`
+and `GCLOUD_PROJECT`.
+
+Use the [Firebase entry point](/docs/observability/getting-started) if you want
+the Firebase Genkit Monitoring dashboard, and this one otherwise. Do not call
+both.
+:::
+
 ## Configuration
 
 To enable exporting to Google Cloud Tracing and Monitoring, import the
@@ -168,7 +187,16 @@ gcloud auth application-default login
   information. By default, this is 5000 in dev and 300000 in prod.
 - `DisableMetrics`: If `true`, metrics are not exported.
 - `DisableTraces`: If `true`, traces are not exported.
-- `DisableLoggingInputAndOutput`: If `true`, disables PII redaction and preserves inputs/outputs in traces and logs.
+- `DisableLoggingInputAndOutput`: If `true`, prompt and response content is left
+  out of exported logs. Defaults to `false`, which means input and output
+  **are** exported. Set it to `true` for any workload whose prompts can carry
+  user data.
+
+:::caution[Prompt content is exported by default]
+With the default configuration, the text a user sends and the text the model
+returns are written to Cloud Logging. Set `DisableLoggingInputAndOutput: true`
+before deploying anything that handles regulated or personal data.
+:::
 
 The plugin requires your Google Cloud project credentials. If you're running
 your flows from a Google Cloud environment (Cloud Run, etc), the credentials are
@@ -293,6 +321,19 @@ The metrics management console contains a tabular view of all collected metrics,
 
 Genkit collects several categories of metrics, including flow-level, action-level, and generate-level metrics. Each metric has several useful dimensions facilitating robust filtering and grouping.
 
+<Lang lang="go">
+
+The Go plugin's exact metric names and dimension keys are listed on
+[Telemetry collection](/docs/observability/telemetry-collection). Use that page
+when you write an alerting policy or a Metrics Explorer query; the names are
+slash-separated (`genkit/ai/generate/input/tokens`, not `input_tokens`) and the
+dimension keys are `modelName`, `featureName`, `path`, `status`, `error`,
+`source`, and `sourceVersion`.
+
+</Lang>
+
+<Lang lang="js python">
+
 Common dimensions include:
 
 - `flow_name` - the top-level name of the flow.
@@ -330,6 +371,8 @@ Common dimensions include:
 | genkit/ai/generate/input_images      | flow_path, model, temperature, topK, topP                            |
 | genkit/ai/generate/output_images     | flow_path, model, temperature, topK, topP                            |
 | genkit/ai/generate/latency           | flow_path, model, temperature, topK, topP, error_code, error_message |
+
+</Lang>
 
 Visualizing metrics can be done through the Metrics Explorer. Using the side menu, select 'Logging' and click 'Metrics explorer'
 

--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -1111,6 +1111,26 @@ TTS models automatically detect the input language. Supported languages include 
 
 <Lang lang="go">
 
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"google.golang.org/genai"
+)
+```
+
+`google.golang.org/genai` is the Google GenAI Go SDK. It is a separate module
+that supplies the config types this plugin takes, so `go mod tidy` will add it
+to your `go.mod` alongside Genkit.
+
 The Google Generative AI plugin provides interfaces to Google's Gemini models through the Gemini API.
 
 ## Configuration
@@ -1268,9 +1288,168 @@ video := googlegenai.VideoModelRef("googleai/veo-3.1-generate-preview", &genai.G
 })
 ```
 
-The plugin advertises this config as the request's input schema and validates it on every call. The [`basic-media` sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-media) reads, edits, generates, and animates a picture in one program.
+The plugin advertises this config as the request's input schema and validates it on every call. Every field of `*genai.GenerateContentConfig` is valid config, so a Gemini API feature the Go SDK models is reachable from Genkit whether or not this page names it. The [`basic-media` sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-media) reads, edits, generates, and animates a picture in one program.
 
 See [Generating content with AI models](/docs/models) for more information.
+
+#### Thinking
+
+`ThinkingConfig` turns on Gemini's internal reasoning. `ThinkingBudget` caps the tokens spent on it, `ThinkingLevel` picks a preset instead, and `IncludeThoughts` asks for thought summaries. Summaries come back as reasoning parts, readable through `resp.Reasoning()`, and the tokens they cost are reported in `resp.Usage.ThoughtsTokens`.
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		ThinkingConfig: &genai.ThinkingConfig{
+			IncludeThoughts: true,
+			ThinkingBudget:  genai.Ptr[int32](8192),
+		},
+	}),
+	ai.WithPrompt("Which is heavier, a kilo of steel or a kilo of feathers?"),
+)
+if err != nil {
+	return err
+}
+
+log.Println(resp.Reasoning())
+log.Println(resp.Text())
+```
+
+Gemini 3 and later take `ThinkingLevel` instead of a token budget: `genai.ThinkingLevelMinimal`, `ThinkingLevelLow`, `ThinkingLevelMedium`, or `ThinkingLevelHigh`.
+
+#### Safety settings
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		SafetySettings: []*genai.SafetySetting{
+			{
+				Category:  genai.HarmCategoryHateSpeech,
+				Threshold: genai.HarmBlockThresholdBlockMediumAndAbove,
+			},
+			{
+				Category:  genai.HarmCategoryDangerousContent,
+				Threshold: genai.HarmBlockThresholdBlockOnlyHigh,
+			},
+		},
+	}),
+	ai.WithPrompt("Tell me a joke."),
+)
+if err != nil {
+	return err
+}
+
+log.Println(resp.Text())
+```
+
+Content the filter stops comes back as a response, not an error. See [Blocked responses](#blocked-responses) for how to detect it and where the raw ratings land.
+
+#### Grounding and URL context
+
+Gemini's server-side tools ride in the config's `Tools` field, separately from Genkit tools, which you pass with `ai.WithTools`. Google Search grounding, Maps grounding, and URL context are all tools in that sense:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Tools: []*genai.Tool{
+			{GoogleSearch: &genai.GoogleSearch{}},
+			{URLContext: &genai.URLContext{}},
+		},
+	}),
+	ai.WithPrompt("What are the top tech news stories this week?"),
+)
+if err != nil {
+	return err
+}
+
+log.Println(resp.Text())
+
+custom, _ := resp.Custom.(map[string]any)
+candidates, _ := custom["candidates"].([]*genai.Candidate)
+for _, cand := range candidates {
+	if cand.GroundingMetadata == nil {
+		continue
+	}
+	for _, chunk := range cand.GroundingMetadata.GroundingChunks {
+		if chunk.Web != nil {
+			log.Printf("source: %s (%s)", chunk.Web.Title, chunk.Web.URI)
+		}
+	}
+}
+```
+
+Genkit does not model grounding metadata, so it arrives raw. `resp.Custom` is a `map[string]any` whose `"candidates"` key holds the `[]*genai.Candidate` the service returned, and `GroundingMetadata` on each candidate carries the search queries, the chunks, and the per-segment supports. `{GoogleMaps: &genai.GoogleMaps{}}` is the Maps equivalent.
+
+#### Code execution
+
+`{CodeExecution: &genai.ToolCodeExecution{}}` lets the model write and run code as part of its answer. The code it wrote and the result of running it come back as custom parts, which the plugin gives you accessors for:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Tools: []*genai.Tool{{CodeExecution: &genai.ToolCodeExecution{}}},
+	}),
+	ai.WithPrompt("Calculate the 20th Fibonacci number."),
+)
+if err != nil {
+	return err
+}
+
+if code := googlegenai.GetExecutableCode(resp.Message); code != nil {
+	log.Printf("%s:\n%s", code.Language, code.Code)
+}
+if result := googlegenai.GetCodeExecutionResult(resp.Message); result != nil {
+	log.Printf("outcome %s: %s", result.Outcome, result.Output)
+}
+```
+
+`GetExecutableCode` and `GetCodeExecutionResult` return the first match in a message, or nil. `googlegenai.ToExecutableCode` and `googlegenai.ToCodeExecutionResult` do the same for a single `*ai.Part` when you need to walk the content yourself.
+
+#### Context caching
+
+`(*ai.Message).WithCacheTTL` marks a message as the end of the cached prefix. Everything up to and including that message is uploaded once and reused, so a long document costs its input tokens on the first request only:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithMessages(
+		ai.NewUserMessage(ai.NewMediaPart("application/pdf", pdfDataURL)).WithCacheTTL(360),
+		ai.NewUserTextMessage("Summarize the document."),
+	),
+)
+if err != nil {
+	return err
+}
+
+log.Println(resp.Usage.CachedContentTokens)
+```
+
+The TTL is in whole seconds and must be positive. On the next turn, reuse the cache the service created rather than paying to build it again: the name it was given comes back under the `"name"` key of the `"cache"` entry in `resp.Message.Metadata`, and `(*ai.Message).WithCacheName` sends it. The cached content must hash identically to what the cache holds, otherwise the request is rejected.
+
+Two request shapes are refused before the request goes out, both with `INVALID_ARGUMENT`: a request that also carries tools, and one that carries a system message.
+
+#### Generated media
+
+Image, video, and audio output arrive as media parts, not as text. Inline bytes are wrapped in a `data:` URL and served-file output carries the file URI, so the same accessor works for both:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-2.5-flash-image"),
+	ai.WithPrompt("A serene Japanese garden with cherry blossoms."),
+)
+if err != nil {
+	return err
+}
+
+for _, part := range resp.MediaParts() {
+	log.Printf("%s: %s", part.ContentType, part.Text)
+}
+```
+
+On a media part, `part.Text` holds the URL. For a `data:` URL, split on the comma and base64-decode the tail to get the bytes. `resp.Media()` returns the first URL alone when one is all you need.
 
 ### Embedding models
 
@@ -1307,9 +1486,23 @@ if err != nil {
 embedder := googlegenai.EmbedderRef("googleai/gemini-embedding-001", &genai.EmbedContentConfig{
 	TaskType: "RETRIEVAL_DOCUMENT",
 })
+
+resp, err := genkit.Embed(ctx, g,
+	ai.WithEmbedder(embedder),
+	ai.WithTextDocs("Machine learning models process data to make predictions."),
+)
+if err != nil {
+	return err
+}
+
+log.Println(resp.Embeddings[0].Embedding)
 ```
 
+`EmbedderRef` returns an `ai.EmbedderRef`, not an `ai.Embedder`, so hold it in a field or variable typed `ai.EmbedderRef`. `ai.WithEmbedder` accepts either type. Passing `ai.WithConfig` as well overrides the config the ref carries.
+
 Requests are split into batches of 100 documents, so an embed call with more documents than the service accepts in one request still works. The response carries one embedding per input, in input order.
+
+Batching is the only limit Genkit handles for you. Each individual document still has to fit the model's own input limit, 2,048 tokens for `gemini-embedding-001`. Genkit neither truncates nor splits a document, so chunk long text before embedding it; an oversized document fails at the service. Check the current limit on the [embeddings model card](https://ai.google.dev/gemini-api/docs/models).
 
 See [Retrieval-augmented generation (RAG)](/docs/rag) for more information.
 
@@ -1370,7 +1563,7 @@ if resp.FinishReason == ai.FinishReasonBlocked {
 }
 ```
 
-`FinishMessage` carries the service's explanation. The raw ratings are attached under `resp.Custom["candidates"]` and, when the prompt itself was blocked, `resp.Custom["promptFeedback"]`.
+`FinishMessage` carries the service's explanation. `resp.Custom` is a `map[string]any`: the raw ratings are attached under its `"candidates"` key as `[]*genai.Candidate` and, when the prompt itself was blocked, under `"promptFeedback"` as a `*genai.GenerateContentResponsePromptFeedback`.
 
 ### Rate limits
 

--- a/src/content/docs/docs/integrations/model-providers.mdx
+++ b/src/content/docs/docs/integrations/model-providers.mdx
@@ -38,14 +38,19 @@ and any other service that exposes an OpenAI-compatible endpoint.
 - [Vertex AI Model Garden](/docs/integrations/vertex-ai#model-garden): Claude, Llama, and Mistral models hosted on Vertex AI, one plugin per family.
 - [Anthropic (Claude)](/docs/integrations/anthropic): Claude models through the Anthropic Messages API.
 - [OpenAI](/docs/integrations/openai): GPT models and embedders through the OpenAI API.
-- [Azure AI Foundry](/docs/integrations/azure-foundry): Models hosted on Azure.
-- [AWS Bedrock](/docs/integrations/aws-bedrock): Models hosted on AWS.
 - [xAI (Grok)](/docs/integrations/xai): Grok models through the xAI API.
 - [DeepSeek](/docs/integrations/deepseek): DeepSeek models.
 - [OpenRouter](/docs/integrations/openrouter): One gateway to models from many vendors, with provider routing and fallback chains.
 - [Kimi](/docs/integrations/kimi): Moonshot AI's Kimi models.
 - [z.AI](/docs/integrations/zai): Z.ai's GLM text and vision models.
 - [DashScope (Qwen)](/docs/integrations/dashscope): Alibaba Cloud's Qwen models.
+
+### Community plugins
+
+These ship outside the `github.com/firebase/genkit/go` module and are not maintained or supported by the Genkit team.
+
+- [Azure AI Foundry](/docs/integrations/azure-foundry): Models hosted on Azure (community-maintained).
+- [AWS Bedrock](/docs/integrations/aws-bedrock): Models hosted on AWS (community-maintained).
 
 </Lang>
 

--- a/src/content/docs/docs/integrations/model-providers.mdx
+++ b/src/content/docs/docs/integrations/model-providers.mdx
@@ -38,19 +38,14 @@ and any other service that exposes an OpenAI-compatible endpoint.
 - [Vertex AI Model Garden](/docs/integrations/vertex-ai#model-garden): Claude, Llama, and Mistral models hosted on Vertex AI, one plugin per family.
 - [Anthropic (Claude)](/docs/integrations/anthropic): Claude models through the Anthropic Messages API.
 - [OpenAI](/docs/integrations/openai): GPT models and embedders through the OpenAI API.
+- [Azure AI Foundry](/docs/integrations/azure-foundry): Models hosted on Azure OpenAI and Azure AI Foundry.
+- [AWS Bedrock](/docs/integrations/aws-bedrock): Models hosted on AWS through the Converse API.
 - [xAI (Grok)](/docs/integrations/xai): Grok models through the xAI API.
 - [DeepSeek](/docs/integrations/deepseek): DeepSeek models.
 - [OpenRouter](/docs/integrations/openrouter): One gateway to models from many vendors, with provider routing and fallback chains.
 - [Kimi](/docs/integrations/kimi): Moonshot AI's Kimi models.
 - [z.AI](/docs/integrations/zai): Z.ai's GLM text and vision models.
 - [DashScope (Qwen)](/docs/integrations/dashscope): Alibaba Cloud's Qwen models.
-
-### Community plugins
-
-These ship outside the `github.com/firebase/genkit/go` module and are not maintained or supported by the Genkit team.
-
-- [Azure AI Foundry](/docs/integrations/azure-foundry): Models hosted on Azure (community-maintained).
-- [AWS Bedrock](/docs/integrations/aws-bedrock): Models hosted on AWS (community-maintained).
 
 </Lang>
 

--- a/src/content/docs/docs/integrations/pgvector.mdx
+++ b/src/content/docs/docs/integrations/pgvector.mdx
@@ -129,13 +129,14 @@ export const askQuestionsOnGoT = ai.defineFlow(
 
 <Lang lang="go">
 
-You can use PostgreSQL and `pgvector` as your retriever implementation. Use the
-following examples as a starting point and modify it to work with your database
-schema.
+You can use PostgreSQL and `pgvector` as your retriever implementation. There is
+no pgvector plugin for Go: this page wires `database/sql` to the database
+directly and defines a retriever over it. Use it as a starting point and modify
+it to work with your own schema.
 
 pgvector is a PostgreSQL extension that adds vector similarity search capabilities to PostgreSQL databases. It provides efficient storage and querying of high-dimensional vectors, making it ideal for AI applications that need both relational and vector data in a single database.
 
-## Installation and Setup
+## Installation and setup
 
 Install the required dependencies:
 
@@ -144,90 +145,178 @@ go get github.com/lib/pq
 go get github.com/pgvector/pgvector-go
 ```
 
-Set up your PostgreSQL database with pgvector:
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	_ "github.com/lib/pq"
+	pgv "github.com/pgvector/pgvector-go"
+	"google.golang.org/genai"
+)
+```
+
+`_ "github.com/lib/pq"` is a blank import. Nothing in your code refers to the
+package; importing it for its side effects is what registers the `postgres`
+driver name that `sql.Open` looks up.
+
+### Create the table
 
 ```sql
 -- Enable the pgvector extension
 CREATE EXTENSION IF NOT EXISTS vector;
 
--- Create a table for storing documents with embeddings
-CREATE TABLE documents (
-  id SERIAL PRIMARY KEY,
-  content TEXT NOT NULL,
-  embedding vector(768), -- Adjust dimension based on your embedding model
-  metadata JSONB,
-  created_at TIMESTAMP DEFAULT NOW()
+-- One row per chunk of transcript
+CREATE TABLE embeddings (
+  id            SERIAL PRIMARY KEY,
+  show_id       TEXT NOT NULL,
+  season_number INT  NOT NULL,
+  episode_id    INT  NOT NULL,
+  chunk         TEXT NOT NULL,
+  embedding     vector(768) NOT NULL
 );
 
--- Create an index for efficient vector similarity search
-CREATE INDEX ON documents USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+-- Index for efficient vector similarity search
+CREATE INDEX ON embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
 ```
+
+Two constraints tie this DDL to the Go code below:
+
+- The width in `vector(N)` must equal the number of dimensions your embedder
+  emits. `text-embedding-004` and `text-embedding-005` emit 768.
+  `gemini-embedding-001` emits 3072, which is above the 2000-dimension ceiling
+  on pgvector's `ivfflat` and `hnsw` indexes, so reduce it with
+  `OutputDimensionality` before you store it.
+- The index operator class must match the distance operator your query uses:
+  `vector_cosine_ops` with `<=>`, `vector_l2_ops` with `<->`, `vector_ip_ops`
+  with `<#>`. A query that uses a different operator ignores the index and
+  falls back to a sequential scan.
+
+### Connect to the database
+
+`*sql.DB` is already a connection pool, so open one per process and share it.
+
+```go
+db, err := sql.Open("postgres", "postgres://user:password@localhost:5432/recaps?sslmode=disable")
+if err != nil {
+	log.Fatal(err)
+}
+defer db.Close()
+```
+
+### Choose an embedder
+
+Indexing and querying must produce vectors of the same width, but Gemini
+embedders want a different task type for each side:
+
+```go
+const embedDim = 768
+
+docEmbedder := googlegenai.EmbedderRef("googleai/gemini-embedding-001", &genai.EmbedContentConfig{
+	TaskType:             "RETRIEVAL_DOCUMENT",
+	OutputDimensionality: genai.Ptr[int32](embedDim),
+})
+
+queryEmbedder := googlegenai.EmbedderRef("googleai/gemini-embedding-001", &genai.EmbedContentConfig{
+	TaskType:             "RETRIEVAL_QUERY",
+	OutputDimensionality: genai.Ptr[int32](embedDim),
+})
+```
+
+Use `docEmbedder` in whatever ingestion job writes rows into `embeddings`, and
+`queryEmbedder` in the retriever below.
 
 ## Usage
 
-We use [database/sql](https://pkg.go.dev/database/sql) to connect to the Postgres server, but you may use another client library of your choice.
+The retriever embeds the query document, then runs a nearest-neighbor search
+scoped to one show. Its per-request config is a struct, so Genkit deserializes
+`ai.RetrieverRequest.Options` into it and validates it before your function
+runs:
 
 ```go
-func defineRetriever(g *genkit.Genkit, db *sql.DB, embedder ai.Embedder) ai.Retriever {
-	f := func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error) {
-		eres, err := genkit.Embed(ctx, g,
-			ai.WithEmbedder(embedder),
-			ai.WithDocs(req.Query))
-		if err != nil {
-			return nil, err
-		}
-		rows, err := db.QueryContext(ctx, `
-			SELECT episode_id, season_number, chunk as content
-			FROM embeddings
-			WHERE show_id = $1
-		  	ORDER BY embedding <#> $2
-		  	LIMIT 2`,
-			req.Options, pgv.NewVector(eres.Embeddings[0].Embedding))
-		if err != nil {
-			return nil, err
-		}
-		defer rows.Close()
+// ShowQuery is the retriever's per-request config. Callers set it with
+// ai.WithConfig.
+type ShowQuery struct {
+	Show string `json:"show"`
+	K    int    `json:"k,omitempty"`
+}
 
-		res := &ai.RetrieverResponse{}
-		for rows.Next() {
-			var eid, sn int
-			var content string
-			if err := rows.Scan(&eid, &sn, &content); err != nil {
+func defineRetriever(g *genkit.Genkit, db *sql.DB, embedder ai.EmbedderArg) ai.Retriever {
+	return genkit.DefineRetrieverAction(g, "pgvector/shows", nil,
+		func(ctx context.Context, req *ai.RetrieverRequest, cfg *ShowQuery) (*ai.RetrieverResponse, error) {
+			// The config type parameter is a pointer, so it is nil when the
+			// caller sends no config at all.
+			if cfg == nil || cfg.Show == "" {
+				return nil, fmt.Errorf("pgvector: the show option is required")
+			}
+			k := cfg.K
+			if k == 0 {
+				k = 3
+			}
+
+			eres, err := genkit.Embed(ctx, g,
+				ai.WithEmbedder(embedder),
+				ai.WithDocs(req.Query))
+			if err != nil {
 				return nil, err
 			}
-			meta := map[string]any{
-				"episode_id":    eid,
-				"season_number": sn,
+
+			// <=> is cosine distance, matching the vector_cosine_ops index.
+			rows, err := db.QueryContext(ctx, `
+				SELECT episode_id, season_number, chunk AS content
+				FROM embeddings
+				WHERE show_id = $1
+				ORDER BY embedding <=> $2
+				LIMIT $3`,
+				cfg.Show, pgv.NewVector(eres.Embeddings[0].Embedding), k)
+			if err != nil {
+				return nil, err
 			}
-			doc := &ai.Document{
-				Content:  []*ai.Part{ai.NewTextPart(content)},
-				Metadata: meta,
+			defer rows.Close()
+
+			res := &ai.RetrieverResponse{}
+			for rows.Next() {
+				var eid, sn int
+				var content string
+				if err := rows.Scan(&eid, &sn, &content); err != nil {
+					return nil, err
+				}
+				res.Documents = append(res.Documents, ai.DocumentFromText(content, map[string]any{
+					"episode_id":    eid,
+					"season_number": sn,
+				}))
 			}
-			res.Documents = append(res.Documents, doc)
-		}
-		if err := rows.Err(); err != nil {
-			return nil, err
-		}
-		return res, nil
-	}
-	return genkit.DefineRetriever(g, "pgvector/shows", nil, f)
+			if err := rows.Err(); err != nil {
+				return nil, err
+			}
+			return res, nil
+		})
 }
 ```
 
-And here's how to use the retriever in a flow:
+And here's how to use the retriever in a flow. `ai.WithConfig` is what sets
+`ai.RetrieverRequest.Options`, which is the value Genkit decodes into the
+`*ShowQuery` parameter:
 
 ```go
-retriever := defineRetriever(g, db, embedder)
+retriever := defineRetriever(g, db, queryEmbedder)
 
-type input struct {
-	Question string
-	Show     string
+type askInput struct {
+	Question string `json:"question"`
+	Show     string `json:"show"`
 }
 
-genkit.DefineFlow(g, "askQuestion", func(ctx context.Context, in input) (string, error) {
+genkit.DefineFlow(g, "askQuestion", func(ctx context.Context, in askInput) (string, error) {
 	res, err := genkit.Retrieve(ctx, g,
 		ai.WithRetriever(retriever),
-		ai.WithConfig(in.Show),
+		ai.WithConfig(&ShowQuery{Show: in.Show, K: 3}),
 		ai.WithTextDocs(in.Question))
 	if err != nil {
 		return "", err
@@ -235,9 +324,12 @@ genkit.DefineFlow(g, "askQuestion", func(ctx context.Context, in input) (string,
 	for _, doc := range res.Documents {
 		fmt.Printf("%+v %q\n", doc.Metadata, doc.Content[0].Text)
 	}
-	// Use documents in RAG prompts.
+	// Use the documents in a RAG prompt.
 	return "", nil
 })
 ```
+
+See the [Retrieval-augmented generation](/docs/rag) page for a general
+discussion on using retrievers for RAG.
 
 </Lang>

--- a/src/content/docs/docs/integrations/pinecone.mdx
+++ b/src/content/docs/docs/integrations/pinecone.mdx
@@ -95,21 +95,41 @@ discussion on indexers and retrievers.
 
 <Lang lang="go">
 
-The Pinecone plugin provides retriever implementatons that use the
+The Pinecone plugin provides a retriever implementation that uses the
 [Pinecone](https://www.pinecone.io/) cloud vector database.
 
 Pinecone is a cloud-native vector database that provides fast, scalable similarity search for AI applications. It offers managed infrastructure with automatic scaling and high availability.
 
-## Configuration
+## Prerequisites
 
-To use this plugin, import the `pinecone` package and initialize it via Genkit's `WithPlugins`:
+Create the Pinecone index before you run any of this code. The plugin does not
+create it for you, and two properties have to be decided at creation time:
+
+- **Dimension**: must equal the number of dimensions your embedder emits.
+  `gemini-embedding-001` emits 3072.
+- **Metric**: use `cosine` for the Gemini text embedders.
+
+The examples on this page use these imports:
 
 ```go
-import "github.com/firebase/genkit/go/plugins/pinecone"
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/pinecone"
+)
 ```
 
+## Configuration
+
+Register the Pinecone plugin, along with whichever plugin supplies your
+embedder, when you initialize Genkit:
+
 ```go
-g := genkit.Init(ctx, genkit.WithPlugins(&pinecone.Pinecone{}))
+g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}, &pinecone.Pinecone{}))
 ```
 
 The plugin requires your Pinecone API key.
@@ -120,7 +140,7 @@ Configure the plugin to use your API key by doing one of the following:
 - Specify the API key when you initialize the plugin:
 
 ```go
-g := genkit.Init(ctx, genkit.WithPlugins(&pinecone.Pinecone{
+g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}, &pinecone.Pinecone{
 	APIKey: pineconeAPIKey,
 }))
 ```
@@ -130,28 +150,70 @@ in conjunction with a service like Cloud Secret Manager or similar.
 
 ## Usage
 
-To retrieve documents from an index or index new documents, first create a retriever definition which returns a `Docstore` (`ds`) and an `ai.Retriever`:
+To retrieve documents from an index or index new documents, first create a
+retriever definition. It returns a `*pinecone.Docstore` (`ds`), used for
+indexing, and an `ai.Retriever`, used for queries:
 
 ```go
+embedder := genkit.LookupEmbedder(g, "googleai/gemini-embedding-001")
+if embedder == nil {
+	log.Fatal("embedder googleai/gemini-embedding-001 is not registered")
+}
+
 ds, menuRetriever, err := pinecone.DefineRetriever(ctx, g, pinecone.Config{
-	IndexID:  "menu_data",                                           // Your Pinecone index
-	Embedder: googlegenai.GoogleAIEmbedder(g, "text-embedding-004"), // Embedding model of your choice
+	IndexID:  "menu-data", // Your Pinecone index
+	Embedder: embedder,
 }, nil)
 if err != nil {
 	log.Fatal(err)
 }
 ```
 
-Index your documents in Pinecone. An example of indexing is provided within the Pinecone plugin as shown below. This functionality should be customized by the user according to their use case.
+`genkit.LookupEmbedder` returns `nil` if no embedder with that identifier is
+registered, so check the result before you use it. The name must carry the
+provider prefix.
+
+The trailing `nil` is a `*ai.RetrieverOptions`: action metadata (`Label`,
+`ConfigSchema`, `Supports`, `Metadata`) for the retriever this call defines.
+Pass `nil` to accept the defaults.
+
+### `pinecone.Config` fields
+
+| Field             | Type          | Purpose                                                                       |
+| ----------------- | ------------- | ----------------------------------------------------------------------------- |
+| `IndexID`         | `string`      | The Pinecone index to read and write.                                          |
+| `Embedder`        | `ai.Embedder` | Embedder used for both indexing and queries. Required.                         |
+| `EmbedderOptions` | `any`         | Options passed through to the embedder on every call.                          |
+| `TextKey`         | `string`      | Metadata key that holds the document text in Pinecone. Defaults to `_content`. |
+
+### Indexing
+
+`pinecone.Index` is a helper to get you started; customize it for your own
+ingestion pipeline. Build the documents first:
 
 ```go
-err = pinecone.Index(ctx, docChunks, ds, "")
-if err != nil {
+docChunks := []*ai.Document{
+	ai.DocumentFromText("Tuesday special: grilled cheese and tomato soup.", map[string]any{
+		"id":     "menu-1",
+		"source": "menu.pdf",
+	}),
+	ai.DocumentFromText("Dessert: lemon sorbet, dairy free.", map[string]any{
+		"id":     "menu-2",
+		"source": "menu.pdf",
+	}),
+}
+
+if err := pinecone.Index(ctx, docChunks, ds, ""); err != nil {
 	log.Fatal(err)
 }
 ```
 
-Then, call Genkit's `Retrieve()` method, passing it the retriever and a text query:
+The last argument is the Pinecone namespace. Pass `""` to use the default
+namespace.
+
+### Retrieving
+
+Call `genkit.Retrieve`, passing it the retriever and a text query:
 
 ```go
 resp, err := genkit.Retrieve(ctx, g, ai.WithRetriever(menuRetriever), ai.WithTextDocs(userInput))

--- a/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-bigquery.mdx
@@ -151,6 +151,25 @@ import "github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
 1. Create a Vertex AI Vector Search index. Details on creating an index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
 2. Create a Bigquery Dataset and a Table within that dataset to store the documents that will be indexed. More information to create Bigquery datasets is available [here](https://cloud.google.com/bigquery/docs/datasets)
 
+### The BigQuery table schema
+
+`GetBigQueryDocumentIndexer` and `GetBigQueryDocumentRetriever` are hard-coded to three `STRING`
+columns named `id`, `content` and `metadata`. Create the table with exactly that shape:
+
+```bash
+bq mk --table your-project-id:your-dataset-id.your-table-id \
+  id:STRING,content:STRING,metadata:STRING
+```
+
+`content` and `metadata` hold the JSON encoding of `ai.Document.Content` and `ai.Document.Metadata`
+as strings, not BigQuery `JSON` values. The indexer generates a random hex `id` per document and
+returns the ids it wrote; the retriever reads the rows back with
+`SELECT id, content, metadata FROM ... WHERE id IN UNNEST(@ids)` using the neighbor IDs the vector
+index returns. A column named or typed differently fails at insert or at read.
+
+Write your own `vectorsearch.DocumentIndexer` and `vectorsearch.DocumentRetriever` pair if you need
+a different schema.
+
 To use Vertex AI Vector Search with Bigquery, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Bigquery dataset:
 
 ```go
@@ -217,19 +236,51 @@ vectorsearchParams := &VectorsearchConfig{
 }
 ```
 
-### Configuration Options
+### Values you need to collect
+
+`VectorsearchConfig` above is a plain local struct, not a Genkit type. It exists only to carry these
+values from configuration to the call sites below; the plugin never sees it. Name it whatever you
+like.
 
 - **ProjectID** (string): GCP Project ID
 - **Location** (string): GCP Project location
 - **IndexID** (string): Vector search index id
 - **IndexEndpointID** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
 - **DeployedIndexID** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
-- **ProjectNumber** (string): GCP Project Number
-- **PublicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **ProjectNumber** (string): the numeric project ID, not the project ID string. Get it with
+  `gcloud projects describe $PROJECT_ID --format='value(projectNumber)'`, or read it from the Cloud
+  console project picker.
+- **PublicDomainName** (string): the `publicEndpointDomainName` of the deployed index endpoint. Get
+  it with
+  `gcloud ai index-endpoints describe $INDEX_ENDPOINT_ID --region=$LOCATION --format='value(publicEndpointDomainName)'`.
 - **Embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
 - **NeighborsCount** (int): Number of neighbors to set in the vector search
 - **DocumentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Bigquery. This can be a custom document indexer as well depending on the user's requirement.
 - **DocumentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Bigquery. This can be a custom document retriever as well depending on the user's requirement.
+
+:::caution
+The plugin queries the public `findNeighbors` endpoint at
+`https://{PublicDomainName}/v1/projects/{ProjectNumber}/locations/{Location}/indexEndpoints/{IndexEndpointID}:findNeighbors`.
+`publicEndpointDomainName` exists only for endpoints deployed with public endpoint access, so index
+endpoints deployed behind VPC peering or Private Service Connect are not supported.
+:::
+
+### Genkit types
+
+These are the types the plugin actually defines.
+
+| Type | Fields |
+| --- | --- |
+| `vectorsearch.VertexAIVectorSearch` | `ProjectID string`, `Location string`. This is the plugin value you pass to `genkit.Init`. |
+| `vectorsearch.Config` | `IndexID string`. The only field, so a retriever definition is `vectorsearch.DefineRetriever(ctx, g, vectorsearch.Config{IndexID: id}, nil)`. |
+| `vectorsearch.IndexParams` | `Docs []*ai.Document`, `Embedder ai.Embedder`, `EmbedderOptions any`, `ProjectID string`, `Location string`, `IndexID string`. |
+| `vectorsearch.RetrieveParams` | `Content *ai.Document`, `Embedder ai.Embedder`, `EmbedderOptions any`, `AuthClient *google.Credentials`, `ProjectNumber string`, `Location string`, `IndexEndpointID string`, `PublicDomainName string`, `DeployedIndexID string`, `NeighborCount int`, `Restricts []Restrict`, `NumericRestricts []NumericRestrict`, `DocumentRetriever DocumentRetriever`. |
+
+The trailing `nil` in `DefineRetriever` is an `*ai.RetrieverOptions`. Pass one to set the retriever's
+label or declare what it supports; `nil` takes the defaults.
+
+`RetrieveParams.Location` is ignored: the plugin uses the `Location` you set on
+`VertexAIVectorSearch`.
 
 ## Usage
 
@@ -271,7 +322,7 @@ if err := vectorsearch.Index(ctx, g, vectorsearch.IndexParams{
 
 ### Retrieving Documents
 
-Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+Call `Retrieve` on the retriever you defined:
 
 ```go
 // Define the retriever for vector search.
@@ -305,5 +356,18 @@ if err != nil {
     return nil, err
 }
 ```
+
+#### Which Retrieve to call
+
+Three forms exist and the other vector store pages use a different one, so:
+
+- `retriever.Retrieve(ctx, req)` is the `ai.Retriever` interface method. It is used here because the
+  request carries a typed `Options` payload, `*vectorsearch.RetrieveParams`, that the vector search
+  retriever needs on every call.
+- `genkit.Retrieve(ctx, g, ai.WithRetriever(r), ai.WithTextDocs(q))` is the form the other pages use.
+  It is equivalent for retrievers that need no options. To pass options through it, add
+  `ai.WithConfig(&vectorsearch.RetrieveParams{...})`.
+- `ai.Retrieve(ctx, reg, opts...)` is the same call taking an `api.Registry` rather than a
+  `*genkit.Genkit`. Use it from plugin code that has no `*genkit.Genkit`.
 
 </Lang>

--- a/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
+++ b/src/content/docs/docs/integrations/vectorsearch-firestore.mdx
@@ -180,6 +180,19 @@ import "github.com/firebase/genkit/go/plugins/vertexai/vectorsearch"
 1. Create a vector search index in Vertex AI. Details on creating vector search index can be found at [Create your Vector Search Index](https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index#create-index)
 2. Create a Firestore Dataset and a Collection within that dataset to store the documents that will be indexed. More information to create Firestore datasets is available [here](https://firebase.google.com/docs/firestore/quickstart#create)
 
+### What the Firestore helpers write
+
+`GetFirestoreDocumentIndexer` writes one auto-ID document per `ai.Document` into the named
+collection, with two fields: `content` (the document's `Content` parts) and `metadata`. It commits
+them in a single batch and returns the generated document IDs, which are the IDs the vector search
+index stores as datapoints. `GetFirestoreDocumentRetriever` reads those documents back by ID.
+
+The collection needs no vector index. The embeddings live in the Vertex AI index, not in Firestore;
+Firestore only holds the document bodies.
+
+Write your own `vectorsearch.DocumentIndexer` and `vectorsearch.DocumentRetriever` pair if you need
+a different shape.
+
 To use the GCP vector search with Firestore, initialize it and define a retriever with an embedder. You can also use a custom indexer and retriever for indexing and retrieving documents from the Firestore dataset:
 
 ```go
@@ -208,7 +221,13 @@ g := genkit.Init(ctx, genkit.WithPlugins(
 
 databaseId := "${FIRESTORE_DATABASE_ID}"         // Replace with your Firestore database ID
 collectionName := "${FIRESTORE_COLLECTION_NAME}" // Replace with your Firestore collection name
+
 firestoreClient, err := firestore.NewClientWithDatabase(ctx, vectorsearchPlugin.ProjectID, databaseId)
+if err != nil {
+	log.Fatalf("failed to create Firestore client: %v", err)
+}
+defer firestoreClient.Close()
+
 documentIndexer := vectorsearch.GetFirestoreDocumentIndexer(firestoreClient, collectionName)
 documentRetriever := vectorsearch.GetFirestoreDocumentRetriever(firestoreClient, collectionName)
 
@@ -241,19 +260,51 @@ vectorsearchParams := &VectorsearchConfig{
 }
 ```
 
-### Configuration Options
+### Values you need to collect
+
+`VectorsearchConfig` above is a plain local struct, not a Genkit type. It exists only to carry these
+values from configuration to the call sites below; the plugin never sees it. Name it whatever you
+like.
 
 - **ProjectID** (string): GCP Project ID
 - **Location** (string): GCP Project location
 - **IndexID** (string): Vector search index id
 - **IndexEndpointID** (string): Vector search endpoint id corresponding to the vector search index. More details can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#create-index-endpoint).
 - **DeployedIndexID** (string): Vector search deployed index id corresponding to the vector search endpoint. More details to deploy an index to an index endpoint can be found [here](https://cloud.google.com/vertex-ai/docs/vector-search/deploy-index-public#deploy-index).
-- **ProjectNumber** (string): GCP Project Number
-- **PublicDomainName** (string): Public Domain Name of the vector search index endpoint.
+- **ProjectNumber** (string): the numeric project ID, not the project ID string. Get it with
+  `gcloud projects describe $PROJECT_ID --format='value(projectNumber)'`, or read it from the Cloud
+  console project picker.
+- **PublicDomainName** (string): the `publicEndpointDomainName` of the deployed index endpoint. Get
+  it with
+  `gcloud ai index-endpoints describe $INDEX_ENDPOINT_ID --region=$LOCATION --format='value(publicEndpointDomainName)'`.
 - **Embedder** ([`ai.Embedder`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Embedder)): The embedding model to use. Must be a configured embedder in your Genkit project.
 - **NeighborsCount** (int): Number of neighbors to set in the vector search
 - **DocumentIndexer** (`func(ctx context.Context, docs []*ai.Document) ([]string, error)`): Document indexer used to insert data with unique IDs in Firestore. This can be a custom document indexer as well depending on the user's requirement.
 - **DocumentRetriever** (`func(ctx context.Context, neighbors []Neighbor, options any) ([]*ai.Document, error)`): Document retriever used to retrieve data with corresponding ID from Firestore. This can be a custom document retriever as well depending on the user's requirement.
+
+:::caution
+The plugin queries the public `findNeighbors` endpoint at
+`https://{PublicDomainName}/v1/projects/{ProjectNumber}/locations/{Location}/indexEndpoints/{IndexEndpointID}:findNeighbors`.
+`publicEndpointDomainName` exists only for endpoints deployed with public endpoint access, so index
+endpoints deployed behind VPC peering or Private Service Connect are not supported.
+:::
+
+### Genkit types
+
+These are the types the plugin actually defines.
+
+| Type | Fields |
+| --- | --- |
+| `vectorsearch.VertexAIVectorSearch` | `ProjectID string`, `Location string`. This is the plugin value you pass to `genkit.Init`. |
+| `vectorsearch.Config` | `IndexID string`. The only field, so a retriever definition is `vectorsearch.DefineRetriever(ctx, g, vectorsearch.Config{IndexID: id}, nil)`. |
+| `vectorsearch.IndexParams` | `Docs []*ai.Document`, `Embedder ai.Embedder`, `EmbedderOptions any`, `ProjectID string`, `Location string`, `IndexID string`. |
+| `vectorsearch.RetrieveParams` | `Content *ai.Document`, `Embedder ai.Embedder`, `EmbedderOptions any`, `AuthClient *google.Credentials`, `ProjectNumber string`, `Location string`, `IndexEndpointID string`, `PublicDomainName string`, `DeployedIndexID string`, `NeighborCount int`, `Restricts []Restrict`, `NumericRestricts []NumericRestrict`, `DocumentRetriever DocumentRetriever`. |
+
+The trailing `nil` in `DefineRetriever` is an `*ai.RetrieverOptions`. Pass one to set the retriever's
+label or declare what it supports; `nil` takes the defaults.
+
+`RetrieveParams.Location` is ignored: the plugin uses the `Location` you set on
+`VertexAIVectorSearch`.
 
 ## Usage
 
@@ -295,7 +346,7 @@ if err := vectorsearch.Index(ctx, g, vectorsearch.IndexParams{
 
 ### Retrieving Documents
 
-Use [`ai.Retrieve`](https://pkg.go.dev/github.com/firebase/genkit/go/ai#Retrieve) with the retriever you defined:
+Call `Retrieve` on the retriever you defined:
 
 ```go
 // Define the retriever for vector search.
@@ -327,5 +378,18 @@ if err != nil {
     return nil, err
 }
 ```
+
+#### Which Retrieve to call
+
+Three forms exist and the other vector store pages use a different one, so:
+
+- `retriever.Retrieve(ctx, req)` is the `ai.Retriever` interface method. It is used here because the
+  request carries a typed `Options` payload, `*vectorsearch.RetrieveParams`, that the vector search
+  retriever needs on every call.
+- `genkit.Retrieve(ctx, g, ai.WithRetriever(r), ai.WithTextDocs(q))` is the form the other pages use.
+  It is equivalent for retrievers that need no options. To pass options through it, add
+  `ai.WithConfig(&vectorsearch.RetrieveParams{...})`.
+- `ai.Retrieve(ctx, reg, opts...)` is the same call taking an `api.Registry` rather than a
+  `*genkit.Genkit`. Use it from plugin code that has no `*genkit.Genkit`.
 
 </Lang>

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -650,6 +650,23 @@ Vector Search has both ingestion and hosting costs. See [Vertex AI pricing](http
 
 <Lang lang="go">
 
+The examples on this page use these imports:
+
+```go
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"google.golang.org/genai"
+)
+```
+
+Vertex AI and the Gemini API are served by the same `googlegenai` package; the
+plugin value you pass to `genkit.Init` decides which backend you talk to.
+
 The Google Generative AI plugin provides access to Google's Gemini models through Vertex AI.
 
 ## Configuration
@@ -663,6 +680,28 @@ import "github.com/firebase/genkit/go/plugins/googlegenai"
 ```go
 g := genkit.Init(context.Background(), genkit.WithPlugins(&googlegenai.VertexAI{}))
 ```
+
+### Prerequisites
+
+Before the first request:
+
+1. Create or select a Google Cloud project, and make sure billing is enabled on it.
+
+2. Enable the Vertex AI API on that project:
+
+   ```shell
+   gcloud services enable aiplatform.googleapis.com --project=$PROJECT_ID
+   ```
+
+3. Grant the Vertex AI User role (`roles/aiplatform.user`) to the principal your app runs as.
+
+4. For local development, get Application Default Credentials:
+
+   ```shell
+   gcloud auth application-default login
+   ```
+
+A missing step 2 surfaces at request time as an HTTP 403 with reason `SERVICE_DISABLED`, not as a startup error.
 
 ### Google Cloud credentials
 
@@ -700,7 +739,24 @@ gcloud auth application-default login
 
 2. In addition, make sure the account is granted the Vertex AI User IAM role (`roles/aiplatform.user`). See the Vertex AI [access control](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/access-control) docs.
 
-To use credentials other than the detected ones, set `Credentials` to an `*auth.Credentials` from `cloud.google.com/go/auth`.
+On Cloud Run, GKE, or Compute Engine the attached service account is already detected, so leave `Credentials` unset. Set it only to load a key file or to impersonate another service account. It takes an `*auth.Credentials` from `cloud.google.com/go/auth`, which you build with `cloud.google.com/go/auth/credentials`:
+
+```go
+import "cloud.google.com/go/auth/credentials"
+
+creds, err := credentials.DetectDefault(&credentials.DetectOptions{
+	Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+})
+if err != nil {
+	log.Fatal(err)
+}
+
+g := genkit.Init(context.Background(), genkit.WithPlugins(&googlegenai.VertexAI{
+	ProjectID:   "my-project-id",
+	Location:    "us-central1",
+	Credentials: creds,
+}))
+```
 
 ### Express Mode
 
@@ -934,7 +990,11 @@ These behave exactly as they do on the Google AI plugin, so they are documented 
 
 ## Model Garden
 
-Third-party models hosted in Vertex AI Model Garden come from the `vertexai/modelgarden` package, which ships one plugin per family: `modelgarden.Anthropic` for Claude, `modelgarden.Llama` for Meta Llama, and `modelgarden.Mistral` for Mistral and Codestral. Each takes a `ProjectID` and `Location`, falling back to the same environment variables as the main plugin, and registers its models under the `vertexai/` prefix.
+Third-party models hosted in Vertex AI Model Garden come from a separate package, which ships one plugin per family: `modelgarden.Anthropic` for Claude, `modelgarden.Llama` for Meta Llama, and `modelgarden.Mistral` for Mistral and Codestral. Each takes a `ProjectID` and `Location`, falling back to the same environment variables as the main plugin, and registers its models under the `vertexai/` prefix.
+
+```go
+import "github.com/firebase/genkit/go/plugins/vertexai/modelgarden"
+```
 
 ```go
 g := genkit.Init(ctx, genkit.WithPlugins(
@@ -947,11 +1007,31 @@ resp, err := genkit.Generate(ctx, g,
 )
 ```
 
-Unlike the Gemini models, Model Garden models cannot be listed through the SDK when authenticating with Google credentials, so each plugin registers a fixed catalog at initialization. See the [`modelgarden`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden), [`modelgarden-llama`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden-llama), and [`modelgarden-mistral`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden-mistral) samples.
+Unlike the Gemini models, Model Garden models cannot be listed through the SDK when authenticating with Google credentials, so each plugin registers a fixed catalog at initialization. An ID outside its family's catalog does not resolve.
+
+**`modelgarden.Anthropic`**
+
+`claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-sonnet-4`, `claude-haiku-4-5`, `claude-3-7-sonnet`, `claude-3-5-sonnet-v2`, `claude-3-5-sonnet`, `claude-3-5-haiku`, `claude-3-sonnet`, `claude-3-haiku`, `claude-3-opus`.
+
+Date-pinned spellings of the older models (`claude-opus-4@20250514`, `claude-sonnet-4@20250514`, `claude-3-7-sonnet@20250219`, `claude-3-5-sonnet-v2@20241022`, `claude-3-5-sonnet@20240620`, `claude-3-sonnet@20240229`, `claude-3-haiku@20240307`, `claude-3-opus@20240229`) still resolve, and are marked deprecated. Keys are Vertex AI publisher model IDs, not Anthropic API date-versioned IDs.
+
+**`modelgarden.Llama`**
+
+`meta/llama-4-maverick-17b-128e-instruct-maas`, `meta/llama-4-scout-17b-16e-instruct-maas`, `meta/llama-3.3-70b-instruct-maas`.
+
+**`modelgarden.Mistral`**
+
+`mistral-medium-3`, `mistral-small-2503`, `codestral-2`. The bare publisher ID is the key; `mistralai/`-prefixed forms are accepted too.
+
+:::caution
+A Model Garden model must be enabled for your project in the [Vertex AI Model Garden console](https://console.cloud.google.com/vertex-ai/model-garden) before a request to it succeeds.
+:::
+
+See the [`modelgarden`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden), [`modelgarden-llama`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden-llama), and [`modelgarden-mistral`](https://github.com/genkit-ai/genkit/tree/main/go/samples/modelgarden-mistral) samples.
 
 ## Vector Search
 
-Vertex AI Vector Search is a retriever plugin in the `vertexai/vectorsearch` package, with document storage backed by either BigQuery or Cloud Firestore. See [Vector Search with BigQuery](/docs/integrations/vectorsearch-bigquery) and [Vector Search with Firestore](/docs/integrations/vectorsearch-firestore) for the setup, and the [`vectorsearch-biqguery`](https://github.com/genkit-ai/genkit/tree/main/go/samples/vectorsearch-biqguery) and [`vectorsearch-firestore`](https://github.com/genkit-ai/genkit/tree/main/go/samples/vectorsearch-firestore) samples for working programs.
+Vertex AI Vector Search is a retriever plugin in `github.com/firebase/genkit/go/plugins/vertexai/vectorsearch`, with document storage backed by either BigQuery or Cloud Firestore. See [Vector Search with BigQuery](/docs/integrations/vectorsearch-bigquery) and [Vector Search with Firestore](/docs/integrations/vectorsearch-firestore) for the setup, and the [`vectorsearch-biqguery`](https://github.com/genkit-ai/genkit/tree/main/go/samples/vectorsearch-biqguery) and [`vectorsearch-firestore`](https://github.com/genkit-ai/genkit/tree/main/go/samples/vectorsearch-firestore) samples for working programs.
 
 ## Next steps
 

--- a/src/content/docs/docs/integrations/zai.mdx
+++ b/src/content/docs/docs/integrations/zai.mdx
@@ -132,7 +132,8 @@ streaming flow you can call from the Dev UI.
 | `TopP` | `*float64` | Nucleus sampling threshold, 0.01 to 1. |
 | `MaxOutputTokens` | `int` | Sent as the API's `max_tokens`, up to 131072. |
 | `StopSequences` | `[]string` | Up to four. |
-| `Thinking` | `*zai.ThinkingConfig` | `Type` is `zai.ThinkingTypeEnabled`, the Z.ai default, or `zai.ThinkingTypeDisabled`. `ClearThinking` decides whether the reasoning is cleared from the response, and Z.ai defaults it to true. |
+| `Thinking` | `*zai.ThinkingConfig` | `Type` is `zai.ThinkingTypeEnabled`, the Z.ai default, or `zai.ThinkingTypeDisabled`. |
+| `Thinking.ClearThinking` | `*bool` | Sent as the API's `clear_thinking`. Z.ai defaults it to true, which strips the reasoning from the response. Point it at `false` to keep the reasoning. |
 | `DoSample` | `*bool` | `false` turns sampling off, which makes `Temperature` and `TopP` inert. |
 
 Z.ai documents no penalties, no log probabilities, and no seed, so those fields are deliberately
@@ -172,5 +173,29 @@ g := genkit.Init(ctx, genkit.WithPlugins(&zai.ZAI{
 Reasoning text, streamed token usage, cached prompt tokens, and mid-generation provider failures are
 handled the same way for every plugin in this family. See the
 [OpenAI-compatible plugin](/docs/integrations/openai-compatible/) page.
+
+One GLM-specific departure: `resp.Reasoning()` comes back empty even with thinking enabled, because
+Z.ai clears the reasoning by default. Set `Thinking.ClearThinking` to a pointer to `false` to keep
+it:
+
+```go
+clearThinking := false
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModel(zai.ModelRef("glm-5.1", &zai.ChatConfig{
+		Thinking: &zai.ThinkingConfig{
+			Type:          zai.ThinkingTypeEnabled,
+			ClearThinking: &clearThinking,
+		},
+	})),
+	ai.WithPrompt("Which is heavier, a kilo of steel or a kilo of feathers?"),
+)
+if err != nil {
+	log.Fatalf("could not generate: %v", err)
+}
+
+fmt.Println(resp.Reasoning())
+fmt.Println(resp.Text())
+```
 
 </Lang>

--- a/src/content/docs/docs/interrupts.mdx
+++ b/src/content/docs/docs/interrupts.mdx
@@ -438,6 +438,13 @@ askQuestion := genkit.DefineTool(g, "askQuestion",
 )
 ```
 
+`ai.InterruptWith(tc, meta)` is a typed wrapper over
+`tc.Interrupt(&ai.InterruptOptions{Metadata: ...})`: it JSON-marshals `meta`
+into the same metadata map and calls the same method, so both halt the loop
+identically. Prefer `ai.InterruptWith` with a struct, because that is what
+`ai.InterruptAs[T]` reads back. Reach for `tc.Interrupt` only when you already
+hold a `map[string]any`.
+
 ### Use interrupts
 
 Interrupts are passed into the `WithTools()` option when generating content, just like
@@ -471,34 +478,67 @@ if resp.FinishReason == ai.FinishReasonInterrupted {
 Responding to an interrupt is done using the tool's `RespondWith()` method and
 `ai.WithToolResponses()` on a subsequent `Generate` call, passing in the existing
 message history. `RespondWith()` answers the paused call outright, so the tool
-function never runs again:
+function never runs again.
+
+A single turn can raise interrupts from more than one tool, so dispatch on the
+tool name rather than assuming which tool paused. This example adds a second
+interrupting tool beside `askQuestion`:
 
 ```go
+type BudgetInput struct {
+	Dollars float64 `json:"dollars"`
+}
+
+// A second tool that pauses, so the loop below has something to dispatch on.
+confirmBudget := genkit.DefineTool(g, "confirmBudget",
+	"use this to have the user approve a spend before committing to it",
+	func(tc *ai.ToolContext, input BudgetInput) (bool, error) {
+		return false, ai.InterruptWith(tc, InterruptMetadata{Reason: "confirm_budget"})
+	},
+)
+
+const maxRounds = 5
+
 resp, err := genkit.Generate(ctx, g,
 	ai.WithPrompt("Help me plan a backyard BBQ."),
 	ai.WithSystem("Ask clarifying questions until you have a complete solution."),
-	ai.WithTools(askQuestion),
+	ai.WithTools(askQuestion, confirmBudget),
 )
 if err != nil {
 	return err
 }
 
-for resp.FinishReason == ai.FinishReasonInterrupted {
+for round := 0; round < maxRounds && resp.FinishReason == ai.FinishReasonInterrupted; round++ {
 	var responses []*ai.Part
 
 	for _, interrupt := range resp.Interrupts() {
-		// RespondWith is typed against the tool's output, so the answer
-		// cannot drift from what the tool would have returned.
-		part, err := askQuestion.RespondWith(interrupt, getUserAnswer(interrupt))
-		if err != nil {
-			return err
+		// Every interrupt in this turn needs exactly one response or restart
+		// part, so dispatch on the tool that raised it.
+		switch interrupt.ToolRequest.Name {
+		case askQuestion.Name():
+			// RespondWith is typed against the tool's output, so the answer
+			// cannot drift from what the tool would have returned.
+			part, err := askQuestion.RespondWith(interrupt, getUserAnswer(interrupt))
+			if err != nil {
+				return err
+			}
+			responses = append(responses, part)
+
+		case confirmBudget.Name():
+			part, err := confirmBudget.RespondWith(interrupt, userApproves(interrupt))
+			if err != nil {
+				return err
+			}
+			responses = append(responses, part)
+
+		default:
+			return fmt.Errorf("no handler for interrupt from tool %q", interrupt.ToolRequest.Name)
 		}
-		responses = append(responses, part)
 	}
 
 	resp, err = genkit.Generate(ctx, g,
 		ai.WithMessages(resp.History()...),
-		ai.WithTools(askQuestion),
+		ai.WithTools(askQuestion, confirmBudget),
 		ai.WithToolResponses(responses...),
 	)
 	if err != nil {
@@ -508,6 +548,114 @@ for resp.FinishReason == ai.FinishReasonInterrupted {
 
 fmt.Println(resp.Text())
 ```
+
+`RespondWith()` and `RestartWith()` check that the part belongs to the tool you
+called them on. Handing `askQuestion` an interrupt raised by `confirmBudget`
+returns an `INVALID_ARGUMENT` error reading
+`tool request is for "confirmBudget", not "askQuestion"`, so a mismatched branch
+fails loudly rather than producing a wrong answer.
+
+:::caution[Answer every interrupt, exactly once]
+Every interrupt in a turn must get exactly one response or restart part.
+
+- Answer some but not all, and the next `Generate` fails with
+  `ai.ErrUnresolvedToolRequest`.
+- Answer none of them, and the resume is empty. Genkit treats an empty resume
+  as no resume at all, re-sends the identical history, and a
+  `for resp.FinishReason == ai.FinishReasonInterrupted` loop never terminates,
+  burning tokens on every pass. That is why the loop above has a round cap and
+  why the `default` branch returns an error instead of skipping the part.
+:::
+
+### Out-of-band approval
+
+The examples above collect the answer inline, but the point of an interrupt is
+usually that the answer arrives later, from a different process. `ai.Message`
+and `ai.Part` are plain structs with JSON tags, so a paused run round-trips
+through `json.Marshal`. Store `resp.History()` and `resp.Interrupts()` under an
+approval ID, return the ID to the caller, and rebuild the call when the decision
+comes back. `askQuestion` is the tool from above, held in a package-level
+`*ai.ToolAction[QuestionInput, string]` so both handlers reach the same one:
+
+```go
+// Store is whatever you already run: Firestore, Redis, a table.
+type Store interface {
+	Put(ctx context.Context, key string, blob []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+}
+
+// A paused run is ordinary JSON.
+type pausedRun struct {
+	History    []*ai.Message `json:"history"`
+	Interrupts []*ai.Part    `json:"interrupts"`
+}
+
+// Park the run when generation stops on an interrupt, then hand the caller
+// the approval ID and return.
+func park(ctx context.Context, store Store, approvalID string, resp *ai.ModelResponse) error {
+	blob, err := json.Marshal(pausedRun{
+		History:    resp.History(),
+		Interrupts: resp.Interrupts(),
+	})
+	if err != nil {
+		return err
+	}
+	return store.Put(ctx, approvalID, blob)
+}
+
+// Later, on a different request and possibly in a different process.
+func resume(ctx context.Context, g *genkit.Genkit, store Store, approvalID, answer string) (*ai.ModelResponse, error) {
+	blob, err := store.Get(ctx, approvalID)
+	if err != nil {
+		return nil, err
+	}
+	var run pausedRun
+	if err := json.Unmarshal(blob, &run); err != nil {
+		return nil, err
+	}
+
+	var responses []*ai.Part
+	for _, interrupt := range run.Interrupts {
+		if interrupt.ToolRequest.Name != askQuestion.Name() {
+			return nil, fmt.Errorf("no handler for interrupt from tool %q", interrupt.ToolRequest.Name)
+		}
+		part, err := askQuestion.RespondWith(interrupt, answer)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, part)
+	}
+
+	return genkit.Generate(ctx, g,
+		ai.WithMessages(run.History...),
+		// Every tool named by a pending request has to be on this call, or
+		// Generate fails with ai.ErrToolNotFound.
+		ai.WithTools(askQuestion),
+		ai.WithToolResponses(responses...),
+	)
+}
+```
+
+`ai.WithToolRestarts()` rehydrates the same way when the tool has to run again
+rather than be answered outright.
+
+[Agent interrupts](/docs/agents/interrupts) do this persistence for you: the
+session store holds the paused history, so the resuming request carries only the
+decision.
+
+#### Resuming from an untrusted caller
+
+`Generate` matches each restart or respond part to a pending tool request by
+tool name and ref only. It does not check that a restarted input matches what
+the model originally asked for, and a part that matches nothing pending is
+silently dropped rather than rejected. Respond output is validated against the
+tool's output schema and nothing more.
+
+So if the resume payload arrives over the network, re-read the paused history
+from your own store and verify every part against it before calling `Generate`.
+The agent runtime does exactly this with
+`aix.ValidateResumeAgainstHistory(resume, history)`, described in
+[Agent interrupts](/docs/agents/interrupts).
 
 ## Tools with restartable interrupts
 
@@ -602,13 +750,16 @@ if err != nil {
 	return err
 }
 
-for resp.FinishReason == ai.FinishReasonInterrupted {
+for round := 0; round < maxRounds && resp.FinishReason == ai.FinishReasonInterrupted; round++ {
 	var restarts, responses []*ai.Part
 
 	for _, interrupt := range resp.Interrupts() {
 		meta, ok := ai.InterruptAs[TransferInterrupt](interrupt)
 		if !ok {
-			continue
+			// Skipping the part here would leave the interrupt unanswered,
+			// so fail instead.
+			return fmt.Errorf("interrupt from %q carried no TransferInterrupt metadata",
+				interrupt.ToolRequest.Name)
 		}
 
 		switch meta.Reason {
@@ -644,6 +795,17 @@ for resp.FinishReason == ai.FinishReasonInterrupted {
 				}
 				responses = append(responses, part)
 			}
+
+		default:
+			// An unrecognized reason still has to be answered.
+			part, err := transferMoney.RespondWith(interrupt, TransferOutput{
+				Status:  "cancelled",
+				Message: fmt.Sprintf("Unhandled interrupt reason %q.", meta.Reason),
+			})
+			if err != nil {
+				return err
+			}
+			responses = append(responses, part)
 		}
 	}
 
@@ -660,6 +822,14 @@ for resp.FinishReason == ai.FinishReasonInterrupted {
 
 fmt.Println(resp.Text())
 ```
+
+The type parameter on `ai.WithResumedMetadata[TransferInput]` is the tool's
+input type, and you have to write it out because the option's only argument is a
+`map[string]any`, which gives the compiler nothing to infer from. Its sibling
+`ai.WithNewInput` is generic on the same parameter but infers it from the value
+you pass. Getting it wrong is a compile error rather than a runtime surprise:
+`RestartWith` on a `*ai.ToolAction[In, Out]` accepts only an
+`ai.RestartWithOption[In]`.
 
 ### Access original input after replacement
 

--- a/src/content/docs/docs/local-observability.mdx
+++ b/src/content/docs/docs/local-observability.mdx
@@ -44,11 +44,19 @@ tooling of your choice.
 
 ## Tracing & metrics
 
-Genkit automatically collects traces and metrics without requiring explicit configuration, allowing you to observe and debug your Genkit code's behavior
-in the Developer UI. Genkit stores these traces, enabling you to analyze
-your Genkit flows step-by-step with detailed input/output logging and
-statistics. In production, Genkit can export traces and metrics to Firebase
-Genkit Monitoring for further analysis.
+Genkit automatically collects traces and metrics without requiring explicit
+configuration. Genkit stores the traces and the Developer UI displays them, so
+you can analyze a flow step-by-step with its inputs, outputs, and timing.
+
+Metrics travel a separate path. Genkit records metric families for feature,
+flow, action, generate, and tool activity, including `genkit/flow/latency` and
+the token counters `genkit/ai/generate/input/tokens` and
+`genkit/ai/generate/output/tokens`. The full table is in
+[Telemetry collection](/docs/observability/telemetry-collection). The Developer
+UI does not display metrics: they only leave the process once an exporting
+plugin such as the Firebase plugin is installed. In production, Genkit can
+export both traces and metrics to Firebase Genkit Monitoring for further
+analysis.
 
 <Lang lang="js">
 
@@ -162,14 +170,28 @@ The console starts at info. To see Genkit's per-request detail in the terminal
 as well, lower the level:
 
 ```go
-// Console only. In dev the Developer UI already receives debug and above,
-// whatever this is set to.
-logger.SetLevel(slog.LevelDebug)
+func main() {
+	ctx := context.Background()
+
+	// Console only. In dev the Developer UI already receives debug and above,
+	// whatever this is set to.
+	logger.SetLevel(slog.LevelDebug)
+
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+	// ... define flows, serve ...
+	_ = g
+}
 ```
 
-`SetLevel` installs Genkit's console handler as the process default. If your
-application configured its own default `slog` handler, Genkit leaves it alone
-and warns instead, so set that handler's level rather than calling `SetLevel`.
+Order relative to `genkit.Init` does not matter. `SetLevel` is not
+`slog.SetDefault`: it recomposes Genkit's console handler with every sink already
+registered rather than replacing the default outright, and `genkit.Init`
+recomposes again when it registers the Developer UI sink. The caution above does
+not apply to it.
+
+If your application configured its own default `slog` handler, Genkit leaves it
+alone and warns instead, so set that handler's level rather than calling
+`SetLevel`.
 
 ### Environment variables
 
@@ -195,8 +217,122 @@ and anything else as JSON. `slog` groups flatten into dotted keys.
 
 Export never blocks your code. Records are batched and posted in the background,
 and dropped rather than queued when the buffer fills, with one warning on
-stderr. There is no flush at process exit either, so a short-lived `go run .`
-can lose its last few records.
+stderr.
+
+## Trace your own work
+
+### Add a step and attach attributes
+
+A step is a named span inside a flow. `genkit.Run` creates one:
+
+```go
+hits, err := genkit.Run(ctx, "retrieve", func() (int, error) {
+	return len(docs), nil
+})
+```
+
+`genkit.Run` does not pass the step's context into `fn`, so anything inside it
+that traces its own work reports against the enclosing flow instead of the step.
+Use `genkit.RunWithContext` when the work inside takes a context:
+
+```go
+file, err := genkit.RunWithContext(ctx, "upload-image",
+	func(ctx context.Context) (*genai.File, error) {
+		// The upload's own HTTP spans nest under "upload-image".
+		return client.Files.UploadFromPath(ctx, path, nil)
+	})
+```
+
+To attach a measurement to the active span, use the OpenTelemetry API directly.
+The attributes appear on the span in the Developer UI trace viewer:
+
+```go
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+trace.SpanFromContext(ctx).SetAttributes(
+	attribute.Float64("retrieval.hitRate", rate),
+	attribute.Int("retrieval.docs", len(docs)),
+)
+```
+
+### Get the current trace id
+
+Inside a flow, a step, or a tool, `tracing.SpanTraceInfo(ctx)` returns the ids of
+the span that is active:
+
+```go
+import (
+	"github.com/firebase/genkit/go/core/logger"
+	"github.com/firebase/genkit/go/core/tracing"
+)
+
+info := tracing.SpanTraceInfo(ctx)
+logger.Error(ctx, "request failed",
+	"traceId", info.TraceID,
+	"spanId", info.SpanID,
+	"path", tracing.SpanPath(ctx))
+```
+
+Return that trace id to the caller in a response header and an operator can go
+straight to `genkit trace:get <traceId>`. `tracing.SpanPath(ctx)` gives the step's
+path within the trace, which is what identifies a step in the Developer UI.
+
+Genkit's spans are ordinary OpenTelemetry spans, so the standard API works too:
+`trace.SpanContextFromContext(ctx).TraceID().String()` from
+`go.opentelemetry.io/otel/trace` returns the same value.
+
+### Export to any OTel backend
+
+Genkit's traces go through a standard OpenTelemetry `TracerProvider`, so any
+exporter can be attached alongside the Developer UI sink. Register the span
+processor after `genkit.Init`, so the provider Genkit installed is the one you
+extend:
+
+```go
+import (
+	"github.com/firebase/genkit/go/core/tracing"
+	"github.com/firebase/genkit/go/genkit"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+g := genkit.Init(ctx)
+tracing.TracerProvider().RegisterSpanProcessor(sdktrace.NewBatchSpanProcessor(yourExporter))
+```
+
+`yourExporter` is any `sdktrace.SpanExporter`: OTLP, Jaeger, or one you wrote. If
+you are packaging the exporter for other people to install rather than wiring it
+into one application, do it as a plugin instead; see
+[Writing Genkit plugins](/docs/plugin-authoring/overview).
+
+## Shutdown and flushing
+
+The Genkit instance itself needs no shutdown. There is no `Close` or `Shutdown`
+method; background work is released by cancelling the context you passed to
+`genkit.Init`.
+
+Traces can be drained explicitly, because `tracing.TracerProvider` hands you the
+OpenTelemetry provider:
+
+```go
+import "github.com/firebase/genkit/go/core/tracing"
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := genkit.Init(ctx)
+	defer tracing.TracerProvider().Shutdown(context.Background())
+	// ... define flows, serve ...
+	_ = g
+}
+```
+
+Use `ForceFlush` instead of `Shutdown` if the process keeps running afterwards.
+Log export has no equivalent hook, so a short-lived `go run .` can still lose its
+last few log records; sleep briefly before exit if that matters.
 
 </Lang>
 

--- a/src/content/docs/docs/mcp-server.mdx
+++ b/src/content/docs/docs/mcp-server.mdx
@@ -14,6 +14,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 The Genkit MCP (Model Context Protocol) Server enables seamless integration of your Genkit projects with various development environments and AI tools. By exposing Genkit functionalities through the Model Context Protocol, it allows LLM agents and IDEs to discover, interact with, and monitor your Genkit flows and other components.
 
+:::note
+This page covers the MCP server that the Genkit CLI runs so an assistant can drive your app. To expose your own tools and resources to an MCP client, see [Model Context Protocol (MCP)](/docs/model-context-protocol).
+:::
+
 <Aside type="caution" title="Experimental">
   The Genkit MCP server is an experimental feature and may change without
   notice.
@@ -189,15 +193,20 @@ Once configured, Cline will automatically detect and leverage the tools provided
 
 Once configured, your MCP-aware tool can interact with the Genkit MCP Server. Here are some of the available operations:
 
+:::caution
+Several tools take a `language` argument and **default to `js` when it is omitted**. `get_usage_guide` accepts `js` or `go`. `list_genkit_docs` and `search_genkit_docs` accept `js`, `go`, or `python`. Always pass it explicitly, or you will get JavaScript answers for a project in another language.
+:::
+
 ### Get Genkit usage guide
 
 You can use the `get_usage_guide` tool to fetch a usage guide for the Genkit AI framework. You can specify a language for the guide. The usage guide includes best practices and recommended project structure and plugins to use. This tool is intended to be used by AI assistants to understand building Genkit apps.
 
 **Example:**
-To get the usage guide for the JS SDK:
+To get the usage guide for the JS SDK, or for the Go SDK:
 
 ```
 @genkit:get_usage_guide { "language": "js" }
+@genkit:get_usage_guide { "language": "go" }
 ```
 
 ### Access Genkit documentation
@@ -209,17 +218,19 @@ You can use the following tools to access the Genkit documentation:
 - `read_genkit_docs`: Reads the content of specific documentation files.
 
 **Example:**
-To list the documentation (filepaths) for the JS SDK:
+To list the documentation (filepaths) for the JS SDK, or for the Go SDK:
 
 ```
 @genkit:list_genkit_docs { "language": "js" }
+@genkit:list_genkit_docs { "language": "go" }
 ```
 
 **Example:**
-To read the documentation for JS flows:
+To read the documentation for flows. The `filePaths` come from `list_genkit_docs` or `search_genkit_docs` and already carry the language prefix, so `read_genkit_docs` takes no `language`:
 
 ```
 @genkit:read_genkit_docs { "filePaths": ["js/flows.md"] }
+@genkit:read_genkit_docs { "filePaths": ["go/flows.md"] }
 ```
 
 **Example:**
@@ -228,6 +239,7 @@ keywords). This tool returns file paths, titles, and descriptions for matching d
 
 ```
 @genkit:search_genkit_docs { "query": "stream flow", "language": "js" }
+@genkit:search_genkit_docs { "query": "stream flow", "language": "go" }
 ```
 
 ### Runtime management
@@ -239,10 +251,11 @@ You can use the following tools to manage the application runtime:
 - `restart_runtime`: Restarts the runtime process.
 
 **Example:**
-To start the runtime for a Node.js project:
+To start the runtime for a Node.js project, or for a Go project:
 
 ```
 @genkit:start_runtime { "command": "npm", "args":["run", "dev"] }
+@genkit:start_runtime { "command": "go", "args":["run", "."] }
 ```
 
 ### List Genkit flows

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -668,7 +668,7 @@ Both `Request` fields above are the same `*ai.ModelRequest`:
 | `Docs`       | `[]*ai.Document`        |
 
 :::note
-`ai.ModelRequest` carries no model name. In `WrapGenerate`, read `params.Options.Model`. In `WrapModel`, the name is not on `params` at all: capture it in `WrapGenerate` and close over it, as the [caching example](#caching-middleware) does.
+`ai.ModelRequest` carries no model name. In `WrapGenerate`, read `params.Options.Model`. In `WrapModel`, the name is not on `params` at all: if needed, capture it in `WrapGenerate` and close over it.
 :::
 
 **Mutating params.** A hook may edit `params` in place, or build a different value and hand that to `next`; the engine reads whatever it is given. Three rules follow from how the loop owns these values:
@@ -801,123 +801,13 @@ func (Counter) New(ctx context.Context) (*ai.Hooks, error) {
 
 The built-in `Filesystem` middleware uses this pattern: `New` allocates a per-call file-state cache and a path-lock map, then the read, write, and edit tool implementations close over both.
 
-State that must outlive one call goes on the middleware value instead, and the value is shared, so guard it. The caching and budget middleware below both do this.
+### Illustrative example: Guardrails middleware
 
-### Caching middleware
-
-Genkit ships no cache middleware. `WrapModel` is the seam for one: it sees every model call, and it is the layer at which a repeat question can be answered without paying for it.
+The following example demonstrates how to build an illustrative custom middleware that performs pre- and post-generation policy checks. Using `WrapModel` and `WrapGenerate`, the middleware can evaluate inputs before an expensive model invocation runs, and inspect outputs before returning them to the caller:
 
 ```go
-type cacheEntry struct {
-    body    []byte
-    expires time.Time
-}
-
-// Cache serves repeat model calls from memory. Share one value across calls:
-// New runs once per Generate call, so a cache in a closure would never hit.
-type Cache struct {
-    TTL time.Duration
-
-    mu      sync.RWMutex
-    entries map[string]cacheEntry
-}
-
-func (*Cache) Name() string { return "mine/cache" }
-
-func (c *Cache) New(context.Context) (*ai.Hooks, error) {
-    // ModelRequest carries no model name, so read it from the generate hook.
-    var model string
-    return &ai.Hooks{
-        WrapGenerate: func(ctx context.Context, p *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
-            model = p.Options.Model
-            return next(ctx, p)
-        },
-        WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
-            // A hit produces no chunks, so decline to serve streaming calls.
-            if p.Callback != nil {
-                return next(ctx, p)
-            }
-            key, err := cacheKey(model, p.Request)
-            if err != nil {
-                return next(ctx, p)
-            }
-            if resp, ok := c.load(key); ok {
-                return resp, nil
-            }
-            resp, err := next(ctx, p)
-            if err != nil {
-                return nil, err
-            }
-            c.save(key, resp)
-            return resp, nil
-        },
-    }, nil
-}
-
-// cacheKey hashes everything that can change the answer. Leaving out Config or
-// Tools would serve a stale answer after either one changes.
-func cacheKey(model string, req *ai.ModelRequest) (string, error) {
-    tools := slices.Clone(req.Tools)
-    slices.SortFunc(tools, func(a, b *ai.ToolDefinition) int { return strings.Compare(a.Name, b.Name) })
-    body, err := json.Marshal(struct {
-        Model      string                `json:"model"`
-        Messages   []*ai.Message         `json:"messages"`
-        Config     any                   `json:"config"`
-        Output     *ai.ModelOutputConfig `json:"output"`
-        ToolChoice ai.ToolChoice         `json:"toolChoice"`
-        Tools      []*ai.ToolDefinition  `json:"tools"`
-        Docs       []*ai.Document        `json:"docs"`
-    }{model, req.Messages, req.Config, req.Output, req.ToolChoice, tools, req.Docs})
-    if err != nil {
-        return "", err
-    }
-    sum := sha256.Sum256(body)
-    return hex.EncodeToString(sum[:]), nil
-}
-
-func (c *Cache) load(key string) (*ai.ModelResponse, bool) {
-    c.mu.RLock()
-    e, ok := c.entries[key]
-    c.mu.RUnlock()
-    if !ok || time.Now().After(e.expires) {
-        return nil, false
-    }
-    var resp ai.ModelResponse
-    if err := json.Unmarshal(e.body, &resp); err != nil {
-        return nil, false
-    }
-    return &resp, true
-}
-
-func (c *Cache) save(key string, resp *ai.ModelResponse) {
-    body, err := json.Marshal(resp)
-    if err != nil {
-        return
-    }
-    c.mu.Lock()
-    defer c.mu.Unlock()
-    if c.entries == nil {
-        c.entries = map[string]cacheEntry{}
-    }
-    c.entries[key] = cacheEntry{body: body, expires: time.Now().Add(c.TTL)}
-}
-```
-
-Storing the marshalled response rather than the pointer costs one round trip but keeps the entry immune to a caller mutating it, and it is the same code you need to move the map to Redis.
-
-Three traps are worth stating plainly:
-
-- **The key must cover the tools and the config.** Drop either and a config change silently serves the old answer. Sort the tool definitions first, since their order is not stable.
-- **The key must cover the model.** `ModelParams` does not carry the model name, so a cache that keys only on `p.Request` will serve one model's answer for another. Capturing `p.Options.Model` in `WrapGenerate`, as above, is the way to get it.
-- **A hit replays nothing.** Streaming callers expect chunks, and a cached response has none. Either decline to serve streaming calls, as above, or replay the cached content through `p.Callback` before returning.
-
-### Guardrails
-
-`WrapModel` and `WrapGenerate` are the two places to put a policy check: one before the expensive model runs, one after it answers. Screening input with a cheap model is the standard way to cap abuse cost, because the expensive call never happens.
-
-```go
-// Guardrail screens the request before the expensive model runs, and checks the
-// answer before the caller sees it. Both hooks use a cheap classifier model.
+// Guardrail screens the request before the model runs, and checks the
+// response before the caller sees it. Both hooks use a classifier model.
 type Guardrail struct {
     Classifier string `json:"classifier,omitempty"`
     g          *genkit.Genkit
@@ -939,7 +829,7 @@ func (gr Guardrail) classify(ctx context.Context, instruction, text string) (str
 
 func (gr Guardrail) New(context.Context) (*ai.Hooks, error) {
     return &ai.Hooks{
-        // Input guardrail: screen before spending on the expensive model.
+        // Input guardrail: screen before running the primary model.
         WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
             var sb strings.Builder
             for _, m := range p.Request.Messages {
@@ -953,14 +843,14 @@ func (gr Guardrail) New(context.Context) (*ai.Hooks, error) {
                 return nil, err
             }
             if verdict != "ALLOW" {
-                // Returning without calling next: the expensive model never runs.
+                // Returning without calling next: the primary model never runs.
                 return nil, status.Errorf(status.ErrFailedPrecondition,
                     "input guardrail tripped: %s", verdict)
             }
             return next(ctx, p)
         },
 
-        // Output guardrail: check the answer before the caller acts on it.
+        // Output guardrail: check the response before returning to the caller.
         WrapGenerate: func(ctx context.Context, p *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
             resp, err := next(ctx, p)
             if err != nil || resp.Text() == "" {
@@ -980,74 +870,9 @@ func (gr Guardrail) New(context.Context) (*ai.Hooks, error) {
 }
 ```
 
-The output hook can also replace the response instead of failing, since `WrapGenerate` returns the `*ai.ModelResponse` the caller receives. Failing is the safer default: a substituted answer is easy to mistake for the model's own.
+The output hook can also modify or replace the response if desired, as `WrapGenerate` returns the `*ai.ModelResponse` received by the caller.
 
-`WrapTool` is the third seam. Refusing a dangerous tool call there, as the [short-circuiting example](#what-each-hook-receives) shows, lets the model read the refusal and try something else on the next turn, rather than ending the run.
-
-### Budgets and limits
-
-Genkit ships no budget primitive. `ai.WithMaxTurns` caps loop iterations (default 5, then `ai.ErrMaxTurnsExceeded`) and `MaxOutputTokens` caps a single response, so a long-context loop can stay inside both and still burn unbounded tokens. `WrapModel` sees every model call and `ai.ModelResponse.Usage` carries the counts, so a real budget is a short middleware:
-
-```go
-// Budget caps the tokens one Generate call may spend across all of its model
-// calls, and how many model calls may be in flight at once.
-type Budget struct {
-    MaxTokens int `json:"maxTokens,omitempty"`
-    sem       chan struct{}
-}
-
-func NewBudget(maxTokens, maxInFlight int) Budget {
-    var sem chan struct{}
-    if maxInFlight > 0 {
-        sem = make(chan struct{}, maxInFlight)
-    }
-    return Budget{MaxTokens: maxTokens, sem: sem}
-}
-
-func (Budget) Name() string { return "mine/budget" }
-
-func (b Budget) New(context.Context) (*ai.Hooks, error) {
-    var (
-        mu   sync.Mutex
-        used int
-    )
-    return &ai.Hooks{
-        WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
-            mu.Lock()
-            spent := used
-            mu.Unlock()
-            if b.MaxTokens > 0 && spent >= b.MaxTokens {
-                return nil, status.Errorf(status.ErrResourceExhausted,
-                    "token budget exhausted: %d/%d", spent, b.MaxTokens)
-            }
-
-            if b.sem != nil {
-                select {
-                case b.sem <- struct{}{}:
-                    defer func() { <-b.sem }()
-                case <-ctx.Done():
-                    return nil, ctx.Err()
-                }
-            }
-
-            resp, err := next(ctx, p)
-            if err != nil {
-                return nil, err
-            }
-            if u := resp.Usage; u != nil {
-                mu.Lock()
-                used += u.InputTokens + u.OutputTokens
-                mu.Unlock()
-            }
-            return resp, nil
-        },
-    }, nil
-}
-```
-
-Note where each piece of state lives. `used` is a closure variable, so it bounds one `Generate` call, which is the useful scope for a per-request cap. `sem` is a field on the middleware value, so one `Budget` shared across handlers caps the whole process. Swap them around and you get the other behavior. `ai.GenerationUsage` also reports `TotalTokens` and `CachedContentTokens` if you want to price cache hits differently.
-
-`ResourceExhausted` is the right status here: it tells the caller to back off rather than retry immediately. See [Error types](/docs/error-types) for how that reaches your HTTP layer.
+Similarly, `WrapTool` can intercept tool calls, allowing you to validate or reject arguments before tool execution occurs.
 
 ### Plugin-provided middleware and plugin-level state
 

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -253,6 +253,8 @@ g := genkit.Init(ctx, genkit.WithPlugins(
 ))
 ```
 
+The snippets that follow also draw on `log`, `net/http`, `os`, `time`, `github.com/firebase/genkit/go/ai`, and `github.com/firebase/genkit/go/core/status`.
+
 For pure Go programs that just attach middleware to a `genkit.Generate()` call, plugin registration is optional. Passing a middleware value directly to `ai.WithUse` invokes its `New` method on the local fast path without consulting the registry.
 
 ## Attaching middleware
@@ -320,6 +322,12 @@ The `plugins/middleware` package provides several useful middleware options out 
 
 Automatically retries failed model API calls on transient error codes (such as `RESOURCE_EXHAUSTED` and `UNAVAILABLE`) using exponential backoff with jitter. Only the model API call is retried; the surrounding tool loop is not replayed.
 
+Genkit does not retry on its own. A bare `genkit.Generate` makes exactly one attempt per model call, and `Retry` is entirely opt-in.
+
+:::caution
+Your provider plugin may retry underneath the middleware, and the two counts multiply rather than add. With the AWS Bedrock plugin's default of 3 SDK retries, `&middleware.Retry{MaxRetries: 3}` permits up to 16 provider calls. Set the SDK's retry count to 0 when you use the middleware, or drop the middleware and rely on the SDK. See [`MaxRetries`](/docs/integrations/aws-bedrock) for Bedrock and [`option.WithMaxRetries`](/docs/integrations/anthropic) for Anthropic.
+:::
+
 ```go
 resp, err := genkit.Generate(ctx, g,
     ai.WithModelName("googleai/gemini-flash-latest"),
@@ -356,6 +364,29 @@ A classified error is retried only when its status is on the list. An **unclassi
 
 - A cancelled context classifies as `CANCELLED`, which is not on the default list, so cancelling stops the retries. A `context.DeadlineExceeded` classifies as `DEADLINE_EXCEEDED`, which is on the list, so it is retried.
 - Wrapping an error with `%v` instead of `%w` destroys its classification. That silently converts a non-retryable `INVALID_ARGUMENT` into an always-retried unclassified error.
+
+**Deadlines and cancellation.** Genkit sets no default request timeout. The deadline on the context you hand `genkit.Generate` is the only bound, so give it one:
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+    defer cancel()
+
+    resp, err := genkit.Generate(ctx, g,
+        ai.WithPrompt("Summarize the release notes."),
+        ai.WithUse(&middleware.Retry{MaxRetries: 3}),
+    )
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    w.Write([]byte(resp.Text()))
+}
+```
+
+That one deadline covers every retry attempt; it does not restart per attempt, and the backoff waits come out of the same budget. `&middleware.Retry{MaxRetries: 3, InitialDelayMs: 1000, BackoffFactor: 2}` spends 1s, then 2s, then 4s sleeping alone, before counting any time in the model. Size the timeout for the whole cascade, not for one call.
+
+Cancelling the context stops the retries: a cancelled context classifies as `CANCELLED`, which is not on the retry list. Because `r.Context()` is cancelled when the HTTP client disconnects, an abandoned request stops burning attempts on its own.
 
 ### 2. Fallback middleware (`Fallback`)
 
@@ -399,6 +430,19 @@ The [retry-fallback sample](https://github.com/genkit-ai/genkit/tree/main/go/sam
 Restricts tool execution to an allow list. Tools not in the list trigger a tool interrupt that you can resolve by prompting the user and then resuming with an explicit approval flag.
 
 ```go
+type WriteFileInput struct {
+    Path    string `json:"path"`
+    Content string `json:"content"`
+}
+
+writeFileTool := genkit.DefineTool(g, "write_file", "Write a text file.",
+    func(ctx *ai.ToolContext, in WriteFileInput) (string, error) {
+        if err := os.WriteFile(in.Path, []byte(in.Content), 0o600); err != nil {
+            return "", err
+        }
+        return "wrote " + in.Path, nil
+    })
+
 // 1. Initial attempt: any tool not in AllowedTools interrupts the call.
 resp, err := genkit.Generate(ctx, g,
     ai.WithPrompt("write a file"),
@@ -412,34 +456,50 @@ if err != nil {
 }
 
 if resp.FinishReason == ai.FinishReasonInterrupted {
-    interrupt := resp.Interrupts()[0]
-
-    // 2. Ask the user for approval, then re-create the tool request with the approval flag.
-    approved, err := writeFileTool.RestartWith(interrupt,
-        ai.WithResumedMetadata[WriteFileInput](map[string]any{"toolApproved": true}),
-    )
-    if err != nil {
-        log.Fatal(err)
+    // 2. One turn can hold several interrupts. Approve each one you accept.
+    var restarts []*ai.Part
+    for _, interrupt := range resp.Interrupts() {
+        // Show interrupt.ToolRequest to the user before approving.
+        approved, err := writeFileTool.RestartWith(interrupt,
+            ai.WithResumedMetadata[WriteFileInput](map[string]any{"toolApproved": true}),
+        )
+        if err != nil {
+            log.Fatal(err)
+        }
+        restarts = append(restarts, approved)
     }
 
-    // 3. Resume execution.
+    // 3. Resume, with the same middleware config as the first call.
     resumed, err := genkit.Generate(ctx, g,
         ai.WithMessages(resp.History()...),
         ai.WithTools(writeFileTool),
-        ai.WithToolRestarts(approved),
-        ai.WithUse(&middleware.ToolApproval{}),
+        ai.WithToolRestarts(restarts...),
+        ai.WithUse(&middleware.ToolApproval{AllowedTools: []string{}}),
     )
     _ = resumed
 }
 ```
 
-A bare resume without the `toolApproved` flag is **not** treated as approval, so unrelated resume flows can't bypass approval gating.
+`RestartWith` is a method on the typed `*ai.ToolAction[In, Out]` that `genkit.DefineTool` returns, so it needs the tool's input type at compile time. When the interrupted tool is not known statically, resolve it by name and use the type-erased `Restart`:
+
+```go
+tool := genkit.LookupTool(g, interrupt.ToolRequest.Name)
+approved := tool.Restart(interrupt, &ai.RestartOptions{
+    ResumedMetadata: map[string]any{"toolApproved": true},
+})
+```
+
+A bare resume without the `toolApproved` flag is **not** treated as approval, so unrelated resume flows can't bypass approval gating. Approval travels entirely through that restart metadata, not through the allow list, which is why the resume call above passes the same config as the first one.
 
 A blocked call is still visible in traces: when a `WrapTool` hook resolves a call without running the tool, Genkit emits the tool span the tool itself would have produced.
 
 **Configuration options:**
 
-- `AllowedTools` (optional): The list of tool names pre-approved to run without interruption. Tools not in this list trigger an interrupt. An empty list interrupts every tool.
+- `AllowedTools` (defaults to gating every tool): The tool names pre-approved to run without interruption. The gate is a membership test, so a nil slice and an empty slice behave identically: every tool interrupts. There is no wildcard. To let a tool run unconditionally, list its name.
+
+:::caution
+The approval flag is the literal key `"toolApproved"` in the resumed-metadata namespace. Avoid that key in your own `ai.ResumedValue` reads, or your tool and the middleware will read each other's flag.
+:::
 
 ### 4. Skills middleware (`Skills`)
 
@@ -466,7 +526,7 @@ Loading a skill costs a turn of the tool loop, so raise `ai.WithMaxTurns` above 
 
 ### 5. Filesystem middleware (`Filesystem`)
 
-Grants the model access to a single root directory by injecting file manipulation tools. Two are always registered, `list_files` and `read_file`; `write_file` and `edit_file` join them only when `AllowWriteAccess` is true. Path safety is enforced by `os.Root` (Go 1.25+), which rejects any path that resolves outside the root, including via `..`, absolute paths, or symbolic links.
+Grants the model access to a single root directory by injecting file manipulation tools. Two are always registered, `list_files` and `read_file`; `write_file` and `edit_file` join them only when `AllowWriteAccess` is true. Path safety is enforced by `os.Root`, which rejects any path that resolves outside the root, including via `..`, absolute paths, or symbolic links.
 
 ```go
 resp, err := genkit.Generate(ctx, g,
@@ -487,6 +547,25 @@ resp, err := genkit.Generate(ctx, g,
 `read_file` does not return the file in its tool result. It answers with a short summary and injects the contents as a user message on the next turn, which is why the middleware needs a `WrapGenerate` hook as well as tools. `edit_file` refuses to touch a file that was not read earlier in the same call, and `write_file` refuses to overwrite an existing one that was not read; both refuse again if the file changed on disk since that read. Creating a new file with `write_file` needs no prior read.
 
 The [filesystem sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-middleware/filesystem) ships a small mock project and one flow per mode, read-only and write-enabled.
+
+### The experimental middleware plugin
+
+A second, in-preview middleware plugin lives at `github.com/firebase/genkit/go/plugins/middleware/exp`. It provides `Agents` for sub-agent delegation and `Artifacts` for session artifact access, and is documented in [Multi-agent delegation](/docs/agents/multi-agent). It registers under the provider name `genkit-middleware-exp`, so its names do not collide with the stable plugin's and you can register both:
+
+```go
+import (
+    "github.com/firebase/genkit/go/plugins/middleware"
+    middlewarex "github.com/firebase/genkit/go/plugins/middleware/exp"
+)
+
+g := genkit.Init(ctx, genkit.WithPlugins(
+    &googlegenai.GoogleAI{},
+    &middleware.Middleware{},
+    &middlewarex.Middleware{},
+))
+```
+
+A `.prompt` reference such as `genkit-middleware/retry` resolves to the stable plugin; the experimental ones are named `genkit-middleware-exp/agents` and `genkit-middleware-exp/artifacts`. Being in preview, they may change in any minor release.
 
 ## Building your own custom middleware
 
@@ -519,6 +598,26 @@ type Hooks struct {
 
 Implement only the hooks your middleware needs. A nil hook field is treated as a pass-through.
 
+The middleware in this section draw on these imports:
+
+```go
+import (
+    "context"
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    "slices"
+    "strings"
+    "sync"
+    "time"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/core/logger"
+    "github.com/firebase/genkit/go/core/status"
+    "github.com/firebase/genkit/go/genkit"
+)
+```
+
 ### When each hook fires
 
 A `Generate` call runs a tool loop: the model produces output, any tool calls execute, results feed back into a new model call, and so on until the model stops. The hooks attach at three different layers of this loop:
@@ -530,6 +629,80 @@ A `Generate` call runs a tool loop: the model produces output, any tool calls ex
 | `WrapTool`     | Once per tool execution. May run **concurrently** for parallel tool calls in the same iteration. | Logic about a single tool execution: approval, sandboxing, logging.                                      |
 
 `WrapGenerate` and `WrapModel` are not called concurrently within a single `Generate` call. `WrapTool` may be, since multiple tools can execute in parallel.
+
+### What each hook receives
+
+`ai.GenerateParams`, for `WrapGenerate`:
+
+| Field          | Type                     | What it is                                                                                                                           |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `Request`      | `*ai.ModelRequest`       | The model request for this turn, with the messages accumulated so far. Replace it or edit it to change what the model receives.       |
+| `Options`      | `*ai.GenerateActionOptions` | A per-turn copy of the options `Generate` was called with, carrying what `Request` does not: `Model`, `MaxTurns`, resume directives. |
+| `Iteration`    | `int`                    | The tool-loop iteration, 0-indexed.                                                                                                   |
+| `MessageIndex` | `int`                    | The index of the next message in the streamed response sequence.                                                                      |
+| `Callback`     | `ai.ModelStreamCallback` | The streaming callback, or nil when not streaming.                                                                                    |
+
+`ai.ModelParams`, for `WrapModel`:
+
+| Field      | Type                     | What it is                              |
+| ---------- | ------------------------ | --------------------------------------- |
+| `Request`  | `*ai.ModelRequest`       | The model request about to be sent.     |
+| `Callback` | `ai.ModelStreamCallback` | The streaming callback, or nil.         |
+
+`ai.ToolParams`, for `WrapTool`:
+
+| Field     | Type              | What it is                                                                                                          |
+| --------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `Request` | `*ai.ToolRequest` | `Name` the tool name, `Input` the decoded arguments as `any`, `Ref` the model's call id, `Partial` for stream chunks. |
+| `Tool`    | `ai.Tool`         | The resolved tool: `Tool.Name()`, `Tool.Definition()`.                                                               |
+
+Both `Request` fields above are the same `*ai.ModelRequest`:
+
+| Field        | Type                    |
+| ------------ | ----------------------- |
+| `Messages`   | `[]*ai.Message`         |
+| `Config`     | `any`                   |
+| `Tools`      | `[]*ai.ToolDefinition`  |
+| `ToolChoice` | `ai.ToolChoice`         |
+| `Output`     | `*ai.ModelOutputConfig` |
+| `Docs`       | `[]*ai.Document`        |
+
+:::note
+`ai.ModelRequest` carries no model name. In `WrapGenerate`, read `params.Options.Model`. In `WrapModel`, the name is not on `params` at all: capture it in `WrapGenerate` and close over it, as the [caching example](#caching-middleware) does.
+:::
+
+**Mutating params.** A hook may edit `params` in place, or build a different value and hand that to `next`; the engine reads whatever it is given. Three rules follow from how the loop owns these values:
+
+- `GenerateParams.Request` and `ModelParams.Request` are fresh per turn, so an in-place edit stays with that turn. The exception is a `*ai.Message` shared with the next turn: copy the message with `Clone()` before editing its text.
+- `GenerateParams.Options` is a shallow per-turn copy. Writes to it reach nothing, so treat it as read-only.
+- For redaction that must not reach the stored history, prefer `WrapModel`, and shallow-copy the `ModelRequest` plus only the messages and parts you change.
+
+Middleware that emits its own chunks through `Callback` must set `ModelResponseChunk.Role` and `Index` explicitly, and advance `GenerateParams.MessageIndex` so downstream middleware and the model see the shifted value.
+
+**Short-circuiting.** A hook can return without calling `next`. `WrapTool` is the useful case: return an `*ai.MultipartToolResponse` and the tool never runs, but the model still receives a result it can react to on the next turn.
+
+```go
+type ToolRefusal struct {
+    Denied []string `json:"denied,omitempty"`
+}
+
+func (ToolRefusal) Name() string { return "mine/toolRefusal" }
+
+func (tr ToolRefusal) New(context.Context) (*ai.Hooks, error) {
+    return &ai.Hooks{
+        WrapTool: func(ctx context.Context, p *ai.ToolParams, next ai.ToolNext) (*ai.MultipartToolResponse, error) {
+            if slices.Contains(tr.Denied, p.Request.Name) {
+                return &ai.MultipartToolResponse{
+                    Output: map[string]any{"error": "denied by policy: " + p.Request.Name},
+                }, nil
+            }
+            return next(ctx, p)
+        },
+    }, nil
+}
+```
+
+This is the shape `ToolApproval` uses. A hook that skips `next` still produces the tool span, so the refusal is visible in traces.
 
 ### Logging from a hook
 
@@ -627,6 +800,254 @@ func (Counter) New(ctx context.Context) (*ai.Hooks, error) {
 ```
 
 The built-in `Filesystem` middleware uses this pattern: `New` allocates a per-call file-state cache and a path-lock map, then the read, write, and edit tool implementations close over both.
+
+State that must outlive one call goes on the middleware value instead, and the value is shared, so guard it. The caching and budget middleware below both do this.
+
+### Caching middleware
+
+Genkit ships no cache middleware. `WrapModel` is the seam for one: it sees every model call, and it is the layer at which a repeat question can be answered without paying for it.
+
+```go
+type cacheEntry struct {
+    body    []byte
+    expires time.Time
+}
+
+// Cache serves repeat model calls from memory. Share one value across calls:
+// New runs once per Generate call, so a cache in a closure would never hit.
+type Cache struct {
+    TTL time.Duration
+
+    mu      sync.RWMutex
+    entries map[string]cacheEntry
+}
+
+func (*Cache) Name() string { return "mine/cache" }
+
+func (c *Cache) New(context.Context) (*ai.Hooks, error) {
+    // ModelRequest carries no model name, so read it from the generate hook.
+    var model string
+    return &ai.Hooks{
+        WrapGenerate: func(ctx context.Context, p *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
+            model = p.Options.Model
+            return next(ctx, p)
+        },
+        WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+            // A hit produces no chunks, so decline to serve streaming calls.
+            if p.Callback != nil {
+                return next(ctx, p)
+            }
+            key, err := cacheKey(model, p.Request)
+            if err != nil {
+                return next(ctx, p)
+            }
+            if resp, ok := c.load(key); ok {
+                return resp, nil
+            }
+            resp, err := next(ctx, p)
+            if err != nil {
+                return nil, err
+            }
+            c.save(key, resp)
+            return resp, nil
+        },
+    }, nil
+}
+
+// cacheKey hashes everything that can change the answer. Leaving out Config or
+// Tools would serve a stale answer after either one changes.
+func cacheKey(model string, req *ai.ModelRequest) (string, error) {
+    tools := slices.Clone(req.Tools)
+    slices.SortFunc(tools, func(a, b *ai.ToolDefinition) int { return strings.Compare(a.Name, b.Name) })
+    body, err := json.Marshal(struct {
+        Model      string                `json:"model"`
+        Messages   []*ai.Message         `json:"messages"`
+        Config     any                   `json:"config"`
+        Output     *ai.ModelOutputConfig `json:"output"`
+        ToolChoice ai.ToolChoice         `json:"toolChoice"`
+        Tools      []*ai.ToolDefinition  `json:"tools"`
+        Docs       []*ai.Document        `json:"docs"`
+    }{model, req.Messages, req.Config, req.Output, req.ToolChoice, tools, req.Docs})
+    if err != nil {
+        return "", err
+    }
+    sum := sha256.Sum256(body)
+    return hex.EncodeToString(sum[:]), nil
+}
+
+func (c *Cache) load(key string) (*ai.ModelResponse, bool) {
+    c.mu.RLock()
+    e, ok := c.entries[key]
+    c.mu.RUnlock()
+    if !ok || time.Now().After(e.expires) {
+        return nil, false
+    }
+    var resp ai.ModelResponse
+    if err := json.Unmarshal(e.body, &resp); err != nil {
+        return nil, false
+    }
+    return &resp, true
+}
+
+func (c *Cache) save(key string, resp *ai.ModelResponse) {
+    body, err := json.Marshal(resp)
+    if err != nil {
+        return
+    }
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if c.entries == nil {
+        c.entries = map[string]cacheEntry{}
+    }
+    c.entries[key] = cacheEntry{body: body, expires: time.Now().Add(c.TTL)}
+}
+```
+
+Storing the marshalled response rather than the pointer costs one round trip but keeps the entry immune to a caller mutating it, and it is the same code you need to move the map to Redis.
+
+Three traps are worth stating plainly:
+
+- **The key must cover the tools and the config.** Drop either and a config change silently serves the old answer. Sort the tool definitions first, since their order is not stable.
+- **The key must cover the model.** `ModelParams` does not carry the model name, so a cache that keys only on `p.Request` will serve one model's answer for another. Capturing `p.Options.Model` in `WrapGenerate`, as above, is the way to get it.
+- **A hit replays nothing.** Streaming callers expect chunks, and a cached response has none. Either decline to serve streaming calls, as above, or replay the cached content through `p.Callback` before returning.
+
+### Guardrails
+
+`WrapModel` and `WrapGenerate` are the two places to put a policy check: one before the expensive model runs, one after it answers. Screening input with a cheap model is the standard way to cap abuse cost, because the expensive call never happens.
+
+```go
+// Guardrail screens the request before the expensive model runs, and checks the
+// answer before the caller sees it. Both hooks use a cheap classifier model.
+type Guardrail struct {
+    Classifier string `json:"classifier,omitempty"`
+    g          *genkit.Genkit
+}
+
+func (Guardrail) Name() string { return "mine/guardrail" }
+
+func (gr Guardrail) classify(ctx context.Context, instruction, text string) (string, error) {
+    verdict, err := genkit.GenerateText(ctx, gr.g,
+        ai.WithModelName(gr.Classifier),
+        ai.WithSystem("%s Answer with one word: ALLOW or BLOCK.", instruction),
+        ai.WithPrompt("%s", text),
+    )
+    if err != nil {
+        return "", err
+    }
+    return strings.TrimSpace(verdict), nil
+}
+
+func (gr Guardrail) New(context.Context) (*ai.Hooks, error) {
+    return &ai.Hooks{
+        // Input guardrail: screen before spending on the expensive model.
+        WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+            var sb strings.Builder
+            for _, m := range p.Request.Messages {
+                if m.Role == ai.RoleUser {
+                    sb.WriteString(m.Text())
+                    sb.WriteString("\n")
+                }
+            }
+            verdict, err := gr.classify(ctx, "Decide whether this request is abusive.", sb.String())
+            if err != nil {
+                return nil, err
+            }
+            if verdict != "ALLOW" {
+                // Returning without calling next: the expensive model never runs.
+                return nil, status.Errorf(status.ErrFailedPrecondition,
+                    "input guardrail tripped: %s", verdict)
+            }
+            return next(ctx, p)
+        },
+
+        // Output guardrail: check the answer before the caller acts on it.
+        WrapGenerate: func(ctx context.Context, p *ai.GenerateParams, next ai.GenerateNext) (*ai.ModelResponse, error) {
+            resp, err := next(ctx, p)
+            if err != nil || resp.Text() == "" {
+                return resp, err
+            }
+            verdict, err := gr.classify(ctx, "Decide whether this answer leaks private data.", resp.Text())
+            if err != nil {
+                return nil, err
+            }
+            if verdict != "ALLOW" {
+                return nil, status.Errorf(status.ErrFailedPrecondition,
+                    "output guardrail tripped: %s", verdict)
+            }
+            return resp, nil
+        },
+    }, nil
+}
+```
+
+The output hook can also replace the response instead of failing, since `WrapGenerate` returns the `*ai.ModelResponse` the caller receives. Failing is the safer default: a substituted answer is easy to mistake for the model's own.
+
+`WrapTool` is the third seam. Refusing a dangerous tool call there, as the [short-circuiting example](#what-each-hook-receives) shows, lets the model read the refusal and try something else on the next turn, rather than ending the run.
+
+### Budgets and limits
+
+Genkit ships no budget primitive. `ai.WithMaxTurns` caps loop iterations (default 5, then `ai.ErrMaxTurnsExceeded`) and `MaxOutputTokens` caps a single response, so a long-context loop can stay inside both and still burn unbounded tokens. `WrapModel` sees every model call and `ai.ModelResponse.Usage` carries the counts, so a real budget is a short middleware:
+
+```go
+// Budget caps the tokens one Generate call may spend across all of its model
+// calls, and how many model calls may be in flight at once.
+type Budget struct {
+    MaxTokens int `json:"maxTokens,omitempty"`
+    sem       chan struct{}
+}
+
+func NewBudget(maxTokens, maxInFlight int) Budget {
+    var sem chan struct{}
+    if maxInFlight > 0 {
+        sem = make(chan struct{}, maxInFlight)
+    }
+    return Budget{MaxTokens: maxTokens, sem: sem}
+}
+
+func (Budget) Name() string { return "mine/budget" }
+
+func (b Budget) New(context.Context) (*ai.Hooks, error) {
+    var (
+        mu   sync.Mutex
+        used int
+    )
+    return &ai.Hooks{
+        WrapModel: func(ctx context.Context, p *ai.ModelParams, next ai.ModelNext) (*ai.ModelResponse, error) {
+            mu.Lock()
+            spent := used
+            mu.Unlock()
+            if b.MaxTokens > 0 && spent >= b.MaxTokens {
+                return nil, status.Errorf(status.ErrResourceExhausted,
+                    "token budget exhausted: %d/%d", spent, b.MaxTokens)
+            }
+
+            if b.sem != nil {
+                select {
+                case b.sem <- struct{}{}:
+                    defer func() { <-b.sem }()
+                case <-ctx.Done():
+                    return nil, ctx.Err()
+                }
+            }
+
+            resp, err := next(ctx, p)
+            if err != nil {
+                return nil, err
+            }
+            if u := resp.Usage; u != nil {
+                mu.Lock()
+                used += u.InputTokens + u.OutputTokens
+                mu.Unlock()
+            }
+            return resp, nil
+        },
+    }, nil
+}
+```
+
+Note where each piece of state lives. `used` is a closure variable, so it bounds one `Generate` call, which is the useful scope for a per-request cap. `sem` is a field on the middleware value, so one `Budget` shared across handlers caps the whole process. Swap them around and you get the other behavior. `ai.GenerationUsage` also reports `TotalTokens` and `CachedContentTokens` if you want to price cache hits differently.
+
+`ResourceExhausted` is the right status here: it tells the caller to back off rather than retry immediately. See [Error types](/docs/error-types) for how that reaches your HTTP layer.
 
 ### Plugin-provided middleware and plugin-level state
 

--- a/src/content/docs/docs/model-context-protocol.mdx
+++ b/src/content/docs/docs/model-context-protocol.mdx
@@ -377,7 +377,13 @@ Once you start the inspector, you can list prompts and actions and test them out
 
 <Lang lang="go">
 
-The MCP (Model Context Protocol) plugin enables integration with MCP servers and allows you to expose Genkit tools as MCP servers. You can connect to external MCP servers to use their tools and prompts, manage multiple server connections, or turn your Genkit application into an MCP server.
+The MCP (Model Context Protocol) plugin connects Genkit to MCP servers and lets you publish your own Genkit tools and resources as an MCP server. Connect to one server with `GenkitMCPClient`, to several with `MCPHost`, or expose your own application with `NewMCPServer`.
+
+The full API reference is the package documentation: [pkg.go.dev/github.com/firebase/genkit/go/plugins/mcp](https://pkg.go.dev/github.com/firebase/genkit/go/plugins/mcp).
+
+:::note
+This page is about your application talking to MCP servers. The [Genkit MCP server](/docs/mcp-server) page documents a different thing: the MCP server that the Genkit CLI runs so an IDE assistant can list and run your flows.
+:::
 
 ## Prerequisites
 
@@ -389,37 +395,67 @@ This plugin requires MCP servers to be available. For testing and development, y
 
 ## Configuration
 
-### Single Server Connection
+### Connecting to a single server
 
-To connect to a single MCP server, import the `mcp` package and create a `GenkitMCPClient`:
-
-```go
-import "github.com/firebase/genkit/go/plugins/mcp"
-```
+To connect to a single MCP server, create a `GenkitMCPClient`. This program starts `mcp-server-time` as a child process, hands its tools to a model, and shuts the child down on exit:
 
 ```go
-ctx := context.Background()
-g := genkit.Init(ctx)
+package main
 
-client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
-    Name: "mcp-server-time",
-    Stdio: &mcp.StdioConfig{
-        Command: "uvx",
-        Args: []string{"mcp-server-time"},
-    },
-})
-if err != nil {
-    log.Fatal(err)
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/mcp"
+)
+
+func main() {
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+
+	client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
+		Name: "mcp-server-time",
+		Stdio: &mcp.StdioConfig{
+			Command: "uvx",
+			Args:    []string{"mcp-server-time"},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Disconnect()
+
+	tools, err := client.GetActiveTools(ctx, g)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// ai.WithTools takes ai.ToolRef, so widen the slice first.
+	refs := make([]ai.ToolRef, 0, len(tools))
+	for _, t := range tools {
+		refs = append(refs, t)
+	}
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("googleai/gemini-flash-latest"),
+		ai.WithPrompt("What time is it in Tokyo?"),
+		ai.WithTools(refs...),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(resp.Text())
 }
 ```
+
+Later examples reuse `ctx`, `g`, and `client` from this program and the same import block, plus `fmt`, `net/http`, `os`, `os/signal`, `strings`, `syscall`, and `time` from the standard library where the snippet uses them.
 
 ### Multiple server management
 
 To manage connections to multiple MCP servers, use `MCPHost`:
-
-```go
-import "github.com/firebase/genkit/go/plugins/mcp"
-```
 
 ```go
 host, err := mcp.NewMCPHost(g, mcp.MCPHostOptions{
@@ -452,68 +488,116 @@ if err != nil {
 }
 ```
 
-### Exposing as MCP server
-
-To expose your Genkit tools as an MCP server, create an `MCPServer`:
-
-```go
-import "github.com/firebase/genkit/go/plugins/mcp"
-```
-
-```go
-// Define your tools first
-addTool := genkit.DefineTool(g, "add", "Add two numbers",
-    func(ctx *ai.ToolContext, input struct{A, B int}) (int, error) {
-        return input.A + input.B, nil
-    })
-
-// Create MCP server
-server := mcp.NewMCPServer(g, mcp.MCPServerOptions{
-    Name:    "genkit-calculator",
-    Version: "1.0.0",
-})
-```
+:::caution
+`NewMCPHost` connects to every entry in `MCPServers` synchronously, but it does not report per-server failures. A server it cannot reach is logged at error level and skipped; the call still returns a host and a nil error, so `if err != nil` never fires for a server that is down. To detect a specific failure, construct the host with no `MCPServers` and call `host.Connect(ctx, g, name, config)` yourself, which does return the connection error.
+:::
 
 ## Usage
 
-### Using Tools from MCP Servers
+### Using tools from MCP servers
 
-Once connected to an MCP server, you can retrieve and use its tools:
+`GetActiveTools` returns every tool the connected server advertises:
 
 ```go
-// Get a specific tool
-echoTool, err := client.GetTool(ctx, g, "echo")
+tools, err := client.GetActiveTools(ctx, g)
 if err != nil {
     log.Fatal(err)
 }
+```
 
-// Use the tool in your workflow
-resp, err := genkit.Generate(ctx, g,
-    ai.WithModel(myModel),
-    ai.WithPrompt("Use the echo tool to repeat this message"),
-    ai.WithTools(echoTool),
-)
+There is no single-tool getter on the client. To use one tool, select it from the returned slice. `host.GetActiveTools(ctx, g)` is the same call across every server the host is connected to.
+
+#### Tool, prompt, and resource names
+
+Every action a client registers is namespaced with the client's `Name` and an underscore: `<clientName>_<toolName>`. A client named `mcp-server-time` exposing `get_current_time` registers the tool as `mcp-server-time_get_current_time`. Prompts and resources use the same form. To attribute a tool back to its server, cut the name at the first underscore:
+
+```go
+for _, t := range tools {
+    server, _, _ := strings.Cut(t.Name(), "_")
+    fmt.Println(t.Name(), "from", server)
+}
+```
+
+:::caution
+If you leave `Name` empty, the client falls back to `unnamed`. Two unnamed clients that both expose a `search` tool collide, so always give each server a distinct `Name`.
+:::
+
+#### Tool results
+
+Unlike a Genkit-native tool, an MCP tool returns the MCP result object unchanged. The Genkit Go plugin performs no text or JSON coercion, so the tool's output is a `*mcp.CallToolResult` from `github.com/mark3labs/mcp-go/mcp`, with its `Content` array intact. A model consuming the tool sees that object. Your own code, if it runs a tool directly or inspects a tool response part, has to walk the array. `mcp.ExtractTextFromContent` pulls the text out of one content item:
+
+```go
+// mcpgo "github.com/mark3labs/mcp-go/mcp"
+result, ok := out.(*mcpgo.CallToolResult) // out is the tool's output value
+if !ok {
+    log.Fatalf("unexpected tool output type %T", out)
+}
+for _, c := range result.Content {
+    if text := mcp.ExtractTextFromContent(c); text != "" {
+        fmt.Println(text)
+    }
+}
+```
+
+:::note
+This differs from the JavaScript plugin, which namespaces with `/` and coerces MCP content into a plain Genkit value.
+:::
+
+A disabled or disconnected client returns `nil, nil` from `GetActiveTools`, so an empty list is not distinguishable from a server with no tools. Check `client.IsEnabled()` when the difference matters.
+
+### Using resources from MCP servers
+
+Resources are content a server offers by URI, which a model can pull in. `GetActiveResources` returns them as Genkit `ai.Resource` values, namespaced the same way as tools:
+
+```go
+resources, err := client.GetActiveResources(ctx)
 if err != nil {
     log.Fatal(err)
 }
+for _, r := range resources {
+    fmt.Println(r.Name())
+}
+```
+
+`host.GetActiveResources(ctx)` does the same across every connected server. Both static resources and URI templates are returned. Unlike `GetActiveTools`, these calls return an error when the client is disabled or not connected.
+
+You can define local resources with `genkit.DefineResource`, and an MCP server you run publishes them (see [Running as an MCP server](#running-as-an-mcp-server)):
+
+```go
+genkit.DefineResource(g, "handbook", &ai.ResourceOptions{
+    URI:         "file:///docs/handbook.md",
+    Description: "Company handbook",
+}, func(ctx context.Context, input *ai.ResourceInput) (*ai.ResourceOutput, error) {
+    b, err := os.ReadFile("/docs/handbook.md")
+    if err != nil {
+        return nil, err
+    }
+    return &ai.ResourceOutput{Content: []*ai.Part{ai.NewTextPart(string(b))}}, nil
+})
 ```
 
 ### Using prompts from MCP servers
 
-Retrieve and use prompts from connected MCP servers:
+`GetPrompt` fetches a prompt from a connected server, registers it on the Genkit instance under its namespaced name, and returns it as an `ai.Prompt`:
 
 ```go
-// Get a specific prompt
-simplePrompt, err := client.GetPrompt(ctx, g, "simple_prompt")
+func (c *GenkitMCPClient) GetPrompt(ctx context.Context, g *genkit.Genkit, promptName string, args map[string]string) (ai.Prompt, error)
+func (h *MCPHost) GetPrompt(ctx context.Context, g *genkit.Genkit, serverName, promptName string, args map[string]string) (ai.Prompt, error)
+```
+
+MCP prompt arguments are string-valued. Pass `nil` when the prompt takes none. The return value is an `ai.Prompt`, not prompt text, so run it with `Execute` rather than passing it to `ai.WithPrompt`:
+
+```go
+prompt, err := client.GetPrompt(ctx, g, "current_time", map[string]string{"timezone": "UTC"})
 if err != nil {
     log.Fatal(err)
 }
 
-// Use the prompt
-resp, err := genkit.Generate(ctx, g,
-    ai.WithModel(myModel),
-    ai.WithPrompt(simplePrompt),
-)
+resp, err := prompt.Execute(ctx, ai.WithModelName("googleai/gemini-flash-latest"))
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(resp.Text())
 ```
 
 ### Managing multiple servers
@@ -533,8 +617,8 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Disconnect a server completely
-err = host.Disconnect(ctx, "weather")
+// Restart one server's connection
+err = host.Reconnect(ctx, "weather")
 if err != nil {
     log.Fatal(err)
 }
@@ -550,52 +634,147 @@ prompt, err := host.GetPrompt(ctx, g, "mcp-server-time", "current_time", nil)
 if err != nil {
     log.Fatal(err)
 }
-```
 
-For individual client management (disable/enable without disconnecting), you would access the clients directly. The manager focuses on connection lifecycle management.
-
-### Running as MCP server
-
-To run your Genkit application as an MCP server:
-
-```go
-// Auto-expose all defined tools
-server := mcp.NewMCPServer(g, mcp.MCPServerOptions{
-    Name:    "genkit-calculator",
-    Version: "1.0.0",
-})
-
-
-// Start the MCP server
-log.Println("Starting MCP server...")
-if err := server.ServeStdio(); err != nil {
+// Disconnect a server completely, dropping it from the host
+err = host.Disconnect(ctx, "weather")
+if err != nil {
     log.Fatal(err)
 }
 ```
 
+`MCPHost` exposes no accessor for the clients it owns, so per-server control is limited to `Connect`, `Reconnect`, and `Disconnect`. If you need per-client control, build the clients yourself with `NewGenkitMCPClient` and keep the references. Note that `client.Disable()` closes the connection, which kills a stdio child, and `client.Reenable()` reconnects. There is no way to keep a connection open while suppressing its tools.
+
+### Lifecycle and production concerns
+
+Nothing is closed for you. Wire shutdown into your own signal handling:
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+
+client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{ /* ... */ })
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Disconnect() // closes the transport, which reaps the stdio child
+```
+
+For a host, call `host.Disconnect(ctx, name)` for each server you connected. There is no `CloseAll`, so track the names yourself. A stdio child that is never disconnected lives until your process exits.
+
+The rest of the operational picture:
+
+- **Timeouts.** Per-request calls (`GetActiveTools`, `GetActiveResources`, `GetPrompt`, and tool execution) take a context and honor it, so wrap them in `context.WithTimeout`. Connection setup does not: `NewGenkitMCPClient` takes no context and starts the transport with a background context, so a stdio child that never speaks blocks indefinitely. `StreamableHTTPConfig.Timeout` bounds individual HTTP requests; `StdioConfig` and `SSEConfig` have no timeout field.
+- **Concurrency.** Neither `MCPHost` nor `GenkitMCPClient` is safe for concurrent use. `Connect`, `Disconnect`, `Reconnect`, `Disable`, and `Reenable` mutate unguarded internal state. Do connection management at startup, or guard every host and client call with your own mutex. Concurrent reads while nothing is connecting or disconnecting are fine.
+- **Reconnection.** There is no automatic reconnect. Call `host.Reconnect(ctx, name)` or `client.Restart(ctx)` yourself.
+- **Failed handshakes.** If the MCP `initialize` exchange fails, the error is recorded on the connection rather than returned: `NewGenkitMCPClient` still gives you a client, and `GetActiveTools` then returns an empty list with no error. Call `GetActiveTools` right after construction to confirm the server really answered.
+
+### Running as an MCP server
+
+`mcp.NewMCPServer` returns a `GenkitMCPServer` that publishes every tool defined with `genkit.DefineTool` and every resource registered on the Genkit instance. It discovers them from the registry, so you do not list them anywhere:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/mcp"
+)
+
+type addInput struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+func main() {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+
+	// NewMCPServer picks up every tool already defined on g, so this value
+	// does not need to be referenced again.
+	genkit.DefineTool(g, "add", "Add two numbers",
+		func(ctx *ai.ToolContext, in addInput) (int, error) {
+			return in.A + in.B, nil
+		})
+
+	srv := mcp.NewMCPServer(g, mcp.MCPServerOptions{
+		Name:    "genkit-calculator",
+		Version: "1.0.0",
+	})
+
+	log.Println("starting MCP server on stdio")
+	if err := srv.ServeStdio(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Flows are not published. To expose a flow over MCP, wrap it in a tool defined with `genkit.DefineTool`. The `list_flows` and `run_flow` tools described on the [Genkit MCP server](/docs/mcp-server) page belong to the Genkit CLI's own server, not to yours.
+
+:::caution
+In stdio mode the MCP server owns stdout: every byte written there must be protocol framing. The standard `log` package writes to stderr, so `log.Println` is safe, but `fmt.Println`, anything writing to `os.Stdout`, and any library that prints a startup banner will corrupt the stream. Keep all diagnostics on stderr.
+:::
+
+The server speaks stdio only. `Serve(transport)` ignores its argument and calls `ServeStdio` regardless, and `Close()` is currently a no-op. `GetServer()` returns the underlying `mcp-go` server, but it is nil until `ServeStdio` has run the server's setup pass, so it is not usable as an HTTP escape hatch. `ListRegisteredTools` and `ListRegisteredResources` are empty for the same reason until the server starts.
+
 ## Transport options
 
-### Stdio Transport
+`MCPClientOptions` has three transport fields. Set exactly one.
 
-You can use either Stdio or SSE
+| Field | Use |
+| --- | --- |
+| `Stdio *StdioConfig` | Start a local server process and speak over its stdin and stdout. |
+| `StreamableHTTP *StreamableHTTPConfig` | Connect to a remote server over Streamable HTTP. This is the current HTTP transport in the MCP specification. |
+| `SSE *SSEConfig` | Connect to a remote server over HTTP with server-sent events. This is the legacy HTTP transport; prefer Streamable HTTP for new servers. |
+
+### Stdio
 
 ```go
 Stdio: &mcp.StdioConfig{
     Command: "uvx",
-    Args: []string{"mcp-server-time"},
-    Env: []string{"DEBUG=1"},
+    Args:    []string{"mcp-server-time"},
+    Env:     []string{"DEBUG=1"},
 }
 ```
 
+### Streamable HTTP
+
+`Headers` are sent on every request, which is how you reach an authenticated server:
+
 ```go
-SSE: &mcp.SSEConfig{
-    BaseURL: "http://localhost:3000/sse",
-}
+client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
+    Name: "docs-server",
+    StreamableHTTP: &mcp.StreamableHTTPConfig{
+        BaseURL: "https://mcp.example.com/mcp",
+        Headers: map[string]string{"Authorization": "Bearer " + os.Getenv("MCP_TOKEN")},
+        Timeout: 30 * time.Second,
+    },
+})
+```
+
+### SSE
+
+`SSEConfig` takes the same headers but has no `Timeout` field. Set the timeout on a custom `HTTPClient`, which is also where custom TLS or instrumentation goes:
+
+```go
+client, err := mcp.NewGenkitMCPClient(mcp.MCPClientOptions{
+    Name: "legacy-server",
+    SSE: &mcp.SSEConfig{
+        BaseURL:    "https://mcp.example.com/sse",
+        Headers:    map[string]string{"Authorization": "Bearer " + os.Getenv("MCP_TOKEN")},
+        HTTPClient: &http.Client{Timeout: 30 * time.Second},
+    },
+})
 ```
 
 ## Testing
 
-### Testing Your MCP Server
+### Testing your MCP server
 
 To test your Genkit application as an MCP server:
 
@@ -613,11 +792,12 @@ npx @modelcontextprotocol/inspector go run main.go
 
 ```go
 type MCPClientOptions struct {
-    Name     string          // Server identifier
-    Version  string          // Version number (defaults to "1.0.0")
-    Disabled bool            // Disabled flag to temporarily disable this client
-    Stdio    *StdioConfig    // Stdio transport config
-    SSE      *SSEConfig      // SSE transport config
+    Name           string                // Client name; also the namespace prefix (defaults to "unnamed")
+    Version        string                // Version number (defaults to "1.0.0")
+    Disabled       bool                  // Temporarily disable this client
+    Stdio          *StdioConfig          // Stdio transport config
+    SSE            *SSEConfig            // SSE transport config (legacy HTTP transport)
+    StreamableHTTP *StreamableHTTPConfig // Streamable HTTP transport config
 }
 ```
 
@@ -626,10 +806,37 @@ type MCPClientOptions struct {
 ```go
 type StdioConfig struct {
     Command string   // Command to run
+    Env     []string // Extra environment variables, in KEY=VALUE form
     Args    []string // Command arguments
-    Env     []string // Environment variables
 }
 ```
+
+`Env` is appended to the parent process environment (`os.Environ()`), not a replacement for it, so `PATH` and everything else is inherited and `uvx` resolves. A duplicate key overrides the inherited value.
+
+### SSEConfig
+
+```go
+type SSEConfig struct {
+    BaseURL    string            // SSE endpoint, for example https://mcp.example.com/sse
+    Headers    map[string]string // Sent on every request; use for Authorization or API keys
+    HTTPClient *http.Client      // Optional; set the timeout, TLS config, or instrumentation here
+}
+```
+
+`SSEConfig` has no `Timeout` field. Set it on `HTTPClient`.
+
+### StreamableHTTPConfig
+
+```go
+type StreamableHTTPConfig struct {
+    BaseURL    string            // Endpoint, for example https://mcp.example.com/mcp
+    Headers    map[string]string // Sent on every request; use for Authorization or API keys
+    HTTPClient *http.Client      // Currently ignored by this transport; use Timeout instead
+    Timeout    time.Duration     // Per-request HTTP timeout
+}
+```
+
+The Streamable HTTP transport applies `Headers` and `Timeout` only. `HTTPClient` is accepted but not wired up, so custom TLS or instrumentation needs the SSE transport today.
 
 ### MCPServerConfig
 

--- a/src/content/docs/docs/model-context-protocol.mdx
+++ b/src/content/docs/docs/model-context-protocol.mdx
@@ -646,7 +646,7 @@ if err != nil {
 
 ### Lifecycle and production concerns
 
-Nothing is closed for you. Wire shutdown into your own signal handling:
+Manage connection lifecycle and signal handling explicitly during application shutdown:
 
 ```go
 ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -661,13 +661,13 @@ if err != nil {
 defer client.Disconnect() // closes the transport, which reaps the stdio child
 ```
 
-For a host, call `host.Disconnect(ctx, name)` for each server you connected. There is no `CloseAll`, so track the names yourself. A stdio child that is never disconnected lives until your process exits.
+For an `MCPHost`, call `host.Disconnect(ctx, name)` for each registered server during shutdown to ensure stdio child processes and network transports are cleanly terminated.
 
 The rest of the operational picture:
 
 - **Timeouts.** Per-request calls (`GetActiveTools`, `GetActiveResources`, `GetPrompt`, and tool execution) take a context and honor it, so wrap them in `context.WithTimeout`. Connection setup does not: `NewGenkitMCPClient` takes no context and starts the transport with a background context, so a stdio child that never speaks blocks indefinitely. `StreamableHTTPConfig.Timeout` bounds individual HTTP requests; `StdioConfig` and `SSEConfig` have no timeout field.
-- **Concurrency.** Neither `MCPHost` nor `GenkitMCPClient` is safe for concurrent use. `Connect`, `Disconnect`, `Reconnect`, `Disable`, and `Reenable` mutate unguarded internal state. Do connection management at startup, or guard every host and client call with your own mutex. Concurrent reads while nothing is connecting or disconnecting are fine.
-- **Reconnection.** There is no automatic reconnect. Call `host.Reconnect(ctx, name)` or `client.Restart(ctx)` yourself.
+- **Concurrency.** Host and client management operations (`Connect`, `Disconnect`, `Reconnect`, `Disable`, `Reenable`) mutate connection state. Initialize connections during application startup, or protect dynamic connection changes with synchronization. Read operations during active flows are safe once connections are established.
+- **Reconnection.** Connection recovery is managed explicitly using `host.Reconnect(ctx, name)` or `client.Restart(ctx)`.
 - **Failed handshakes.** If the MCP `initialize` exchange fails, the error is recorded on the connection rather than returned: `NewGenkitMCPClient` still gives you a client, and `GetActiveTools` then returns an empty list with no error. Call `GetActiveTools` right after construction to confirm the server really answered.
 
 ### Running as an MCP server

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -676,6 +676,27 @@ responses, using a variety of strategies. Read more on the
 
 <Lang lang="go">
 
+### Set up a project
+
+The examples on this page assume a Go module with Genkit and the Google AI
+plugin installed:
+
+```bash
+go mod init example
+go get github.com/firebase/genkit/go
+go get github.com/firebase/genkit/go/plugins/googlegenai
+```
+
+`&googlegenai.GoogleAI{}` reads its credentials from the environment when its
+`APIKey` field is empty, consulting `GEMINI_API_KEY` and then `GOOGLE_API_KEY`:
+
+```bash
+export GEMINI_API_KEY=<your key>
+```
+
+The [Get started](/docs/get-started) guide covers picking a server framework and
+wiring Genkit into it.
+
 ### The `genkit.Generate()` function
 
 In Genkit, the primary interface through which you interact with generative AI
@@ -782,6 +803,47 @@ However, `genkit.Generate()` also provides an interface for more advanced
 interactions with generative models, which you will see in the sections that
 follow.
 
+#### Passing options
+
+`genkit.Generate()` takes `...ai.GenerateOption`. `ai.CommonGenOption`
+(`ai.WithModel()`, `ai.WithModelName()`, `ai.WithTools()`, `ai.WithUse()`,
+`ai.WithMaxTurns()`, `ai.WithMessages()`, and the rest) and `ai.PromptingOption`
+(`ai.WithPrompt()`, `ai.WithSystem()`, and their `Parts` and `Fn` variants) both
+embed `ai.GenerateOption`, so options of any of these kinds collect into one
+`[]ai.GenerateOption` and spread into the call:
+
+```go
+opts := []ai.GenerateOption{
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
+	ai.WithStepName("draft"),
+}
+
+resp, err := genkit.Generate(ctx, g, opts...)
+```
+
+`ai.WithStepName()`, `ai.WithToolResponses()`, and `ai.WithToolRestarts()` are
+the three that are `ai.GenerateOption` and nothing else: they mean nothing to a
+prompt definition, so `genkit.DefinePrompt()` does not accept them.
+
+#### How prompt text is treated
+
+`ai.WithPrompt(text string, args ...any)` sets the last user message, and
+`ai.WithSystem()` has the same shape. Two rules govern the text:
+
+- **With no args the text is used verbatim.** A `%` in user input is harmless.
+  Pass args and the text becomes a `fmt.Sprintf` format string, so
+  `ai.WithPrompt("Classify this review: %s", review)` is the way to interpolate.
+- **Handlebars templating applies only under `genkit.DefinePrompt()`.** There the
+  text is compiled as a Dotprompt template against the prompt's input, so
+  `{{field}}` resolves. On a plain `genkit.Generate()` call the braces are sent
+  literally. A `{{role}}` marker is always an error, because this slot is one
+  message; `ai.WithMessagesTemplate()`, which `genkit.DefinePrompt()` takes, is
+  where multi-turn templates belong.
+
+Do not concatenate untrusted text into `text`. Pass it as a `%s` argument, or use
+`ai.WithPromptFn()` or `ai.WithPromptParts()`, whose content is never templated.
+
 ### System prompts
 
 Some models support providing a _system prompt_, which gives the model
@@ -802,10 +864,60 @@ resp, err := genkit.Generate(ctx, g,
 For models that don't support system prompts, `ai.WithSystem()` simulates it by
 modifying the request to appear _like_ a system prompt.
 
+### Multi-turn conversations with messages
+
+For multi-turn conversations, pass the history with `ai.WithMessages()`. It fills
+the slot between the system prompt and the user prompt, so it combines with
+`ai.WithSystem()` and `ai.WithPrompt()` rather than replacing them. Repeating the
+option appends.
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithSystem("You are a helpful travel assistant."),
+	ai.WithMessages(
+		ai.NewUserTextMessage("Hello, can you help me plan a trip?"),
+		ai.NewModelTextMessage("Of course. Where are you thinking of going?"),
+	),
+	ai.WithPrompt("I want to visit Japan for two weeks in spring."),
+)
+```
+
+Message text passed this way is used verbatim and is never compiled as a
+template, so history containing literal braces passes through untouched.
+
+Every message carries an `ai.Role`, one of four constants:
+
+| Constant       | Wire value | Meaning                                            |
+| -------------- | ---------- | -------------------------------------------------- |
+| `ai.RoleSystem` | `system`   | User-independent instructions                       |
+| `ai.RoleUser`   | `user`     | A turn from the client                              |
+| `ai.RoleModel`  | `model`    | A turn from the model (Genkit's name for assistant) |
+| `ai.RoleTool`   | `tool`     | The result of a local tool call                     |
+
+The `ai.NewUserTextMessage()`, `ai.NewModelTextMessage()`, and
+`ai.NewSystemTextMessage()` constructors set the role for you.
+`ai.NewMessage(role, metadata, parts...)` is the general form when you need a
+different role, metadata, or non-text parts.
+
+For persistent chat sessions with automatic history management, use the
+[Chat API](/docs/chat) instead of managing the slice yourself.
+
 ### Model parameters
 
 The `genkit.Generate()` function takes a `ai.WithConfig()` option, through which
-you can specify optional settings that control how the model generates content:
+you can specify optional settings that control how the model generates content.
+
+The value you pass is the config type of the model's own provider SDK, not a
+Genkit type. For the Google AI and Vertex AI plugins that is
+`*genai.GenerateContentConfig` from Google's GenAI Go SDK, so the snippets below
+need one more import:
+
+```go
+import "google.golang.org/genai"
+```
+
+Anthropic, Ollama, and the OpenAI-compatible plugins each take their own config
+type; check the plugin's page for which one.
 
 ```go
 resp, err := genkit.Generate(ctx, g,
@@ -880,8 +992,8 @@ Low temperature values&mdash;between 0.0 and 1.0&mdash;amplify the difference in
 likelihoods between tokens, with the result that the model will be even less
 likely to produce a token it already evaluated to be unlikely. This is often
 perceived as output that is less creative. Although 0.0 is technically not a
-valid value, many models treat it as indicating that the model should behave
-deterministically, and to only consider the single most likely token.
+valid value, many models treat it as a request for greedy decoding: always take
+the single most likely next token.
 
 High temperature values&mdash;those greater than 1.0&mdash;compress the
 differences in likelihoods between tokens, with the result that the model
@@ -902,8 +1014,37 @@ token (but still take into account the probability of each token). A value of
 
 _Top-k_ is an integer value that also controls the number of possible tokens you
 want the model to consider, but this time by explicitly specifying the maximum
-number of tokens. Specifying a value of 1 means that the model should behave
-deterministically.
+number of tokens. A value of 1 leaves the model only its most likely token,
+which is greedy decoding again.
+
+:::caution[Greedy decoding is not reproducibility]
+Neither `Temperature: 0` nor `TopK: 1` makes output reproducible. Providers
+batch, shard, and update their serving stacks, so the same request at
+temperature 0 can still come back with different text tomorrow, or on a
+different replica today. Treat these as controls on style, not as a way to pin
+an answer.
+:::
+
+#### Seeds
+
+Genkit has no seed option of its own: `ai.GenerationCommonConfig`, the
+provider-neutral config struct, covers only API key, max output tokens, stop
+sequences, temperature, top-k, top-p, and version. A seed is always set through
+the provider's config. For the Google plugins:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		Temperature: genai.Ptr[float32](0),
+		Seed:        genai.Ptr[int32](42),
+	}),
+)
+```
+
+The Ollama, xAI, DashScope, and OpenRouter configs each carry their own `Seed`
+field. Not every provider exposes one. In every case a seed is best effort: it
+improves the odds that two identical requests agree, and it guarantees nothing.
 
 #### Experiment with model parameters
 
@@ -944,6 +1085,29 @@ if err != nil {
 
 The constructor for the model reference will enforce that the correct config
 type is provided which may reduce mismatches.
+
+#### Pinning a model version
+
+`gemini-flash-latest` and every other `-latest` alias floats. The provider
+repoints it on its own schedule, which can change latency, cost, safety
+behavior, and structured-output reliability with no code change and no deploy on
+your side. Examples on this site use aliases for readability. Production code
+that you can be paged for should pin.
+
+Because the Google AI and Vertex AI plugins resolve model IDs lazily, a dated ID
+works directly, whether or not the plugin's curated list mentions it:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-2.5-flash-001"),
+	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
+)
+```
+
+Keep the pin in source, review it deliberately, and re-run your eval set when you
+move it. Genkit's semantic versioning covers the Go API only: model identity and
+provider retirement schedules belong to the provider, so a pin protects you from
+a silent swap but not from a model being withdrawn.
 
 ### Structured output
 
@@ -1083,10 +1247,78 @@ depend on your exact use case, but here are some general hints:
   nested types. Try using clear names, fewer fields, or a flattened structure
   if you are not able to reliably generate structured data.
 
-- **Retry the `genkit.Generate()` call**. If the model you've chosen only
-  rarely fails to generate conformant output, you can treat the error as you
-  would treat a network error, and retry the request using some kind of
-  incremental back-off strategy.
+- **Ask again with the error**. A model that produced almost-valid JSON usually
+  fixes it when told what was wrong, so a bounded repair loop beats a plain
+  retry.
+
+A schema failure arrives as `status.ErrInvalidOutput`, which you match with
+`errors.Is`. Feed the validation error back into the next attempt:
+
+```go
+import (
+	"errors"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/middleware"
+)
+```
+
+```go
+const task = "Invent a menu item for a pirate themed restaurant."
+
+opts := []ai.GenerateOption{ai.WithPrompt(task)}
+
+var item *MenuItem
+var err error
+
+for attempt := 0; attempt < 3; attempt++ {
+	item, _, err = genkit.GenerateData[MenuItem](ctx, g, opts...)
+	if err == nil {
+		break
+	}
+	if !errors.Is(err, status.ErrInvalidOutput) {
+		return err // something other than a schema failure
+	}
+	// Tell the model what was wrong with its last attempt and ask again.
+	opts = append(opts, ai.WithPrompt(
+		task+" Your previous reply did not match the required schema: %v. "+
+			"Reply with valid JSON only, no prose and no code fence.", err))
+}
+if err != nil {
+	return fmt.Errorf("no conforming output after 3 attempts: %w", err)
+}
+```
+
+Only one prompt survives: `ai.WithPrompt()` shares a single slot with the other
+prompt options, and the last one set wins, so each pass replaces the instruction
+rather than stacking another.
+
+Note the discarded response. On a schema failure the parse happens before
+`genkit.Generate()` returns, so it hands back a nil `*ai.ModelResponse` along
+with the error. The offending text is not available to you; the validation
+error, which names the field that failed, is what you have to work with.
+
+:::caution[Retry middleware does not cover this]
+`middleware.Retry` hooks the Model stage only: it retries individual model API
+calls. Output-schema validation runs in the action layer above it, so the
+`ErrInvalidOutput` never reaches the hook, and re-issuing the identical request
+with no feedback would not fix it anyway. Use the loop above for
+nonconformance, and the middleware for transport failures
+(`UNAVAILABLE`, `DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`, `ABORTED`,
+`INTERNAL`):
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
+	ai.WithUse(&middleware.Retry{MaxRetries: 2}),
+)
+```
+
+See [Middleware](/docs/middleware), which also covers `middleware.Fallback`.
+:::
 
 #### Blocked and interrupted responses
 
@@ -1121,7 +1353,7 @@ and any of them can be selected explicitly:
 | `json`  | the default when you set an output type     | one value matching the schema      |
 | `jsonl` | `ai.WithOutputFormat(ai.OutputFormatJSONL)` | a slice, written one item per line |
 | `array` | `ai.WithOutputFormat(ai.OutputFormatArray)` | a slice, written as one JSON array |
-| `enum`  | `ai.WithOutputEnums(...)`                   | one string out of a fixed set      |
+| `enum`  | `ai.WithOutputEnums("yes", "no")`           | one string out of a fixed set      |
 
 `jsonl` and `array` need an array schema, so the output type has to be a slice.
 `ai.WithOutputEnums()` sets the schema and the format together, so it is the
@@ -1154,6 +1386,45 @@ The [basic-formats](https://github.com/genkit-ai/genkit/tree/main/go/samples/bas
 sample puts `json`, `jsonl`, and `enum` side by side over one story premise, a
 flow for each.
 
+#### Enum output
+
+`ai.WithOutputEnums()` is the whole of what a classification needs: it sets the
+format and the schema together, and the answer comes back as text.
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Classify the sentiment of this review: %s", review),
+	ai.WithOutputEnums("positive", "negative", "neutral"),
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+sentiment := resp.Text()
+```
+
+The signature is `ai.WithOutputEnums[T ~string](values ...T)`, so your own string
+type works and keeps the labels in one place:
+
+```go
+type Sentiment string
+
+const (
+	Positive Sentiment = "positive"
+	Negative Sentiment = "negative"
+	Neutral  Sentiment = "neutral"
+)
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Classify the sentiment of this review: %s", review),
+	ai.WithOutputEnums(Positive, Negative, Neutral),
+)
+```
+
+A reply outside the set fails with a `status.ErrInvalidOutput` error reading
+`message <reply> not in list of valid enums: ...`, so the value you read is
+always one of the labels you supplied.
+
 #### What a chunk means, per format
 
 The format decides what one streamed chunk contains, which is the part that
@@ -1182,14 +1453,32 @@ as a failure.
 #### Custom formats
 
 Register your own format with `genkit.DefineFormats()`, then select it by name.
-The name comes from the formatter's own `Name()` method:
+The name comes from the formatter's own `Name()` method.
+
+A format is two types. `ai.Formatter` is the registered one, and it is a factory:
+Genkit calls its `Handler()` once per request to get an `ai.FormatHandler` that
+owns that request's parsing state.
+
+```go
+import (
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+)
+```
 
 ```go
 // csvFormatter asks the model for comma-separated values.
 type csvFormatter struct{}
 
+var _ ai.Formatter = csvFormatter{}
+
 func (csvFormatter) Name() string { return "csv" }
 
+// schema is the JSON Schema of the requested output type, or nil when the
+// request asked for no type. Echo it back in Config().Schema if the model
+// should see it.
 func (csvFormatter) Handler(schema map[string]any) (ai.FormatHandler, error) {
 	return &csvHandler{}, nil
 }
@@ -1259,6 +1548,16 @@ the minimum. `ParseOutput()` and `ParseChunk()` add `ai.StreamingFormatHandler`,
 and without them both `resp.Output()` and `chunk.Output()` fail. A name can be
 claimed only once: registering one that is already taken panics, and that
 includes the five built-ins, so they cannot be replaced.
+
+The `ai.ModelOutputConfig` your handler returns from `Config()` has four fields.
+`Format` and `ContentType` are what the CSV handler above sets. The other two
+decide how the model learns the shape of the answer: `Schema` is the JSON Schema
+to send, normally the map handed to `Handler()`, and `Constrained` says the
+schema can be enforced natively rather than described in prose. `Constrained`
+is a request, not a switch. Genkit keeps it only when the caller asked for
+constrained output, a schema exists, and the model declares support; otherwise it
+clears the flag, drops `Schema`, and injects your `Instructions()` into the
+prompt instead.
 
 ### Streaming
 
@@ -1471,6 +1770,308 @@ resp, err := genkit.Generate(ctx, g,
 The [basic-media](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-media)
 sample covers both ways to attach a picture, and goes on to editing, generating,
 and animating one.
+
+#### What a media part holds
+
+`ai.NewMediaPart(mimeType, contents)` builds a `*ai.Part` with two fields set:
+`ContentType` holds the MIME type, and `Text` holds the URL, whether that is an
+`https:` URL or a `data:` URI. There is no separate URL field. Read one back with
+the `IsMedia()` predicate:
+
+```go
+for _, p := range resp.Message.Content {
+	if p.IsMedia() {
+		log.Printf("%s at %s", p.ContentType, p.Text)
+	}
+}
+```
+
+`IsImage()`, `IsAudio()`, and `IsVideo()` narrow by MIME type prefix. On a
+response, `resp.MediaParts()` returns every media part directly, and
+`resp.Media()` returns the URL of the first one as a string, discarding its
+content type.
+
+### Generating media
+
+Image, video, and speech models answer with media parts rather than text, so the
+same `genkit.Generate()` call covers them. This example generates an image and
+writes it to disk:
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+func main() {
+	ctx := context.Background()
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.GoogleAI{}))
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("googleai/imagen-4.0-generate-001"),
+		ai.WithPrompt("An illustration of a dog wearing a space suit, photorealistic."),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	parts := resp.MediaParts()
+	if len(parts) == 0 {
+		log.Fatalf("no image returned: finish reason %q", resp.FinishReason)
+	}
+
+	data, err := mediaBytes(parts[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := os.WriteFile("dog.png", data, 0o644); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// mediaBytes decodes a media part's payload. Generated media normally arrives
+// as a "data:" URI, but a provider that stores the result returns an "https:"
+// file URI instead, so branch on the prefix.
+func mediaBytes(p *ai.Part) ([]byte, error) {
+	if !strings.HasPrefix(p.Text, "data:") {
+		return nil, fmt.Errorf("media is hosted at %s; fetch it over HTTP", p.Text)
+	}
+	_, encoded, ok := strings.Cut(p.Text, ",")
+	if !ok {
+		return nil, fmt.Errorf("malformed data URI")
+	}
+	return base64.StdEncoding.DecodeString(encoded)
+}
+```
+
+Text-to-speech works the same way. The difference is the config: a TTS model
+needs the audio modality and a voice, which are provider settings rather than
+Genkit ones.
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-2.5-flash-preview-tts"),
+	ai.WithConfig(&genai.GenerateContentConfig{
+		ResponseModalities: []string{"AUDIO"},
+		SpeechConfig: &genai.SpeechConfig{
+			VoiceConfig: &genai.VoiceConfig{
+				PrebuiltVoiceConfig: &genai.PrebuiltVoiceConfig{VoiceName: "Algenib"},
+			},
+		},
+	}),
+	ai.WithPrompt("Say that Genkit is an amazing AI framework."),
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+parts := resp.MediaParts()
+if len(parts) == 0 {
+	log.Fatalf("no audio returned: finish reason %q", resp.FinishReason)
+}
+data, err := mediaBytes(parts[0])
+if err != nil {
+	log.Fatal(err)
+}
+if err := os.WriteFile("output.wav", data, 0o644); err != nil {
+	log.Fatal(err)
+}
+```
+
+See the [Google GenAI plugin](/docs/integrations/google-genai) page for the
+Imagen, Veo, and TTS model IDs each backend serves.
+
+### Reasoning
+
+Models that expose their intermediate thinking return it as reasoning parts,
+separate from the answer. `resp.Reasoning()` concatenates them:
+
+```go
+if thinking := resp.Reasoning(); thinking != "" {
+	log.Printf("model reasoning:\n%s", thinking)
+}
+```
+
+`p.IsReasoning()` identifies one part at a time, and
+`ai.NewReasoningPart(text, signature)` builds one. The signature is the opaque
+blob some providers attach to prove the reasoning is theirs; pass `nil` when
+there is none. If you replay history yourself rather than using
+`resp.History()`, carry the signature back unchanged on the next turn, or the
+provider may reject the request.
+
+Reasoning tokens are billed and are reported separately in
+`resp.Usage.ThoughtsTokens`.
+
+### Resources
+
+A resource is content addressed by URI that a prompt can reference by name
+instead of embedding inline. Define one with `genkit.DefineResource()`:
+
+```go
+genkit.DefineResource(g, "company-docs", &ai.ResourceOptions{
+	URI:         "file:///docs/handbook.pdf",
+	Description: "Company handbook",
+}, func(ctx context.Context, in *ai.ResourceInput) (*ai.ResourceOutput, error) {
+	content, err := os.ReadFile("/docs/handbook.pdf")
+	if err != nil {
+		return nil, err
+	}
+	return &ai.ResourceOutput{
+		Content: []*ai.Part{ai.NewTextPart(string(content))},
+	}, nil
+})
+```
+
+`ai.ResourceOptions.URI` and `ai.ResourceOptions.Template` are mutually
+exclusive. `URI` matches one exact address. `Template` is a URI template that
+matches a family of them, and the captured segments arrive as
+`ai.ResourceInput.Variables`, a `map[string]string`, alongside the full
+`ai.ResourceInput.URI`:
+
+```go
+genkit.DefineResource(g, "user-profile", &ai.ResourceOptions{
+	Template:    "profile://users/{userID}",
+	Description: "A user's profile",
+}, func(ctx context.Context, in *ai.ResourceInput) (*ai.ResourceOutput, error) {
+	profile, err := loadProfile(ctx, in.Variables["userID"])
+	if err != nil {
+		return nil, err
+	}
+	return &ai.ResourceOutput{
+		Content: []*ai.Part{ai.NewTextPart(profile)},
+	}, nil
+})
+```
+
+The handler always returns `ai.ResourceOutput.Content` as `[]*ai.Part`, so a
+resource can serve media as easily as text.
+
+Reference a resource from a request with `ai.NewResourcePart(uri)`. For a
+resource you do not want in the registry, build it with `ai.NewResource()` and
+attach it to a single call with `ai.WithResources()`, which appends when
+repeated:
+
+```go
+scratch := ai.NewResource("scratch", &ai.ResourceOptions{
+	URI: "mem:///scratch",
+}, func(ctx context.Context, in *ai.ResourceInput) (*ai.ResourceOutput, error) {
+	return &ai.ResourceOutput{Content: []*ai.Part{ai.NewTextPart(notes)}}, nil
+})
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithResources(scratch),
+	ai.WithPromptParts(
+		ai.NewTextPart("Summarize these notes."),
+		ai.NewResourcePart("mem:///scratch"),
+	),
+)
+```
+
+Resources attached this way live in a temporary registry for the duration of the
+request and are discarded afterward.
+
+### Token usage and cost
+
+`resp.Usage` reports what the request consumed. It is a `*ai.GenerationUsage`
+and can be nil, because a provider that reports nothing leaves it unset:
+
+```go
+if u := resp.Usage; u != nil {
+	log.Printf("in=%d out=%d total=%d thoughts=%d cached=%d",
+		u.InputTokens, u.OutputTokens, u.TotalTokens,
+		u.ThoughtsTokens, u.CachedContentTokens)
+}
+```
+
+| Field                                                                       | Type                 | What it counts                              |
+| --------------------------------------------------------------------------- | -------------------- | ------------------------------------------- |
+| `InputTokens`, `OutputTokens`, `TotalTokens`                                | `int`                | The usual billing counters                   |
+| `ThoughtsTokens`                                                            | `int`                | Reasoning tokens, billed but not returned    |
+| `CachedContentTokens`                                                       | `int`                | Input tokens served from the provider's cache |
+| `InputCharacters`, `InputImages`, `InputVideos`, `InputAudioFiles`          | `int`                | Non-token input units some providers bill on |
+| `OutputCharacters`, `OutputImages`, `OutputVideos`, `OutputAudioFiles`      | `int`                | The output twins of those                    |
+| `Custom`                                                                    | `map[string]float64` | Provider-specific metrics                    |
+
+Every field is `omitempty`, so a zero means "not reported" as often as it means
+zero. Read `Custom` with the two-value map form rather than trusting a zero.
+
+:::caution[A tool loop reports its last turn only]
+The `*ai.ModelResponse` you get back carries the usage of the final model call.
+Genkit does not accumulate usage across the turns of a tool loop, so billing a
+whole loop means summing the turns yourself. Attach middleware to see each model
+call, as in the metering example on the [Middleware](/docs/middleware) page.
+:::
+
+#### Caching
+
+Providers discount input tokens they have already processed. A hit shows up as a
+nonzero `resp.Usage.CachedContentTokens`, which is the only reliable way to
+confirm caching is working.
+
+| Plugin                                                        | Caching in Go                                                                                                                                          |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Google AI and Vertex AI](/docs/integrations/google-genai)     | Explicit. Call `WithCacheTTL()` on the last message you want cached.                                                                                     |
+| [OpenAI-compatible](/docs/integrations/openai-compatible)      | Implicit, decided by the provider. [xAI](/docs/integrations/xai) adds a `PromptCacheKey` config field that routes matching prefixes to the same backend. |
+| [Anthropic](/docs/integrations/anthropic)                      | Not available. The plugin reports `CachedContentTokens` on a hit but has no way to place a cache breakpoint.                                             |
+
+For the Google plugins, mark the boundary on the message:
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithModelName("googleai/gemini-flash-latest"),
+	ai.WithMessages(
+		ai.NewUserTextMessage(handbook).WithCacheTTL(300), // cache everything up to here for 5 minutes
+	),
+	ai.WithPrompt("What is the parental leave policy?"),
+)
+```
+
+Context caching there is exclusive with tools and with system prompts: a request
+that marks a message for caching and also carries either one is rejected with
+`INVALID_ARGUMENT`. Not every Gemini model version supports it, so check the
+provider's documentation before you rely on it.
+
+### Timeouts and cancellation
+
+Genkit has no per-generation timeout option. The context you pass to
+`genkit.Generate()` is the mechanism, and it reaches the provider's HTTP
+request:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
+)
+```
+
+Cancelling the context aborts the in-flight provider call and ends the tool loop.
+An expired deadline classifies as `status.DeadlineExceeded`; an explicit cancel
+classifies as `status.Cancelled`. See [Error types](/docs/error-types).
+
+:::caution[Put the deadline outside Retry, not under it]
+`status.DeadlineExceeded` is on `middleware.Retry`'s default status list, so a
+deadline that fires inside a retried call looks retryable: the middleware waits
+out its backoff and tries again against a context that is already dead, until
+`MaxRetries` is exhausted. `status.Cancelled` is not on that list, so an explicit
+cancel stops immediately. Either derive the deadline in the caller, above the
+`genkit.Generate()` that carries `ai.WithUse(&middleware.Retry{...})`, or drop
+`status.DeadlineExceeded` from `Retry.Statuses`.
+:::
+
+[Concurrency, cancellation, and lifecycle](/docs/concurrency) covers how
+deadlines propagate through flows, tools, and streams.
 
 ### Next steps
 

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1086,28 +1086,20 @@ if err != nil {
 The constructor for the model reference will enforce that the correct config
 type is provided which may reduce mismatches.
 
-#### Pinning a model version
+#### Model versions and aliases
 
-`gemini-flash-latest` and every other `-latest` alias floats. The provider
-repoints it on its own schedule, which can change latency, cost, safety
-behavior, and structured-output reliability with no code change and no deploy on
-your side. Examples on this site use aliases for readability. Production code
-that you can be paged for should pin.
+Model aliases like `gemini-flash-latest` point to the current release of a model. While aliases are convenient during development and prototyping, model providers periodically update which snapshot an alias references, which can affect latency, cost, and output consistency.
 
-Because the Google AI and Vertex AI plugins resolve model IDs lazily, a dated ID
-works directly, whether or not the plugin's curated list mentions it:
+For production workloads where consistent behavior is desired, you can specify a dated or specific model version snapshot:
 
 ```go
 resp, err := genkit.Generate(ctx, g,
-	ai.WithModelName("googleai/gemini-2.5-flash-001"),
+	ai.WithModelName("googleai/gemini-3.7-flash"),
 	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
 )
 ```
 
-Keep the pin in source, review it deliberately, and re-run your eval set when you
-move it. Genkit's semantic versioning covers the Go API only: model identity and
-provider retirement schedules belong to the provider, so a pin protects you from
-a silent swap but not from a model being withdrawn.
+Because plugins like Google AI and Vertex AI resolve model IDs dynamically, specific model versions work directly without requiring updates to the plugin definition. When updating model versions in production, consider testing changes against an evaluation dataset before deploying.
 
 ### Structured output
 

--- a/src/content/docs/docs/observability/advanced-configuration.mdx
+++ b/src/content/docs/docs/observability/advanced-configuration.mdx
@@ -53,22 +53,42 @@ you up and running quickly. These are the provided defaults:
 <Lang lang="go">
 
 This guide focuses on advanced configuration options for deployed features
-using the Firebase telemetry plugin.
+using the Firebase telemetry plugin. Every option lives on
+`firebase.FirebaseTelemetryOptions`, which you pass to
+`firebase.EnableFirebaseTelemetry`. Pass `nil` to take all of the defaults.
+
+| Field                          | Type                  | Default when unset                                                                  |
+| ------------------------------ | --------------------- | ----------------------------------------------------------------------------------- |
+| `ProjectID`                    | `string`              | Read from `FIREBASE_PROJECT_ID`, then `GOOGLE_CLOUD_PROJECT`, then `GCLOUD_PROJECT` |
+| `Credentials`                  | `*google.Credentials` | Application Default Credentials                                                     |
+| `Sampler`                      | `sdktrace.Sampler`    | `AlwaysOnSampler`, so every trace is kept                                           |
+| `MetricExportIntervalMillis`   | `*int`                | 5000 in dev, 300000 in production. Google Cloud rejects anything below 5000         |
+| `MetricExportTimeoutMillis`    | `*int`                | Matches `MetricExportIntervalMillis`                                                |
+| `DisableMetrics`               | `bool`                | `false`. Traces and logs are unaffected by this switch                              |
+| `DisableTraces`                | `bool`                | `false`. Metrics and logs are unaffected by this switch                             |
+| `DisableLoggingInputAndOutput` | `bool`                | `false`, so prompts and model responses are written to Cloud Logging                |
+| `ForceDevExport`               | `bool`                | `false`, so nothing is exported while `GENKIT_ENV=dev`                              |
+
+`google.Credentials` is `golang.org/x/oauth2/google.Credentials`, and
+`sdktrace` is `go.opentelemetry.io/otel/sdk/trace`.
+
+The two interval fields are `*int`, so setting them needs an addressable
+variable:
 
 ```go
-// Note: MetricExportIntervalMillis and MetricExportTimeoutMillis are pointers to int (*int).
-// The values shown below represent the internal defaults in production.
-{
-  DisableMetrics: false,
-  DisableTraces: false,
-  DisableLoggingInputAndOutput: false,
-  ForceDevExport: false,
-  // 5 minutes
-  MetricExportIntervalMillis: nil, // defaults to 300000
-  // 5 minutes
-  MetricExportTimeoutMillis: nil,  // defaults to 300000
-  // OpenTelemetry defaults to sdktrace.AlwaysSample()
-  Sampler: nil, // defaults to sdktrace.AlwaysSample()
+package main
+
+import (
+	"github.com/firebase/genkit/go/plugins/firebase"
+)
+
+func main() {
+	interval := 10000 // Milliseconds.
+
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		ForceDevExport:             true,
+		MetricExportIntervalMillis: &interval,
+	})
 }
 ```
 
@@ -76,8 +96,8 @@ using the Firebase telemetry plugin.
 
 ## Export local telemetry
 
-To export telemetry when running locally set the `forceDevExport` option to
-`true`.
+Nothing is exported while the process runs in a dev environment. To export
+telemetry when running locally, turn on the force dev export option.
 
 <Lang lang="js">
 
@@ -95,11 +115,9 @@ enableFirebaseTelemetry({ forceDevExport: true });
 import "github.com/firebase/genkit/go/plugins/firebase"
 
 func main() {
-  firebase.EnableFirebaseTelemetry(
-    &firebase.FirebaseTelemetryOptions{
-      ForceDevExport: true,
-    }
-  )
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		ForceDevExport: true,
+	})
 }
 ```
 
@@ -131,15 +149,122 @@ enableFirebaseTelemetry({
 import "github.com/firebase/genkit/go/plugins/firebase"
 
 func main() {
-  interval := 10000
-  firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
-    MetricExportIntervalMillis: &interval, // 10 seconds
-    MetricExportTimeoutMillis:  &interval, // 10 seconds
-  })
+	interval := 10000
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		MetricExportIntervalMillis: &interval, // 10 seconds
+		MetricExportTimeoutMillis:  &interval, // 10 seconds
+	})
 }
 ```
 
 </Lang>
+
+<Lang lang="go">
+
+## Sampling
+
+`Sampler` accepts any `sdktrace.Sampler`. Left `nil`, the plugin keeps every
+trace, which is fine in development and expensive at production volume: each
+kept trace costs storage in Cloud Trace and counts against your ingestion quota
+the same way a short export interval costs money in Cloud Monitoring.
+
+Sample a fraction instead, and wrap it in `ParentBased` so a trace that starts
+sampled stays sampled all the way down instead of losing its child spans:
+
+```go
+package main
+
+import (
+	"github.com/firebase/genkit/go/plugins/firebase"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func main() {
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		// Keep 5% of traces. Metrics are unaffected by sampling.
+		Sampler: sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.05)),
+	})
+}
+```
+
+Metrics are not sampled, so request counts and token counts stay exact no matter
+what you set here.
+
+## Instrumentation beyond Genkit
+
+The Go plugin does not auto-instrument anything. Go has no zero-code
+instrumentation equivalent, so the plugin registers a `TracerProvider` and a
+`MeterProvider` and Genkit's own actions are the only things that produce spans
+on them.
+
+To trace your HTTP handlers, your database calls, or any outbound client, add
+the corresponding OpenTelemetry instrumentation library yourself. For example,
+wrap your mux in
+[`otelhttp`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp)
+before passing it to your server. Those libraries read the global provider at
+construction time, so build them after you call
+`firebase.EnableFirebaseTelemetry`. Their spans then land in the same traces as
+your flows.
+
+The only trace-shaping knobs the plugin itself offers are `Sampler`,
+`DisableTraces`, and `DisableMetrics`.
+
+## Flush on shutdown
+
+The plugin installs its own `SIGINT`/`SIGTERM` handler that force-flushes spans
+and metrics with a five-second budget, then calls `os.Exit(0)`. A process that
+terminates on a signal loses nothing, and you do not need to sleep for the
+length of `MetricExportIntervalMillis`.
+
+For a shutdown path that does not go through a signal, flush explicitly:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/plugins/googlecloud"
+)
+
+func flush(ctx context.Context) {
+	if err := googlecloud.FlushMetrics(ctx); err != nil {
+		log.Printf("failed to flush metrics: %v", err)
+	}
+}
+```
+
+`googlecloud.FlushMetrics` works for Firebase telemetry too, because
+`firebase.EnableFirebaseTelemetry` delegates to
+`googlecloud.EnableGoogleCloudTelemetry`. Call it after your HTTP server's
+`Shutdown` returns.
+
+## What lands in telemetry
+
+`DisableLoggingInputAndOutput: true` is the only built-in privacy control. It is
+all or nothing: it removes every prompt and every model response from the
+exported payloads. There is no field-level or key-level redaction option.
+
+Traces are not the place to look for content either way. The `genkit/input` and
+`genkit/output` span attributes are always `<redacted>`, because of trace
+attribute size limits rather than for privacy. The full content travels in the
+Cloud Logging payloads, which is exactly what `DisableLoggingInputAndOutput`
+suppresses.
+
+If you need to keep some content and drop the rest, wrap the span exporter. The
+`redactingSpanExporter` pattern in
+[Writing Genkit plugins](/docs/plugin-authoring/overview#pii-redaction) is the
+supported way to do it, and it is fine to use from application code, not just
+from a plugin.
+
+Locally, the Dev UI writes traces to `.genkit/traces` under your project root,
+with full inputs and outputs and no expiry. Add `.genkit/` to `.gitignore`, and
+delete it when you are done with a prompt you would not want kept.
+
+</Lang>
+
+<Lang lang="js">
 
 ## Adjust auto instrumentation
 
@@ -152,8 +277,6 @@ documentation.
 
 To selectively disable or enable instrumentations that are eligible for auto
 instrumentation, update the `autoInstrumentationConfig` field:
-
-<Lang lang="js">
 
 ```typescript
 import { enableFirebaseTelemetry } from '@genkit-ai/firebase';
@@ -201,11 +324,14 @@ enableFirebaseTelemetry({
 import "github.com/firebase/genkit/go/plugins/firebase"
 
 func main() {
-  firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
-    DisableLoggingInputAndOutput: true,
-  })
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		DisableLoggingInputAndOutput: true,
+	})
 }
 ```
+
+See [What lands in telemetry](#what-lands-in-telemetry) for what this covers
+and what it does not.
 
 </Lang>
 
@@ -235,9 +361,9 @@ enableFirebaseTelemetry({
 import "github.com/firebase/genkit/go/plugins/firebase"
 
 func main() {
-  firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
-    DisableMetrics: true,
-  })
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		DisableMetrics: true,
+	})
 }
 ```
 
@@ -269,9 +395,9 @@ enableFirebaseTelemetry({
 import "github.com/firebase/genkit/go/plugins/firebase"
 
 func main() {
-  firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
-    DisableTraces: true,
-  })
+	firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+		DisableTraces: true,
+	})
 }
 ```
 

--- a/src/content/docs/docs/observability/getting-started.mdx
+++ b/src/content/docs/docs/observability/getting-started.mdx
@@ -51,7 +51,8 @@ and on the Google Cloud Console.
 
    <Lang lang="go">
 
-   a. [Deploy flows using Cloud Run](/docs/deployment/cloud-run)
+   Deploy your flows [with Cloud Run](/docs/deployment/cloud-run) or
+   [to any platform](/docs/deployment/any-platform) that runs a Go binary.
 
    </Lang>
 
@@ -64,6 +65,30 @@ Install the `@genkit-ai/firebase` plugin in your project:
 ```bash
 npm install @genkit-ai/firebase
 ```
+
+</Lang>
+
+<Lang lang="go">
+
+Add the `firebase` plugin to your module:
+
+```bash
+go get github.com/firebase/genkit/go/plugins/firebase
+```
+
+:::note[The Firebase and Google Cloud telemetry plugins are the same code]
+`firebase.EnableFirebaseTelemetry` copies its options into a
+`googlecloud.GoogleCloudTelemetryOptions` and calls
+`googlecloud.EnableGoogleCloudTelemetry`. The option structs are field for
+field identical. The only behavioral difference is project-ID resolution:
+the Firebase entry point checks `FIREBASE_PROJECT_ID` before
+`GOOGLE_CLOUD_PROJECT` and `GCLOUD_PROJECT`.
+
+Use `firebase.EnableFirebaseTelemetry` if you want the Firebase Genkit
+Monitoring dashboard, and
+[`googlecloud.EnableGoogleCloudTelemetry`](/docs/integrations/google-cloud)
+otherwise. Do not call both.
+:::
 
 </Lang>
 
@@ -84,6 +109,22 @@ export ENABLE_FIREBASE_MONITORING=true
 This will use default configuration values. To
 override configuration options, use "Programmatic configuration".
 :::
+
+</Lang>
+
+<Lang lang="go">
+
+There is no environment variable that turns telemetry on. The Go plugin has no
+equivalent of `ENABLE_FIREBASE_MONITORING`, so you always call
+`firebase.EnableFirebaseTelemetry` in code.
+
+Two environment variables still affect what happens after you call it:
+
+- `GENKIT_ENV`: when set to `dev`, nothing is exported unless you also set
+  `ForceDevExport: true`.
+- `FIREBASE_PROJECT_ID`, then `GOOGLE_CLOUD_PROJECT`, then `GCLOUD_PROJECT`:
+  checked in that order to resolve the destination project when you leave
+  `ProjectID` empty.
 
 </Lang>
 
@@ -108,27 +149,60 @@ enableFirebaseTelemetry();
 
 <Lang lang="go">
 
-To enable Firebase Genkit Monitoring in code, call `firebase.EnableFirebaseTelemetry` before initializing Genkit. You can pass configuration options to tweak settings like the metric export
-interval or to set up your local environment to export telemetry data.
+Call `firebase.EnableFirebaseTelemetry` before `genkit.Init`. It returns
+nothing, so there is no error to check. Pass `nil` for the defaults, or a
+`*firebase.FirebaseTelemetryOptions` to tweak settings like the metric export
+interval.
 
 ```go
 package main
 
 import (
-   "context"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
 
-   "github.com/firebase/genkit/go/genkit"
-   "github.com/firebase/genkit/go/plugins/firebase"
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/firebase"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/server"
 )
 
 func main() {
-   ctx := context.Background()
+	ctx := context.Background()
 
-   // Enable telemetry with default options
-   firebase.EnableFirebaseTelemetry(nil)
-   g := genkit.Init(ctx)
+	// Enable telemetry with default options, before genkit.Init.
+	firebase.EnableFirebaseTelemetry(nil)
+
+	g := genkit.Init(ctx,
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-flash-latest"),
+	)
+
+	flow := genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (string, error) {
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Tell a short joke about %s.", topic))
+		if err != nil {
+			return "", fmt.Errorf("failed to generate joke: %w", err)
+		}
+		return resp.Text(), nil
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /jokesFlow", genkit.Handler(flow))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Fatal(server.Start(ctx, "0.0.0.0:"+port, mux))
 }
 ```
+
+The full option list is on
+[Advanced configuration](/docs/observability/advanced-configuration).
 
 </Lang>
 
@@ -171,7 +245,20 @@ dashboard.
 <Lang lang="go">
 
 1. In your Genkit code, set `ForceDevExport` to `true` to send telemetry from
-   your local environment.
+   your local environment. Lower the export interval at the same time so you do
+   not wait five minutes for the first metric:
+
+   ```go
+   interval := 5000 // Milliseconds. Google Cloud rejects anything below 5000.
+
+   firebase.EnableFirebaseTelemetry(&firebase.FirebaseTelemetryOptions{
+   	ForceDevExport:             true,
+   	MetricExportIntervalMillis: &interval,
+   })
+   ```
+
+   `MetricExportIntervalMillis` is a `*int`, so it needs an addressable
+   variable. Leaving it `nil` means 5000 in dev and 300000 in production.
 
 </Lang>
 
@@ -195,7 +282,7 @@ gcloud auth application-default login --impersonate-service-account SERVICE_ACCT
 3. Run and invoke your Genkit feature, and then view metrics on the
    [Genkit Monitoring dashboard](https://console.firebase.google.com/project/_/genai_monitoring).
    Allow for up to 5 minutes to collect the first metric. You can reduce this
-   delay by setting `metricExportIntervalMillis` in the telemetry configuration.
+   delay by lowering the metric export interval in the telemetry configuration.
 
 4. If metrics are not appearing in the Genkit Monitoring dashboard, view the
    [Troubleshooting](/docs/observability/troubleshooting) guide for steps
@@ -224,6 +311,108 @@ It may take up to 5 minutes to collect the first metric (based on the default `m
 
 :::note
 It may take up to 5 minutes to collect the first metric (based on the default `MetricExportIntervalMillis` setting in the telemetry configuration).
+:::
+
+## Correlating a user report to a trace
+
+A support ticket is only useful if you can find the request it describes. Read
+the current trace ID inside the flow and hand it back to the caller.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type jokeResponse struct {
+	Joke    string `json:"joke"`
+	TraceID string `json:"traceId"`
+}
+
+func defineJokesFlow(g *genkit.Genkit) {
+	genkit.DefineFlow(g, "jokesFlow", func(ctx context.Context, topic string) (jokeResponse, error) {
+		traceID := trace.SpanContextFromContext(ctx).TraceID().String()
+
+		resp, err := genkit.Generate(ctx, g, ai.WithPrompt("Tell a short joke about %s.", topic))
+		if err != nil {
+			// Return the ID on the error path too. That is the path users report.
+			return jokeResponse{TraceID: traceID}, fmt.Errorf("failed to generate joke: %w", err)
+		}
+		return jokeResponse{Joke: resp.Text(), TraceID: traceID}, nil
+	})
+}
+```
+
+An `X-Trace-Id` response header works just as well if you do not want to change
+the response body.
+
+With the ID in hand:
+
+- Search for it directly in Cloud Trace, or in the Genkit Monitoring trace
+  viewer.
+- Paste `projects/<project-id>/traces/<trace-id>` into Cloud Logging to pull
+  every log line for that request. Genkit writes the `trace` field of each log
+  entry in exactly that format. See
+  [Telemetry collection](/docs/observability/telemetry-collection).
+
+To capture the ID from outside the flow body, use
+`tracing.WithTelemetryCallback(ctx, func(traceID, spanID string) { ... })` from
+`github.com/firebase/genkit/go/core/tracing` and pass the resulting context into
+the flow.
+
+## Export to any OTLP backend
+
+Firebase and Google Cloud are not the only destinations. `core/tracing` exports
+the SDK tracer provider as application API, so you can attach any OpenTelemetry
+span exporter to it: Datadog, Honeycomb, Grafana, or a self-hosted collector.
+
+```bash
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
+```
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/firebase/genkit/go/core/tracing"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// registerOTLP attaches an OTLP exporter to Genkit's tracer provider and
+// returns a shutdown function that flushes buffered spans.
+func registerOTLP(ctx context.Context) func(context.Context) error {
+	// Reads OTEL_EXPORTER_OTLP_ENDPOINT and the usual OTEL_* variables.
+	exp, err := otlptracegrpc.New(ctx)
+	if err != nil {
+		log.Fatalf("failed to build OTLP exporter: %v", err)
+	}
+
+	tp := tracing.TracerProvider()
+	tp.RegisterSpanProcessor(sdktrace.NewBatchSpanProcessor(exp))
+	return tp.Shutdown
+}
+```
+
+Call `registerOTLP` before `genkit.Init` and defer the returned shutdown
+function. For metrics, build an OTLP `metric.Exporter` and install it with
+`otel.SetMeterProvider`; Genkit records its counters and histograms through the
+global meter provider.
+
+:::caution[Order matters if you also enable Firebase or Google Cloud telemetry]
+`EnableFirebaseTelemetry` and `EnableGoogleCloudTelemetry` build a fresh
+`TracerProvider` and install it as the global one, which discards any span
+processor registered earlier. To send spans to both destinations, call
+`registerOTLP` **after** the telemetry plugin, not before.
 :::
 
 </Lang>

--- a/src/content/docs/docs/observability/telemetry-collection.mdx
+++ b/src/content/docs/docs/observability/telemetry-collection.mdx
@@ -42,6 +42,15 @@ tiers. Specific pricing can be found at the following links:
 The Firebase telemetry plugin collects a number of different metrics to support
 the various Genkit action types detailed in the following sections.
 
+<Lang lang="go">
+
+:::note
+The Go SDK hard-codes the `source` dimension to `go` on every metric and every
+log payload. You can filter or group on it, but you cannot change it.
+:::
+
+</Lang>
+
 ### Feature metrics
 
 Features are the top-level entry-point to your Genkit code. In most cases, this
@@ -72,7 +81,7 @@ Each feature metric contains the following dimensions:
 | name          | The name of the feature. In most cases, this is the top-level Genkit flow        |
 | status        | 'success' or 'failure' depending on whether or not the feature request succeeded |
 | error         | Only set when `status=failure`. Contains the error type that caused the failure  |
-| source        | The Genkit source language. Eg. 'ts'                                             |
+| source        | The Genkit SDK language that emitted the telemetry                               |
 | sourceVersion | The Genkit framework version                                                     |
 
 ### Action and Path metrics
@@ -176,7 +185,7 @@ Each generate metric contains the following dimensions:
 | latencyMs     | The response time taken by the model                                                                 |
 | status        | 'success' or 'failure' depending on whether or not the feature request succeeded                     |
 | error         | Only set when `status=failure`. Contains the error type that caused the failure                      |
-| source        | The Genkit source language. Eg. 'ts'                                                                 |
+| source        | The Genkit SDK language that emitted the telemetry                                                   |
 | sourceVersion | The Genkit framework version                                                                         |
 
 ## Traces
@@ -395,7 +404,7 @@ Metadata:
 | model         | Model name.                                                                                                                                                     |
 | path          | The execution path that generated this log of the format `step1 > step2 > step3                                                                                 |
 | qualifiedPath | The execution path that generated this log, including type information of the format: `/{flow1,t:flow}/{generate,t:util}/{modelProvider/model,t:action,s:model` |
-| source        | The Genkit library language used. This will always be set to 'ts' as it is the only supported language.                                                         |
+| source        | The Genkit SDK language that emitted the log.                                                                                                                   |
 | sourceVersion | The Genkit library version.                                                                                                                                     |
 | temperature   | Model temperature used.                                                                                                                                         |
 
@@ -414,3 +423,38 @@ Metadata:
 | ---------- | ---------------------------------------------------------------- |
 | flowName   | The name of the Genkit flow, action, tool, util, or helper.      |
 | paths      | An array containing all execution paths for the collected spans. |
+
+<Lang lang="go">
+
+## Sensitive data
+
+Read the two halves of this page together before you deploy anything that
+handles regulated or personal data.
+
+- **Traces carry no content.** The `genkit/input` and `genkit/output` span
+  attributes are always `<redacted>`. That is a consequence of Cloud Trace's
+  256-byte attribute value limit, not a privacy feature, and it is true whatever
+  you configure.
+- **Logs carry everything.** The Input, Output, and Config log payloads above
+  contain the full prompt text, the full model response, and the model
+  configuration. Those go to Cloud Logging.
+
+`DisableLoggingInputAndOutput: true` on `firebase.FirebaseTelemetryOptions` (or
+`googlecloud.GoogleCloudTelemetryOptions`) suppresses that content. It is the
+only built-in control and it is all or nothing: there is no per-field, per-flow,
+or per-key redaction option.
+
+:::caution
+Middleware that scrubs the `ModelRequest` does not help here. The log payloads
+are built from the span, not from the request your middleware rewrote, so the
+original text still reaches Cloud Logging.
+:::
+
+For selective redaction, wrap the span exporter and rewrite attributes on the
+way out. The `redactingSpanExporter` pattern in
+[Writing Genkit plugins](/docs/plugin-authoring/overview#pii-redaction) is the
+supported way to do it, and applications may use it, not just plugins. See
+[Advanced configuration](/docs/observability/advanced-configuration) for the
+option reference.
+
+</Lang>

--- a/src/content/docs/docs/observability/troubleshooting.mdx
+++ b/src/content/docs/docs/observability/troubleshooting.mdx
@@ -131,8 +131,6 @@ see the specific failure reason, look for a log that starts with:
 
 <Lang lang="go">
 
-### Intermittent network issues
-
 Occasionally you may have transient network issues that result in a failure to
 upload telemetry data. These failures are logged to Google Cloud Logging. To
 see the specific failure reason, look for a log that contains:

--- a/src/content/docs/docs/overview.mdx
+++ b/src/content/docs/docs/overview.mdx
@@ -157,11 +157,20 @@ const { text } = await ai.generate({
 
 <Lang lang="go">
 
+Each tab is a complete program. Add Genkit to a module with
+`go get github.com/firebase/genkit/go`, then `go mod tidy` after you paste the
+code so the provider plugin and any provider SDK it needs are resolved. Each
+plugin reads its credential from the environment: `GEMINI_API_KEY` for Google
+AI, `OPENAI_API_KEY` for OpenAI, `ANTHROPIC_API_KEY` for Anthropic. Ollama runs
+locally and needs no key.
+
 <Tabs>
 
 <TabItem label="Gemini">
 
 ```go
+package main
+
 import (
 	"context"
 	"log"
@@ -192,6 +201,8 @@ func main() {
 <TabItem label="Image">
 
 ```go
+package main
+
 import (
 	"context"
 	"log"
@@ -232,6 +243,8 @@ func main() {
 <TabItem label="OpenAI">
 
 ```go
+package main
+
 import (
 	"context"
 	"log"
@@ -262,6 +275,8 @@ func main() {
 <TabItem label="Anthropic">
 
 ```go
+package main
+
 import (
 	"context"
 	"log"
@@ -332,6 +347,18 @@ func main() {
 </TabItem>
 
 </Tabs>
+
+## Using Genkit in a server
+
+`genkit.Init` returns a `*genkit.Genkit`. Create one per process in `main()` and
+share it across every request handler: it is safe for concurrent use by many
+goroutines, as are the flow, tool, and prompt values you define from it. The
+`ctx` you pass to `genkit.Generate` propagates cancellation to the provider
+call, but there is no default per-request timeout, so set one with
+`context.WithTimeout`. Retries and provider fallback are opt-in
+[middleware](/docs/middleware). For the whole contract, including parallel tool
+fan-out and shutdown, see
+[Concurrency, cancellation, and lifecycle](/docs/concurrency).
 
 ## Sample programs
 
@@ -560,9 +587,9 @@ Create your own AI-powered feature in minutes with our guides.
 | :---------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Broad AI model support**    | Use a unified interface to integrate with hundreds of models from providers like [Google](/docs/integrations/google-genai), [OpenAI](/docs/integrations/openai), [Anthropic](/docs/integrations/anthropic), [Ollama](/docs/integrations/ollama), and more. Explore, compare, and use the best models for your needs.                                                   |
 | **Simplified AI development** | Use streamlined APIs to build AI features with [structured output](/docs/models#structured-output), [agentic tool calling](/docs/tool-calling), [context-aware generation](/docs/rag), [multi-modal input/output](/docs/models#multimodal-input), and more. Genkit handles the complexity of AI development, so you can build and iterate faster.                      |
-| **Web and mobile ready**      | Integrate seamlessly with frameworks and platforms including Next.js, React, Angular, iOS, and Android using purpose-built [client SDKs](/docs/deployment/firebase) and helpers.                                                                                                                                                                                       |
+| **Web and mobile ready**      | Integrate seamlessly with frameworks and platforms including Next.js, React, Angular, iOS, and Android using [client helpers that call your flows over HTTP](/docs/client).                                                                                                                                                                                       |
 | **Cross-language support**    | Build with the language that best fits your project. Genkit provides SDKs for JavaScript/TypeScript, Go, Python, and Dart with consistent APIs and capabilities across all supported languages.                                                                                                                                                                        |
-| **Deploy anywhere**           | Deploy AI logic to any environment that supports your chosen programming language, such as [Cloud Functions for Firebase](/docs/deployment/firebase), [Google Cloud Run](/docs/deployment/cloud-run), or [third-party platforms](/docs/deployment/any-platform), with or without Google services.                                                                      |
+| **Deploy anywhere**           | Deploy AI logic to any environment that supports your chosen programming language, such as [Google Cloud Run](/docs/deployment/cloud-run) or [any other platform that runs your language's binaries or containers](/docs/deployment/any-platform), with or without Google services.                                                                      |
 | **Developer tools**           | Accelerate AI development with a purpose-built, local [CLI and Developer UI](/docs/devtools). Test prompts and flows against individual inputs or datasets, compare outputs from different models, debug with detailed execution traces, and use immediate visual feedback to iterate rapidly on prompts. Coding with an AI assistant? [Genkit Agent Skills](/docs/develop-with-ai) teach it to write idiomatic Genkit code.                                                              |
 | **Production monitoring**     | Ship AI features with confidence using comprehensive production monitoring. Track model performance, request volumes, latency, and error rates in a [purpose-built dashboard](/docs/observability/getting-started). Identify issues quickly with detailed observability metrics, and ensure your AI features meet quality and performance targets in real-world usage. |
 
@@ -581,7 +608,7 @@ Some key features offered by Genkit include:
 - [AI workflows](/docs/flows)
 - [AI-powered data retrieval (RAG)](/docs/rag)
 
-Genkit is designed for server-side deployment in multiple language environments, and also provides seamless client-side integration through dedicated helpers and [client SDKs](/docs/deployment/firebase).
+Genkit is designed for server-side deployment in multiple language environments, and also provides seamless client-side integration through [dedicated client helpers](/docs/client).
 
 ## Implementation path
 

--- a/src/content/docs/docs/plugin-authoring/overview.mdx
+++ b/src/content/docs/docs/plugin-authoring/overview.mdx
@@ -571,30 +571,6 @@ hook. That shapes what your plugin may hold:
   has to arrange its own flush. See
   [Shutting down cleanly](#shutting-down-cleanly).
 
-### How the constructors are shaped
-
-Genkit has two audiences and two matching styles, and it is worth knowing which
-one you are writing against.
-
-The plugin-facing surface, `core.New*Of` and `ai.New*Action`, reads identity,
-then descriptor, then implementation. Identity is positional because it is
-always required: `core.New*Of` takes the action type and then the name, and
-`ai.New*Action` takes the name. One options struct follows and carries the
-descriptor. For `core.New*Of` it is `core.ActionOptions`, holding the
-description, the metadata, and each schema; for `ai.New*Action` it is a
-primitive-specific struct such as `ai.ModelOptions` or `ai.RetrieverOptions`,
-holding the label, the capabilities, and the config schema. The implementation
-function is positional, and optional lifecycle hooks are fields on the options
-struct. Shaped this way, a new descriptor slot or a new hook is never a
-signature break.
-
-The app-facing surface is `genkit.Define*` and the `ai.With*` request options.
-The request options, and the tool and prompt definers, stay variadic functional
-options, because an application names only the few things it cares about. Each
-`genkit.Define*Action` wrapper takes the same options struct as the plugin-side
-constructor it wraps, because it is that constructor plus registration in one
-call.
-
 ### A minimal plugin end to end
 
 Everything above fits in one file. This one serves a model that echoes the last

--- a/src/content/docs/docs/plugin-authoring/overview.mdx
+++ b/src/content/docs/docs/plugin-authoring/overview.mdx
@@ -422,14 +422,21 @@ your plugin defines, to prevent naming conflicts with other plugins.
 For example, if your plugin has an ID `yourplugin` and provides a model called
 `text-generator`, the full model identifier will be `yourplugin/text-generator`.
 
-This provider ID needs to be exported and you should define it once for your
-plugin and use it consistently when required by a Genkit function.
+Define the provider ID once and use it consistently. It can stay unexported: if
+your plugin exports a `ModelRef` helper, as the example below does, callers
+never spell the raw string.
 
 ```go
 package yourplugin
 
 const providerID = "yourplugin"
 ```
+
+Every Genkit constructor takes the action name as a plain `string`.
+`api.NewName(provider, id)` returns `provider + "/" + id`, so
+`api.NewName(providerID, "text-generator")` and the literal
+`"yourplugin/text-generator"` are the same value. This page uses `api.NewName`
+in plugin code and literals in the application-facing asides.
 
 ### Standard exports
 
@@ -477,7 +484,7 @@ func (p *MyPlugin) Init(ctx context.Context) []api.Action {
         apiKey = os.Getenv("MYPROVIDER_API_KEY")
     }
     if apiKey == "" {
-        panic("myprovider plugin initialization failed: apiKey is required")
+        panic("myprovider requires setting APIKey on the plugin or MYPROVIDER_API_KEY in the environment")
     }
     p.client = newAPIClient(apiKey)
 
@@ -502,6 +509,20 @@ plugin into the `WithPlugins()` option. In it:
 
 To the extent possible, the resources provided by your plugin shouldn't
 assume that any other plugins have been installed before this one.
+
+### Reporting an initialization failure
+
+`Init` returns no error. Genkit treats a plugin that cannot be configured as a
+startup failure, so panic. `genkit.Init` does not recover the panic: it
+propagates to the caller's `main`, which is the intended behavior, because a
+misconfigured plugin cannot serve traffic. There is no degraded-start mode.
+
+Name the provider, what is missing, and how to supply it. The in-tree plugins
+set the pattern:
+
+```go
+panic("Google AI requires setting GEMINI_API_KEY or GOOGLE_API_KEY in the environment. You can get an API key at https://ai.google.dev")
+```
 
 ### Resolving actions on demand
 
@@ -534,6 +555,22 @@ func (p *MyPlugin) ResolveAction(atype api.ActionType, id string) api.Action {
 Because an unknown ID still resolves, a curated catalog is a source of
 capability metadata rather than an allowlist.
 
+### Lifecycle and concurrency
+
+`api.Plugin` is two methods, `Name()` and `Init(ctx)`. There is no teardown
+hook. That shapes what your plugin may hold:
+
+- `Init` runs exactly once per `genkit.Init` call, before any action can run,
+  so the fields it writes need no synchronization.
+- A plugin value must not be passed to two `genkit.Init` calls. Guard it with a
+  flag and panic with `"plugin already initialized"`, as `googlegenai` does.
+- After `Init`, the same plugin pointer serves `ListActions`, `ResolveAction`,
+  and every action call, from many goroutines at once. Anything written after
+  `Init` has to be goroutine-safe.
+- Because there is no shutdown hook, a plugin that owns a flushable resource
+  has to arrange its own flush. See
+  [Shutting down cleanly](#shutting-down-cleanly).
+
 ### How the constructors are shaped
 
 Genkit has two audiences and two matching styles, and it is worth knowing which
@@ -557,6 +594,99 @@ options, because an application names only the few things it cares about. Each
 `genkit.Define*Action` wrapper takes the same options struct as the plugin-side
 constructor it wraps, because it is that constructor plus registration in one
 call.
+
+### A minimal plugin end to end
+
+Everything above fits in one file. This one serves a model that echoes the last
+user message, so you can run it without a provider account and then swap the
+generation function for a real API call.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/core/api"
+    "github.com/firebase/genkit/go/genkit"
+)
+
+const provider = "myprovider"
+
+// EchoConfig is the model's typed config. Its JSON schema is inferred from it
+// and validated on every request.
+type EchoConfig struct {
+    Prefix string `json:"prefix,omitempty"`
+}
+
+// EchoPlugin serves one model.
+type EchoPlugin struct{}
+
+func (p *EchoPlugin) Name() string { return provider }
+
+func (p *EchoPlugin) Init(ctx context.Context) []api.Action {
+    return []api.Action{
+        ai.NewModelAction(api.NewName(provider, "echo-001"),
+            &ai.ModelOptions{
+                Label:    "Echo",
+                Supports: &ai.ModelSupports{Multiturn: true, SystemRole: true},
+            },
+            func(ctx context.Context, req *ai.ModelRequest, cfg *EchoConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+                var text string
+                if n := len(req.Messages); n > 0 {
+                    text = req.Messages[n-1].Text()
+                }
+                if cfg != nil {
+                    text = cfg.Prefix + text
+                }
+
+                if cb != nil {
+                    chunk := &ai.ModelResponseChunk{
+                        Role:    ai.RoleModel,
+                        Content: []*ai.Part{ai.NewTextPart(text)},
+                    }
+                    if err := cb(ctx, chunk); err != nil {
+                        return nil, err
+                    }
+                }
+
+                return &ai.ModelResponse{
+                    Message:      ai.NewModelTextMessage(text),
+                    FinishReason: ai.FinishReasonStop,
+                    Usage:        &ai.GenerationUsage{OutputTokens: len(text)},
+                }, nil
+            }),
+    }
+}
+
+var _ api.Plugin = (*EchoPlugin)(nil)
+
+func main() {
+    ctx := context.Background()
+    g := genkit.Init(ctx, genkit.WithPlugins(&EchoPlugin{}))
+
+    out, err := genkit.GenerateText(ctx, g,
+        ai.WithModelName("myprovider/echo-001"),
+        ai.WithPrompt("hello, plugin"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(out)
+}
+```
+
+Running it prints:
+
+```
+hello, plugin
+```
+
+Run it under `genkit start -- go run .` and the model shows up in the Developer
+UI, config sidebar included, with no further work.
 
 ## Building plugin features
 
@@ -603,7 +733,7 @@ func (p *MyPlugin) newModel(id string) *ai.ModelAction {
     // An application entry corrects or extends what the plugin resolved.
     opts = opts.Overlay(p.Models[id])
 
-    return ai.NewModelAction(providerID+"/"+id, &opts,
+    return ai.NewModelAction(api.NewName(providerID, id), &opts,
         func(ctx context.Context, req *ai.ModelRequest, cfg *MyModelConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
             // cfg arrives deserialized and validated. It is nil when the caller
             // sent no config, because Config here is a pointer type.
@@ -636,6 +766,238 @@ both `ai.Model` and `api.Action`, so `Init` can return it in an `[]api.Action`
 without a type assertion. `ai.ModelOptions.Overlay` returns the receiver with
 every field set in the override replacing it, which is how an application
 corrects one capability without restating the label and the versions.
+
+#### Request and response shapes
+
+The generation function receives an `*ai.ModelRequest` and returns an
+`*ai.ModelResponse`. The request carries no model name: the plugin already knows
+which model it registered.
+
+| `ai.ModelRequest` field | Type | Meaning |
+| --- | --- | --- |
+| `Messages` | `[]*ai.Message` | The conversation history. |
+| `Config` | `any` | The raw config. The framework has already decoded it into your typed `cfg` parameter, so read `cfg` instead. |
+| `Tools` | `[]*ai.ToolDefinition` | Tools the model may ask the caller to run. |
+| `ToolChoice` | `ai.ToolChoice` | `ai.ToolChoiceAuto`, `ai.ToolChoiceRequired`, or `ai.ToolChoiceNone`. |
+| `Output` | `*ai.ModelOutputConfig` | The requested response format. |
+| `Docs` | `[]*ai.Document` | Context documents. See [Retrieval-augmented generation](/docs/rag). |
+
+The response is split between the two sides:
+
+| `ai.ModelResponse` field | Type | Who sets it |
+| --- | --- | --- |
+| `Message` | `*ai.Message` | Plugin. Required, with `Role: ai.RoleModel`. |
+| `FinishReason` | `ai.FinishReason` | Plugin. Required. |
+| `FinishMessage` | `string` | Plugin, when the provider explains why it stopped. |
+| `Usage` | `*ai.GenerationUsage` | Plugin. Strongly recommended: cost and token accounting read it. |
+| `Raw` | `any` | Plugin. The unprocessed provider payload. |
+| `Operation` | `*ai.Operation` | Plugin, for long-running background models only. |
+| `Request` | `*ai.ModelRequest` | Framework. Leave it nil. |
+| `LatencyMs` | `float64` | Framework. Leave it zero. |
+| `Custom` | `any` | Deprecated. Use `Raw`. |
+
+`ai.FinishReason` has seven values:
+
+| Constant | Meaning |
+| --- | --- |
+| `ai.FinishReasonStop` | The model finished normally. |
+| `ai.FinishReasonLength` | Generation hit the token cap. |
+| `ai.FinishReasonBlocked` | A safety or policy filter stopped it. |
+| `ai.FinishReasonOther` | The provider gave a reason none of the others cover. |
+| `ai.FinishReasonUnknown` | The provider gave no reason. |
+| `ai.FinishReasonAborted` | The request was cancelled before it completed. |
+| `ai.FinishReasonInterrupted` | A tool raised an interrupt. The framework sets this in its tool loop, never a plugin. |
+
+Map your provider's reasons onto the first five. Do not invent a value: the
+field is a string type, and Genkit treats every reason except `stop`, `length`,
+and `unknown` as an abnormal finish that skips output parsing.
+
+Fill `Usage` with what the provider billed. Besides `InputTokens`,
+`OutputTokens`, and `TotalTokens`, `ai.GenerationUsage` carries
+`CachedContentTokens`, `ThoughtsTokens`, per-modality counts such as
+`InputImages` and `OutputAudioFiles`, and `Custom map[string]float64` for
+provider metrics such as cost. See [Generating content](/docs/models) for the
+read side.
+
+A text-only conversion, end to end:
+
+```go
+func genkitResponseFromAPIResponse(req *ai.ModelRequest, apiResp *apiResponse) (*ai.ModelResponse, error) {
+    reason := ai.FinishReasonUnknown
+    switch apiResp.StopReason {
+    case "end_turn":
+        reason = ai.FinishReasonStop
+    case "max_tokens":
+        reason = ai.FinishReasonLength
+    case "safety":
+        reason = ai.FinishReasonBlocked
+    }
+
+    return &ai.ModelResponse{
+        Message:      ai.NewModelTextMessage(apiResp.Text),
+        FinishReason: reason,
+        Usage: &ai.GenerationUsage{
+            InputTokens:  apiResp.PromptTokens,
+            OutputTokens: apiResp.CompletionTokens,
+            TotalTokens:  apiResp.TotalTokens,
+        },
+        Raw: apiResp,
+    }, nil
+}
+```
+
+#### Streaming
+
+The fourth parameter of the generation function is an `ai.ModelStreamCallback`,
+an alias for `func(context.Context, *ai.ModelResponseChunk) error`.
+
+The framework passes nil when the caller did not ask for streaming. It never
+passes a no-op, so branch on `cb == nil` to pick your non-streaming transport,
+as the `googlegenai` plugin does:
+
+```go
+func (p *MyPlugin) generate(ctx context.Context, req *ai.ModelRequest, cfg *MyModelConfig, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+    apiReq, err := apiRequestFromGenkitRequest(req, cfg)
+    if err != nil {
+        return nil, err
+    }
+
+    if cb == nil {
+        apiResp, err := p.client.generate(ctx, apiReq)
+        if err != nil {
+            return nil, wrapAPIError(err)
+        }
+        return genkitResponseFromAPIResponse(req, apiResp)
+    }
+
+    stream, err := p.client.generateStream(ctx, apiReq)
+    if err != nil {
+        return nil, wrapAPIError(err)
+    }
+    defer stream.Close()
+
+    for {
+        delta, err := stream.Recv()
+        if errors.Is(err, io.EOF) {
+            break
+        }
+        if err != nil {
+            return nil, wrapAPIError(err)
+        }
+        chunk := &ai.ModelResponseChunk{
+            Role:    ai.RoleModel,
+            Content: []*ai.Part{ai.NewTextPart(delta.Text)},
+        }
+        // Stop reading the provider stream if the consumer went away.
+        if err := cb(ctx, chunk); err != nil {
+            return nil, err
+        }
+    }
+
+    return genkitResponseFromAPIResponse(req, stream.Final())
+}
+```
+
+The chunk contract:
+
+- Chunks are incremental deltas. Put only the new parts in `Content` and leave
+  `Aggregated` false. Set `Aggregated` true only if every chunk repeats
+  everything sent so far.
+- `Index` is the index of the message the chunk belongs to, which is the turn
+  index inside a tool loop, not a candidate index. Use 0 for a single-turn call.
+- `Role` is `ai.RoleModel`.
+- No terminating chunk is required.
+- `cb` is not safe for concurrent use. Call it from one goroutine at a time.
+- The framework does not aggregate chunks. The `*ai.ModelResponse` you return is
+  authoritative, so build it from the provider's final frame, not from what you
+  streamed.
+
+#### Structured output
+
+`req.Output` tells you what shape the caller wants back.
+
+| `ai.ModelOutputConfig` field | Type | Meaning |
+| --- | --- | --- |
+| `Format` | `string` | The requested format, such as `"json"` or `"text"`. |
+| `ContentType` | `string` | The MIME type of the output. |
+| `Schema` | `map[string]any` | A JSON Schema describing the desired response. |
+| `Constrained` | `bool` | Whether the provider must enforce `Schema` natively. |
+
+The contract turns on `Constrained`:
+
+- When it is true, pass `Schema` to your provider's native constrained-output
+  mechanism. Genkit is relying on the provider to enforce it.
+- When it is false, Genkit has already injected format instructions into the
+  prompt. Send the request unchanged.
+
+Genkit sets `Constrained` only when the caller asked for a schema and
+`ModelSupports.Constrained` says the model can serve it. Claim
+`ai.ConstrainedSupportAll` only once you actually wire `Schema` through:
+a false claim turns off the prompt-instruction fallback and nothing enforces
+the schema.
+
+```go
+if req.Output != nil && req.Output.Constrained && req.Output.Schema != nil {
+    apiReq.ResponseFormat = &apiResponseFormat{
+        Type:   "json_schema",
+        Schema: req.Output.Schema,
+    }
+}
+```
+
+#### Tool calling
+
+`req.Tools` holds the tools the caller made available. Translate them into your
+provider's function-declaration type.
+
+| `ai.ToolDefinition` field | Type | Meaning |
+| --- | --- | --- |
+| `Name` | `string` | The tool name the model must echo back. |
+| `Description` | `string` | What the tool does and when to use it. |
+| `InputSchema` | `map[string]any` | JSON Schema for the tool's input. |
+| `OutputSchema` | `map[string]any` | JSON Schema for the tool's output. |
+| `Metadata` | `map[string]any` | Flags Genkit attaches, such as `multipart` and `strict`. |
+| `Key` | `string` | Part of the cross-runtime schema. Go tools leave it empty. |
+
+```go
+for _, t := range req.Tools {
+    apiReq.Functions = append(apiReq.Functions, apiFunction{
+        Name:        t.Name,
+        Description: t.Description,
+        Parameters:  t.InputSchema,
+    })
+}
+```
+
+On the way back, a tool call becomes a part built with `ai.NewToolRequestPart`:
+
+```go
+var parts []*ai.Part
+for _, call := range apiResp.FunctionCalls {
+    parts = append(parts, ai.NewToolRequestPart(&ai.ToolRequest{
+        Name:  call.Name,
+        Ref:   call.ID,       // echoed back on the matching ToolResponse
+        Input: call.Arguments, // any; typically map[string]any
+    }))
+}
+resp := &ai.ModelResponse{
+    Message:      ai.NewModelMessage(parts...),
+    FinishReason: ai.FinishReasonStop,
+}
+```
+
+`ToolRequest.Input` is `any`, not a map type, so decoded JSON arguments go in
+as-is. Set `Partial` to true on a tool-call part emitted as a streaming chunk
+whose arguments are not complete yet.
+
+#### Per-request credentials
+
+Nothing in `ai.ModelRequest` carries a credential. A generation function reads
+request-scoped values from its `ctx`, so an application that needs a different
+key per caller puts it there. See [Passing information through context](/docs/context).
+On the OpenAI-compatible transport there is a ready-made path,
+`compat_oai.RequestConfig.APIKey`: it is code-only, never serializes into the
+schema or the trace, and routes that one request through a client built with it.
 
 #### Defining your model's config schema
 
@@ -672,6 +1034,33 @@ certain inputs are valid for the model. For example, if the model doesn't
 support multi-turn interactions, then it's an error to pass it a message
 history.
 
+The type has ten fields. A nil `Supports` claims nothing at all.
+
+| Field | Type | Declares | Enforced by rejecting |
+| --- | --- | --- | --- |
+| `Multiturn` | `bool` | The model accepts a message history. | A request with more than one message. |
+| `SystemRole` | `bool` | The model accepts messages with role `system`. | A request containing a system message. |
+| `Media` | `bool` | The model accepts media in the prompt. | Media parts in the request. |
+| `Tools` | `bool` | The model can call tools. | A request that carries tools. |
+| `ToolChoice` | `bool` | The caller may force or forbid tool use. | A `ToolChoice` other than `auto`. |
+| `Context` | `bool` | The model grounds on documents natively. | Nothing. When false, Genkit inlines `Docs` into the last user message instead of leaving them in `req.Docs`. |
+| `LongRunning` | `bool` | The model returns an `ai.Operation` to poll. | Nothing; it is advertised metadata. |
+| `ContentType` | `[]string` | The MIME types the model can emit. | Nothing; it is advertised metadata. |
+| `Output` | `[]string` | The output kinds the model can produce, such as `"text"` or `"json"`. | Nothing; it is advertised metadata. |
+| `Constrained` | `ai.ConstrainedSupport` | Whether the provider enforces an output schema natively. | A direct model call with `Output.Constrained` set, when the model claims none. |
+
+`Constrained` is an enum, not a bool:
+
+- `ai.ConstrainedSupportNone`, which is also the zero value, means the provider
+  cannot enforce a schema.
+- `ai.ConstrainedSupportAll` means it always can.
+- `ai.ConstrainedSupportNoTools` means it can, except when the request also
+  carries tools.
+
+Whenever the declaration does not cover the request, `ai.Generate` leaves
+`req.Output.Constrained` false and injects format instructions into the prompt
+instead, so your model function still receives a request it can serve.
+
 Note that these declarations refer to the capabilities of the model as provided
 by your plugin, and do not necessarily map one-to-one to the capabilities of the
 underlying model and model API. For example, even if the model API doesn't
@@ -702,10 +1091,24 @@ Retry and fallback middleware branch on the status an error carries, so classify
 your SDK's errors at the boundary rather than returning them raw.
 
 ```go
+import (
+    "errors"
+
+    "github.com/firebase/genkit/go/core/status"
+)
+
+// providerSDKError stands in for your SDK's error type; substitute the
+// concrete type your client returns.
+type providerSDKError struct {
+    StatusCode int
+}
+
+func (e *providerSDKError) Error() string { return "provider error" }
+
 // wrapAPIError classifies an SDK error so status-aware middleware can tell a
 // rate limit from a request the provider rejected.
 func wrapAPIError(err error) error {
-    var apiErr *apiError
+    var apiErr *providerSDKError
     if !errors.As(err, &apiErr) {
         return err
     }
@@ -716,7 +1119,8 @@ func wrapAPIError(err error) error {
 `status.FromHTTPCode` maps an HTTP status code to a canonical status name, and
 `status.Base` turns that name into the sentinel `status.Errorf` classifies with.
 Recording the cause with `%w` keeps the original error reachable through
-`errors.Is` and `errors.As`.
+`errors.Is` and `errors.As`. See [Error types](/docs/error-types) for the full
+status vocabulary and the sentinels Genkit defines.
 
 Leave anything that is not an API error unclassified. The retry middleware
 retries an unclassified error unconditionally, which is the right answer for a
@@ -724,7 +1128,9 @@ dial timeout, and the fallback middleware leaves it alone, because failing over
 to a different billed model is worth requiring an explicit classification for. A
 classified error is retried only when its status is on the middleware's list, so
 classifying a 401 as `UNAUTHENTICATED` is what stops it being reissued until the
-attempts run out. The [retry and fallback sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-middleware/retry-fallback) shows both from the application side.
+attempts run out. [Middleware](/docs/middleware) covers both from the
+application side, and the [retry and fallback sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-middleware/retry-fallback)
+is the worked example.
 
 Wrap with `%w`, never `%v`. Flattening the error destroys the classification,
 which silently turns a non-retryable `INVALID_ARGUMENT` into an unclassified
@@ -748,6 +1154,8 @@ func ModelRef(id string, config *MyModelConfig) ai.ModelRef {
 
   Callers then write
   `ai.WithModel(myplugin.ModelRef("my-model", &myplugin.MyModelConfig{...}))`.
+  `ai.NewRetrieverRef` and `ai.NewEmbedderRef` are the siblings for the other
+  primitives, with the same `(name string, config any)` signature.
 
 - A `Models map[string]ai.ModelOptions` field on the plugin struct, so an
   application can correct a capability your catalog got wrong, or describe a
@@ -768,8 +1176,16 @@ typed `Config` type parameter, validated the same way. `ai.NewBatchEvaluatorActi
 shares `ai.EvaluatorOptions` with `ai.NewEvaluatorAction`; there is no separate
 batch options type.
 
-Applications reach the same constructors through the registering
-`genkit.Define*Action` wrappers:
+The two you are most likely to write are generic over the config type:
+
+```go
+func NewRetrieverAction[Config any](name string, opts *RetrieverOptions, fn RetrieverActionFunc[Config]) *RetrieverAction
+func NewEmbedderAction[Config any](name string, opts *EmbedderOptions, fn EmbedderActionFunc[Config]) *EmbedderAction
+```
+
+`Config` is inferred from `fn`, and its JSON schema is inferred from `Config`
+unless the options struct's `ConfigSchema` overrides it. Both return an
+unregistered action, so build them as methods and return them from `Init`:
 
 ```go
 type MyRetrieverConfig struct {
@@ -780,29 +1196,70 @@ type MyEmbedderConfig struct {
     Dimensions int `json:"dimensions,omitempty" jsonschema:"minimum=1"`
 }
 
-genkit.DefineRetrieverAction(g, "myprovider/docs",
-    &ai.RetrieverOptions{Label: "My Docs"},
-    func(ctx context.Context, req *ai.RetrieverRequest, cfg *MyRetrieverConfig) (*ai.RetrieverResponse, error) {
-        k := 10
-        if cfg != nil && cfg.K > 0 {
-            k = cfg.K
-        }
-        docs, err := search(ctx, req.Query, k)
-        if err != nil {
-            return nil, err
-        }
-        return &ai.RetrieverResponse{Documents: docs}, nil
-    })
+// retrieve searches the index. req.Query is an *ai.Document.
+func (p *MyPlugin) retrieve(ctx context.Context, req *ai.RetrieverRequest, cfg *MyRetrieverConfig) (*ai.RetrieverResponse, error) {
+    k := 10
+    if cfg != nil && cfg.K > 0 {
+        k = cfg.K
+    }
+    docs, err := p.client.search(ctx, req.Query, k)
+    if err != nil {
+        return nil, wrapAPIError(err)
+    }
+    return &ai.RetrieverResponse{Documents: docs}, nil
+}
 
-genkit.DefineEmbedderAction(g, "myprovider/embed-001",
-    &ai.EmbedderOptions{Label: "My Embedder", Dimensions: 768},
-    func(ctx context.Context, req *ai.EmbedRequest, cfg *MyEmbedderConfig) (*ai.EmbedResponse, error) {
-        vectors, err := embed(ctx, req.Input)
-        if err != nil {
-            return nil, err
+// embed returns one *ai.Embedding per input document, in the same order.
+func (p *MyPlugin) embed(ctx context.Context, req *ai.EmbedRequest, cfg *MyEmbedderConfig) (*ai.EmbedResponse, error) {
+    out := make([]*ai.Embedding, 0, len(req.Input))
+    for _, d := range req.Input {
+        var text string
+        for _, part := range d.Content {
+            if part.IsText() {
+                text += part.Text
+            }
         }
-        return &ai.EmbedResponse{Embeddings: vectors}, nil
-    })
+        v, err := p.client.embed(ctx, text) // v is []float32
+        if err != nil {
+            return nil, wrapAPIError(err)
+        }
+        out = append(out, &ai.Embedding{Embedding: v})
+    }
+    return &ai.EmbedResponse{Embeddings: out}, nil
+}
+
+// Init returns both alongside whatever models the plugin serves.
+func (p *MyPlugin) Init(ctx context.Context) []api.Action {
+    return []api.Action{
+        ai.NewRetrieverAction[*MyRetrieverConfig](api.NewName(providerID, "docs"),
+            &ai.RetrieverOptions{Label: "My Docs"}, p.retrieve),
+        ai.NewEmbedderAction[*MyEmbedderConfig](api.NewName(providerID, "embed-001"),
+            &ai.EmbedderOptions{Label: "My Embedder", Dimensions: 768}, p.embed),
+    }
+}
+```
+
+`ai.EmbedRequest.Input` is `[]*ai.Document`, the same document type
+[Retrieval-augmented generation](/docs/rag) describes, and its `Options` field carries the
+raw config that the framework decoded into `cfg`. `ai.EmbedResponse.Embeddings`
+is `[]*ai.Embedding`, where `Embedding.Embedding` is a `[]float32` and the
+optional `Embedding.Metadata` identifies which part of a document the vector
+covers.
+
+#### From an application
+
+An application does not build unregistered actions. It calls the
+`genkit.Define*Action` wrappers, which take the same options struct and register
+immediately:
+
+```go
+func defineLocalRetriever(g *genkit.Genkit) {
+    genkit.DefineRetrieverAction(g, "myprovider/docs",
+        &ai.RetrieverOptions{Label: "My Docs"},
+        func(ctx context.Context, req *ai.RetrieverRequest, cfg *MyRetrieverConfig) (*ai.RetrieverResponse, error) {
+            return &ai.RetrieverResponse{Documents: search(ctx, req.Query)}, nil
+        })
+}
 ```
 
 ### Registering JSON schemas
@@ -873,6 +1330,13 @@ plugin at the endpoint and every model resolves by name, taking the OpenAI SDK's
 own request type as its config:
 
 ```go
+import (
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/compat_oai"
+    "github.com/openai/openai-go"
+)
+
 g := genkit.Init(ctx, genkit.WithPlugins(&compat_oai.OpenAICompatible{
     Provider: "myprovider",
     APIKey:   apiKey,
@@ -888,11 +1352,17 @@ The [custom provider sample](https://github.com/genkit-ai/genkit/tree/main/go/sa
 is the worked example.
 
 To give your provider a config of its own, and a home for the extensions the SDK
-request type has no room for, declare a struct that embeds
-`compat_oai.RequestConfig`, implement `ApplyToChatCompletion`, and build models
-with `compat_oai.NewChatModel[Config]`:
+request type has no room for, embed `compat_oai.OpenAICompatible` in your plugin
+struct, declare a config that embeds `compat_oai.RequestConfig`, implement
+`ApplyToChatCompletion`, and build models with `compat_oai.NewChatModel[Config]`:
 
 ```go
+type MyPlugin struct {
+    APIKey string
+
+    openAICompatible compat_oai.OpenAICompatible
+}
+
 type ChatConfig struct {
     compat_oai.RequestConfig
 
@@ -914,6 +1384,13 @@ func (p *MyPlugin) newChatModel(id string, opts ai.ModelOptions) *ai.ModelAction
     return compat_oai.NewChatModel[ChatConfig](&p.openAICompatible, id, opts)
 }
 ```
+
+`Init` must populate `p.openAICompatible.Provider`, `APIKey` or `Opts`, and
+`BaseURL` before it builds any model. The `Config` type parameter has to satisfy
+`compat_oai.ChatConfig`, which embedding `compat_oai.RequestConfig` plus your own
+`ApplyToChatCompletion` provides. See
+[OpenAI-compatible APIs](/docs/integrations/openai-compatible) for `openai.Float`,
+`openai.ChatCompletionNewParams`, and `RequestConfig.ApplyVersion`.
 
 Embedding `RequestConfig` gives every config three shared settings: a code-only
 `APIKey` for a per-request credential, `Version` to pin an exact model version,
@@ -977,95 +1454,114 @@ and the page [A Guide to Writing `slog` Handlers](https://github.com/golang/exam
 
 #### Building the plugin
 
-##### Dependencies
-
-Every telemetry plugin needs to import the Genkit core library and several
-OpenTelemetry libraries:
-
-```go
-// Import the Genkit tracing library.
-"github.com/firebase/genkit/go/core/tracing"
-
-// Import the OpenTelemetry libraries.
-"go.opentelemetry.io/otel"
-"go.opentelemetry.io/otel/sdk/metric"
-sdktrace "go.opentelemetry.io/otel/sdk/trace"
-```
-
-If you are building a plugin around an existing OpenTelemetry or `slog`
-integration, you will also need to import them.
-
-##### `Config`
-
-A telemetry plugin should, at a minimum, support the following configuration
-options:
+A telemetry plugin is an ordinary `api.Plugin` that registers no actions. Keep
+its configuration as fields on the plugin struct so `Init` has it in scope, and
+keep the providers it creates so it can flush them later.
 
 ```go
+package mytelemetry
+
+import (
+    "context"
+    "errors"
+    "log/slog"
+    "os"
+    "time"
+
+    "github.com/firebase/genkit/go/core/api"
+    "github.com/firebase/genkit/go/core/tracing"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/sdk/metric"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Config holds the settings every telemetry plugin should accept. Most plugins
+// add settings for the service they export to, such as an API key or a project.
 type Config struct {
-    // Export even in the dev environment.
+    // ForceExport exports even in the dev environment.
     ForceExport bool
 
-    // The interval for exporting metric data.
-    // The default is 60 seconds.
+    // MetricInterval is how often metric data is exported. Genkit's own
+    // exporters use 5s in dev and 5min in production; pick what suits your
+    // backend rather than copying a number from here.
     MetricInterval time.Duration
 
-    // The minimum level at which logs will be written.
-    // Defaults to [slog.LevelInfo].
+    // LogLevel is the minimum level at which logs are written.
+    // Defaults to slog.LevelInfo.
     LogLevel slog.Leveler
 }
-```
 
-Most plugins will also include configuration settings for the service it's
-exporting to (API key, project name, and so on).
+// Plugin exports Genkit telemetry to your service.
+type Plugin struct {
+    Config
 
-##### `Init()`
+    meterProvider *metric.MeterProvider
+}
 
-The `Init()` function of a telemetry plugin should do all of the following:
+// Name returns the provider ID.
+func (p *Plugin) Name() string { return "mytelemetry" }
 
-- Return early if Genkit is running in a development environment (such as when
-  running with with `genkit start`) and the `Config.ForceExport` option isn't
-  set:
+// Init configures the OpenTelemetry SDK. It registers no actions.
+func (p *Plugin) Init(ctx context.Context) []api.Action {
+    // Stay quiet in the dev environment, such as under `genkit start`, unless
+    // the application asked otherwise.
+    if !p.ForceExport && os.Getenv("GENKIT_ENV") == "dev" {
+        return nil
+    }
 
-```go
-shouldExport := cfg.ForceExport || os.Getenv("GENKIT_ENV") != "dev"
-if !shouldExport {
-  return nil
+    // Traces: register a span processor on Genkit's tracer provider.
+    exporter := &redactingSpanExporter{SpanExporter: newSpanExporter()}
+    tracing.TracerProvider().RegisterSpanProcessor(sdktrace.NewBatchSpanProcessor(exporter))
+
+    // Metrics: a periodic reader on the configured interval.
+    interval := p.MetricInterval
+    if interval == 0 {
+        interval = time.Minute
+    }
+    reader := metric.NewPeriodicReader(newMetricExporter(), metric.WithInterval(interval))
+    p.meterProvider = metric.NewMeterProvider(metric.WithReader(reader))
+    otel.SetMeterProvider(p.meterProvider)
+
+    // Logs: your slog handler, honoring the configured minimum level.
+    level := p.LogLevel
+    if level == nil {
+        level = slog.LevelInfo
+    }
+    slog.SetDefault(slog.New(newLogHandler(&slog.HandlerOptions{Level: level})))
+
+    return nil
 }
 ```
 
-- Initialize your trace span exporter and register it with Genkit:
+`newSpanExporter`, `newMetricExporter`, and `newLogHandler` stand in for your
+service's implementations of `sdktrace.SpanExporter`, `metric.Exporter`, and
+`slog.Handler`.
+
+#### Shutting down cleanly
+
+`api.Plugin` has no teardown hook, and both a batch span processor and a
+periodic reader buffer. A process that exits without flushing loses whatever is
+in those buffers. Expose a `Shutdown` the application defers:
 
 ```go
-spanProcessor := sdktrace.NewBatchSpanProcessor(YourCustomSpanExporter{})
-tracing.TracerProvider().RegisterSpanProcessor(spanProcessor)
+// Shutdown flushes and stops both pipelines. Call it before the process exits:
+//
+//	tel := &mytelemetry.Plugin{}
+//	g := genkit.Init(ctx, genkit.WithPlugins(tel))
+//	defer tel.Shutdown(context.Background())
+func (p *Plugin) Shutdown(ctx context.Context) error {
+    var errs error
+    if p.meterProvider != nil {
+        errs = errors.Join(errs, p.meterProvider.Shutdown(ctx))
+    }
+    return errors.Join(errs, tracing.TracerProvider().Shutdown(ctx))
+}
 ```
 
-- Initialize your metric exporter and register it with the OpenTelemetry
-  library:
-
-```go
-r := metric.NewPeriodicReader(
-  YourCustomMetricExporter{},
-  metric.WithInterval(cfg.MetricInterval),
-)
-mp := metric.NewMeterProvider(metric.WithReader(r))
-otel.SetMeterProvider(mp)
-```
-
-Use the user-configured collection interval (`Config.MetricInterval`) when
-initializing the `PeriodicReader`.
-
-- Register your `slog` handler as the default logger:
-
-```go
-logger := slog.New(YourCustomHandler{
-  Options: &slog.HandlerOptions{Level: cfg.LogLevel},
-})
-slog.SetDefault(logger)
-```
-
-You should configure your handler to honor the user-specified minimum log
-level (`Config.LogLevel`).
+The in-tree `googlecloud` plugin takes the other route and installs its own
+`SIGINT` and `SIGTERM` handler that flushes and then exits. That works for a
+server, but it takes the exit path away from the application, so prefer the
+explicit `Shutdown` unless you have a reason not to.
 
 #### PII redaction
 
@@ -1084,12 +1580,19 @@ task. For example, the `googlecloud` plugin removes the `genkit:input` and
 similar to the following:
 
 ```go
+import (
+    "context"
+
+    "go.opentelemetry.io/otel/attribute"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
 type redactingSpanExporter struct {
-    trace.SpanExporter
+    sdktrace.SpanExporter
 }
 
-func (e *redactingSpanExporter) ExportSpans(ctx context.Context, spanData []trace.ReadOnlySpan) error {
-    var redacted []trace.ReadOnlySpan
+func (e *redactingSpanExporter) ExportSpans(ctx context.Context, spanData []sdktrace.ReadOnlySpan) error {
+    redacted := make([]sdktrace.ReadOnlySpan, 0, len(spanData))
     for _, s := range spanData {
         redacted = append(redacted, redactedSpan{s})
     }
@@ -1101,7 +1604,7 @@ func (e *redactingSpanExporter) Shutdown(ctx context.Context) error {
 }
 
 type redactedSpan struct {
-    trace.ReadOnlySpan
+    sdktrace.ReadOnlySpan
 }
 
 func (s redactedSpan) Attributes() []attribute.KeyValue {
@@ -1117,11 +1620,15 @@ func (s redactedSpan) Attributes() []attribute.KeyValue {
 }
 ```
 
+The attribute keys are `genkit:input` and `genkit:output`, with a colon. Genkit
+writes them in `core/tracing`, so a wrapper that filters on any other spelling
+redacts nothing.
+
 #### Troubleshooting
 
-If you're having trouble getting data to show up where you expect, OpenTelemetry
-provides a useful [diagnostic tool](https://opentelemetry.io/docs/languages/js/getting-started/nodejs/#troubleshooting)
-that helps locate the source of the problem.
+If you're having trouble getting data to show up where you expect, the
+[OpenTelemetry Go documentation](https://opentelemetry.io/docs/languages/go/)
+covers SDK diagnostics that help locate the source of the problem.
 
 ## Finding the constructor to call
 
@@ -1187,6 +1694,19 @@ good choices:
 
 - `github.com/yourorg/genkit-plugins/servicename`
 - `github.com/yourorg/your-repo/genkit/servicename`
+
+## Next steps
+
+- Run your plugin under the [Developer UI](/docs/devtools) to check that its
+  models, capability metadata, and config schema look the way you meant.
+- Read [Error types](/docs/error-types) before you classify your provider's
+  errors, and [Middleware](/docs/middleware) to see what that classification
+  buys the application.
+- Read two in-tree plugins as references:
+  [`googlegenai`](https://github.com/genkit-ai/genkit/tree/main/go/plugins/googlegenai)
+  for a native SDK, and
+  [`compat_oai`](https://github.com/genkit-ai/genkit/tree/main/go/plugins/compat_oai)
+  for the OpenAI-compatible path.
 
 </Lang>
 

--- a/src/content/docs/docs/rag.mdx
+++ b/src/content/docs/docs/rag.mdx
@@ -520,10 +520,11 @@ strategies.
 <Lang lang="go">
 
 RAG is a very broad area and there are many different techniques used to achieve
-the best quality RAG. The core Genkit framework offers two main abstractions to
+the best quality RAG. The core Genkit framework offers three main abstractions to
 help you do RAG:
 
-- Embedders: transforms documents into a vector representation
+- Indexers: keep track of your documents so relevant ones can be retrieved for a query.
+- Embedders: transforms documents into a vector representation.
 - Retrievers: retrieve documents from an "index", given a query.
 
 These definitions are broad on purpose because Genkit is un-opinionated about
@@ -549,24 +550,50 @@ data.
 To create a retriever, you can use one of the provided implementations or
 create your own.
 
+### Indexers
+
+The index is responsible for keeping track of your documents so that you can
+quickly retrieve the relevant ones for a query. This is most often a vector
+database: it stores each document alongside its embedding, and retrieves
+documents whose embeddings sit close to the embedding of the query.
+
+Before you can retrieve documents you have to ingest them. A typical ingestion
+pipeline does three things:
+
+1. Split large documents into chunks, so that only the relevant portion
+   augments your prompt and so each chunk fits comfortably in the model's
+   context window. Genkit does not ship a chunker; any Go text splitter works.
+2. Generate an embedding for each chunk.
+3. Write the chunk and its vector to the store.
+
+Ingestion is a batch job, not something that runs per request. Run it once for a
+stable corpus, or on a trigger whenever the source data changes.
+
+Go has no separate indexer action type. Indexing goes through the store handle
+that the plugin's `DefineRetriever` returns alongside the retriever, for example
+`*localvec.DocStore` with `localvec.Index`.
+
 ## Supported retrievers and embedders
 
-Genkit provides retriever support through its plugin system. The
-following plugins are officially supported:
+Genkit provides retriever support through its plugin system:
 
-- [Pinecone](/docs/integrations/pinecone) cloud vector database
-
-In addition, Genkit supports the following vector stores through predefined
-code templates, which you can customize for your database configuration and
-schema:
-
-- PostgreSQL with [`pgvector`](/docs/integrations/pgvector)
+| Vector store                                                                            | Use it when                                                                     |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Dev local vector store](/docs/integrations/dev-local-vectorstore)                        | Prototyping on one machine. Development only; do not use it in production.       |
+| [Pinecone](/docs/integrations/pinecone)                                                   | You want a managed cloud vector database with no database to operate.            |
+| [AlloyDB for PostgreSQL](/docs/integrations/alloydb)                                      | Your data already lives in AlloyDB and you want pgvector search next to it.      |
+| [Cloud SQL for PostgreSQL](/docs/integrations/cloud-sql-postgresql)                       | Same, on managed PostgreSQL.                                                     |
+| [Cloud Firestore vector search](/docs/integrations/cloud-firestore)                       | Your documents are already Firestore documents.                                  |
+| [Vertex AI Vector Search with BigQuery](/docs/integrations/vectorsearch-bigquery)         | Your corpus is in BigQuery and you want Vertex AI to serve the index.            |
+| [Vertex AI Vector Search with Firestore](/docs/integrations/vectorsearch-firestore)       | Same, with Firestore as the document store.                                      |
+| [Self-managed pgvector](/docs/integrations/pgvector)                                      | You run your own PostgreSQL. This is a code template, not a plugin.              |
 
 Embedding model support is provided through the following plugins:
 
-| Plugin                                                  | Models         |
-| ------------------------------------------------------- | -------------- |
-| [Google Generative AI](/docs/integrations/google-genai) | Text embedding |
+| Plugin                                                  | Embedders                                                                |
+| ------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Google Generative AI](/docs/integrations/google-genai) | `googleai/gemini-embedding-001` and the other Gemini API text embedders. |
+| [Vertex AI](/docs/integrations/vertex-ai)               | `vertexai/text-embedding-004`, `vertexai/text-embedding-005` and others. |
 
 ## Defining a RAG flow
 
@@ -574,6 +601,22 @@ The following examples show how you could ingest a collection of restaurant menu
 PDF documents into a vector database and retrieve them for use in a flow that
 determines what food items are available. The [rag sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/rag) is a runnable version of the same shape against the local vector store, and the [pgvector sample](https://github.com/genkit-ai/genkit/tree/main/go/samples/pgvector) is the PostgreSQL equivalent.
 _Note_: Although retriever functions are defined using Genkit, users are expected to add their own functionality to index the documents.
+
+### Prerequisites
+
+This walkthrough registers the [Vertex AI plugin](/docs/integrations/vertex-ai),
+which authenticates with Application Default Credentials. Before you run it:
+
+```bash
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT=your-project-id
+export GOOGLE_CLOUD_LOCATION=us-central1
+```
+
+To use `googleai/...` models and embedders instead, register
+`&googlegenai.GoogleAI{}` and set `GEMINI_API_KEY`. Provider prefixes are not
+interchangeable: a `googleai/` name only resolves if the Google AI plugin is
+registered, and likewise for `vertexai/`.
 
 ### Install dependencies
 
@@ -585,104 +628,142 @@ go get github.com/tmc/langchaingo/textsplitter
 go get github.com/ledongthuc/pdf
 ```
 
-#### Create chunking config
+Neither is a Genkit dependency. Any Go text splitter and any PDF reader work
+here; these two just keep the example short.
 
-This example uses the `textsplitter` library which provides a simple text
-splitter to break up documents into segments that can be vectorized.
+### The complete program
 
-The following definition configures the chunking function to return document
-segments of 200 characters, with an overlap between chunks of 20 characters.
+Everything below is one `main` package. Later sections walk through the pieces.
 
 ```go
-splitter := textsplitter.NewRecursiveCharacter(
-	textsplitter.WithChunkSize(200),
-	textsplitter.WithChunkOverlap(20),
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"github.com/firebase/genkit/go/plugins/localvec"
+	"github.com/firebase/genkit/go/plugins/server"
+	"github.com/ledongthuc/pdf"
+	"github.com/tmc/langchaingo/textsplitter"
 )
-```
 
-More chunking options for this library can be found in the
-[`langchaingo` documentation](https://pkg.go.dev/github.com/tmc/langchaingo/textsplitter#Option).
+func main() {
+	ctx := context.Background()
 
-### Initialize Genkit and vector store
+	// Initialize Genkit with the Vertex AI plugin.
+	g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
 
-Before defining the flows, initialize the Genkit instance and the vector store.
-This prepares the `menuDocStore` for indexing and the `menuPdfRetriever` for retrieval.
+	// Initialize the local vector store plugin.
+	if err := localvec.Init(); err != nil {
+		log.Fatal(err)
+	}
 
-```go
-ctx := context.Background()
+	embedder := genkit.LookupEmbedder(g, "vertexai/text-embedding-004")
+	if embedder == nil {
+		log.Fatal("embedder vertexai/text-embedding-004 is not registered")
+	}
 
-// Initialize Genkit with the Vertex AI plugin
-g := genkit.Init(ctx, genkit.WithPlugins(&googlegenai.VertexAI{}))
+	// Define the retriever and document store. We keep menuDocStore for the
+	// indexer flow and menuPdfRetriever for the retrieval flow.
+	menuDocStore, menuPdfRetriever, err := localvec.DefineRetriever(
+		g,
+		"menuQA",
+		localvec.Config{
+			Dir:      ".genkit/localvec",
+			Embedder: embedder,
+		},
+		nil,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-// Initialize the Local Vector Store plugin
-if err := localvec.Init(); err != nil {
-    log.Fatal(err)
+	splitter := textsplitter.NewRecursiveCharacter(
+		textsplitter.WithChunkSize(200),
+		textsplitter.WithChunkOverlap(20),
+	)
+
+	genkit.DefineFlow(g, "indexMenu",
+		func(ctx context.Context, path string) (map[string]any, error) {
+			// Extract plain text from the PDF. Wrap the logic in Run so it
+			// appears as a step in your traces.
+			pdfText, err := genkit.Run(ctx, "extract", func() (string, error) {
+				return readPDF(path)
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// Split the text into chunks. Wrap the logic in Run so it appears
+			// as a step in your traces.
+			docs, err := genkit.Run(ctx, "chunk", func() ([]*ai.Document, error) {
+				chunks, err := splitter.SplitText(pdfText)
+				if err != nil {
+					return nil, err
+				}
+
+				var docs []*ai.Document
+				for i, chunk := range chunks {
+					docs = append(docs, ai.DocumentFromText(chunk, map[string]any{
+						"id":     fmt.Sprintf("%s#%d", path, i),
+						"source": path,
+					}))
+				}
+				return docs, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// Add chunks to the index using the vector store.
+			if err := localvec.Index(ctx, docs, menuDocStore); err != nil {
+				return nil, err
+			}
+
+			return map[string]any{
+				"success":          true,
+				"documentsIndexed": len(docs),
+			}, nil
+		})
+
+	genkit.DefineFlow(g, "menuQA",
+		func(ctx context.Context, question string) (string, error) {
+			// Retrieve text relevant to the user's question.
+			resp, err := genkit.Retrieve(ctx, g,
+				ai.WithRetriever(menuPdfRetriever),
+				ai.WithConfig(&localvec.RetrieverOptions{K: 3}),
+				ai.WithTextDocs(question))
+			if err != nil {
+				return "", err
+			}
+			if len(resp.Documents) == 0 {
+				return "I don't have that in the indexed material.", nil
+			}
+
+			// Call Generate, including the menu information in your prompt.
+			return genkit.GenerateText(ctx, g,
+				ai.WithModelName("vertexai/gemini-flash-latest"),
+				ai.WithDocs(resp.Documents...),
+				ai.WithSystem(`
+You are acting as a helpful AI assistant that can answer questions about the
+food available on the menu at Genkit Grub Pub.
+Use only the context provided to answer the question. If you don't know, do not
+make up an answer. Do not add or change items on the menu.`),
+				ai.WithPrompt(question))
+		})
+
+	// Keep the process alive so the CLI and the developer UI can reach the
+	// flows. Ctrl-C stops it.
+	log.Fatal(server.Start(ctx, "127.0.0.1:3400", nil))
 }
 
-// Define the Retriever and Document Store.
-// We capture 'menuDocStore' to use in the Indexer Flow,
-// and 'menuPdfRetriever' to use in the Retrieval Flow.
-menuDocStore, menuPdfRetriever, err := localvec.DefineRetriever(
-    g,
-    "menuQA",
-    localvec.Config{
-        Embedder: googlegenai.VertexAIEmbedder(g, "text-embedding-004"),
-    },
-    nil,
-)
-if err != nil {
-    log.Fatal(err)
-}
-```
-
-#### Define your indexer flow
-
-```go
-genkit.DefineFlow(
-    g, "indexMenu",
-    func(ctx context.Context, path string) (any, error) {
-        // Extract plain text from the PDF. Wrap the logic in Run so it
-        // appears as a step in your traces.
-        pdfText, err := genkit.Run(ctx, "extract", func() (string, error) {
-            return readPDF(path)
-        })
-        if err != nil {
-            return nil, err
-        }
-
-        // Split the text into chunks. Wrap the logic in Run so it appears as a
-        // step in your traces.
-        docs, err := genkit.Run(ctx, "chunk", func() ([]*ai.Document, error) {
-            chunks, err := splitter.SplitText(pdfText)
-            if err != nil {
-                return nil, err
-            }
-
-            var docs []*ai.Document
-            for _, chunk := range chunks {
-                docs = append(docs, ai.DocumentFromText(chunk, nil))
-            }
-            return docs, nil
-        })
-        if err != nil {
-            return nil, err
-        }
-
-        // Add chunks to the index using the vector store
-        if err := localvec.Index(ctx, docs, menuDocStore); err != nil {
-            return nil, err
-        }
-
-        return map[string]interface{}{
-            "success": true,
-            "documentsIndexed": len(docs),
-        }, nil
-    },
-)
-```
-
-```go
-// Helper function to extract plain text from a PDF. Excerpted from
+// readPDF extracts plain text from a PDF. Excerpted from
 // https://github.com/ledongthuc/pdf
 func readPDF(path string) (string, error) {
 	f, r, err := pdf.Open(path)
@@ -707,42 +788,92 @@ func readPDF(path string) (string, error) {
 }
 ```
 
+#### Chunking config
+
+The `textsplitter` call above configures the chunking function to return
+document segments of 200 characters, with an overlap between chunks of 20
+characters. More chunking options for this library can be found in the
+[`langchaingo` documentation](https://pkg.go.dev/github.com/tmc/langchaingo/textsplitter#Option).
+
+#### Document metadata
+
+`ai.DocumentFromText(text string, metadata map[string]any) *ai.Document` builds
+a document from a string. `ai.Document` has two fields: `Content []*ai.Part` and
+`Metadata map[string]any`. The local vector store persists the whole document,
+so whatever metadata you attach at index time comes back on every retrieved
+document. Use it for IDs, titles and source paths. The `id` key doubles as the
+citation marker the model sees; see [Citations](#citations).
+
 #### Run the indexer flow
 
 ```bash
-genkit flow:run indexMenu '"menu.pdf"'
+genkit flow:run indexMenu '"menu.pdf"' -- go run .
 ```
+
+Run this from the module directory. `menu.pdf` is resolved relative to that
+directory.
 
 After running the `indexMenu` flow, the vector database will be seeded with
 documents and ready to be used in Genkit flows with retrieval steps.
 
-### Define a flow with retrieval
+### Calling a retriever
 
-The following example shows how you might use a retriever in a RAG flow. This
-example uses Genkit's file-based vector retriever, which you should not use in production.
+`genkit.Retrieve(ctx, g, ai.WithRetriever(r), ai.WithTextDocs(q))` is the form
+to reach for. It resolves the retriever through the registry and records the
+call as a traced step. Three variants exist and none of them is deprecated:
+
+| Call                                  | Use it when                                                                             |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `genkit.Retrieve(ctx, g, opts...)`    | Default. You have a `*genkit.Genkit`.                                                     |
+| `ai.Retrieve(ctx, reg, opts...)`      | Same call, with the registry passed explicitly, for code that has no `*genkit.Genkit`.    |
+| `r.Retrieve(ctx, req)`                | You hold the `ai.Retriever` and want to build the `ai.RetrieverRequest` yourself.         |
+
+You can name a registered retriever instead of holding its value. Plugin
+retrievers register under a provider prefix; the local vector store uses
+`devLocalVectorStore/<name>`:
 
 ```go
-genkit.DefineFlow(
-  g, "menuQA",
-  func(ctx context.Context, question string) (string, error) {
-    // Retrieve text relevant to the user's question.
-    resp, err := genkit.Retrieve(ctx, g, ai.WithRetriever(menuPdfRetriever), ai.WithTextDocs(question))
-    if err != nil {
-        return "", err
-    }
-
-    // Call Generate, including the menu information in your prompt.
-    return genkit.GenerateText(ctx, g,
-        ai.WithModelName("googleai/gemini-flash-latest"),
-        ai.WithDocs(resp.Documents...),
-        ai.WithSystem(`
-You are acting as a helpful AI assistant that can answer questions about the
-food available on the menu at Genkit Grub Pub.
-Use only the context provided to answer the question. If you don't know, do not
-make up an answer. Do not add or change items on the menu.`),
-        ai.WithPrompt(question))
-  })
+resp, err := genkit.Retrieve(ctx, g,
+	ai.WithRetrieverName("devLocalVectorStore/menuQA"),
+	ai.WithDocs(ai.DocumentFromText(question, nil)))
 ```
+
+### When retrieval comes back empty or weak
+
+`ai.RetrieverResponse` carries `Documents` and nothing else. There is no score
+field, so you cannot filter on relevance after the fact. Guard on the count
+before you call the model, as the `menuQA` flow above does:
+
+```go
+if len(resp.Documents) == 0 {
+	return "I don't have that in the indexed material.", nil
+}
+```
+
+A relevance floor is only available where the store's own options support one,
+for example a `MIN_SCORE` predicate in a pgvector query you write yourself. The
+local vector store ranks by cosine similarity internally but returns the top `K`
+documents with no scores, so `K` is its only relevance control.
+
+### Citations
+
+Documents passed with `ai.WithDocs` land on the request's `Docs` field. What
+happens next depends on the model:
+
+- A model that declares `Supports.Context` receives the documents natively.
+  Genkit inserts no markers, and rendering citations in your UI is up to you.
+- Every other model goes through Genkit's augment-with-context middleware, which
+  appends the documents to the last user message as lines of the form
+  `- [<id>]: <text>`.
+
+The bracketed key comes from `ai.AugmentWithContextOptions.CitationKey`. With
+the default settings it is `Metadata["ref"]`, else `Metadata["id"]`, else the
+zero-based index of the document. Set stable IDs at index time, as the indexer
+flow above does, to make those citations addressable.
+
+Only the document text and that one metadata value reach the model. The rest of
+`Metadata` stays on your side, so you do not need to duplicate document text
+into your prompt.
 
 ## Write your own retrievers
 
@@ -805,6 +936,24 @@ advancedMenuRetriever := genkit.DefineRetrieverAction(
 `genkit.DefineRetrieverAction` infers the retriever's config schema from the type of its last function parameter and validates every request against it, so your function receives a typed value instead of an `any` it has to assert. A request that carries a key the schema does not allow fails with `INVALID_ARGUMENT` before your code runs.
 
 _Note_: The `rerank` function is a placeholder for your own logic and is not provided by the Genkit framework.
+
+### The request your retriever receives
+
+`ai.RetrieverRequest` has exactly two fields:
+
+- `Query *ai.Document`: the query, expressed as a document so you can hand it
+  straight to an embedder.
+- `Options any`: the raw per-request config, as set by `ai.WithConfig`.
+
+Retrievers defined with `genkit.DefineRetrieverAction` get that config decoded
+into the typed last parameter and should ignore `req.Options`, which the
+framework normalizes to the same value.
+
+`genkit.DefineRetriever(g, name, opts, fn)` is the older non-generic form. Its
+callback is `ai.RetrieverFunc`,
+`func(ctx context.Context, req *ai.RetrieverRequest) (*ai.RetrieverResponse, error)`,
+so it has to read and type-assert `req.Options` itself. It is deprecated in
+favor of `DefineRetrieverAction`.
 
 </Lang>
 
@@ -897,7 +1046,7 @@ Any async function that returns `list[Document]` can supply context: call databa
 ## Next steps
 
 - Learn about [tool calling](/docs/tool-calling) to give your RAG system access to external APIs and functions
-- Explore [multi-agent systems](/docs/multi-agent) for coordinating multiple AI agents with RAG capabilities
+- Explore [full-stack agents](/docs/agents/overview) for coordinating multiple AI agents with RAG capabilities
 - See the [evaluation guide](/docs/evaluation) for testing and improving your RAG system's performance
 
 <Lang lang="js">

--- a/src/content/docs/docs/testing.mdx
+++ b/src/content/docs/docs/testing.mdx
@@ -3,6 +3,7 @@ title: Testing your AI logic
 description: Learn how to unit-test Genkit flows, prompts, and tools deterministically with mockModel and echoModel - no live model, network, or API key required.
 supportedLanguages:
   - js
+  - go
 ---
 
 import Lang from '../../../components/Lang.astro';
@@ -494,5 +495,482 @@ implementation. It is unrelated to app-level unit testing; see
 - [Tool calling](/docs/tool-calling) - how tool round-trips work
 - [Interrupts](/docs/interrupts) - pausing generation for human input
 - [Evaluation](/docs/evaluation) - assessing real model output quality
+
+</Lang>
+
+<Lang lang="go">
+
+The logic around your model calls — prompt assembly, structured output handling,
+tool wiring, and your flow's own business rules — is ordinary Go, and you test it
+with ordinary `go test`. There is no special test runner and no separate testing
+package: you register a **fake model** on a Genkit instance and run your flow
+against it, so tests are deterministic and need no network or API key.
+
+:::note
+Testing verifies your app's _deterministic_ logic. To assess the _quality_ of a
+real model's output — relevance, groundedness, safety — use
+[Evaluation](/docs/evaluation) instead. The two are complementary.
+:::
+
+## Make your flow testable
+
+The only structural requirement is that your flow takes the `*genkit.Genkit`
+handle as a parameter instead of reading a package-level global. That is what
+lets a test hand it an instance with a fake model registered.
+
+```go title="summarize.go"
+package app
+
+import (
+	"context"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/genkit"
+)
+
+type Summary struct {
+	Headline string   `json:"headline"`
+	Bullets  []string `json:"bullets"`
+}
+
+// NewSummarizeFlow takes g and the model name so a test can swap both.
+func NewSummarizeFlow(g *genkit.Genkit, model string) *core.Flow[string, Summary, struct{}] {
+	return genkit.DefineFlow(g, "summarize",
+		func(ctx context.Context, article string) (Summary, error) {
+			out, _, err := genkit.GenerateData[Summary](ctx, g,
+				ai.WithModelName(model),
+				ai.WithSystem("Summarize the article. Three bullets, no more."),
+				ai.WithPrompt("%s", article),
+			)
+			if err != nil {
+				return Summary{}, err
+			}
+			return *out, nil
+		})
+}
+```
+
+`genkit.DefineFlow` returns a `*core.Flow[In, Out, Stream]` from
+`github.com/firebase/genkit/go/core`. That is the type to name when you store a
+flow in a struct field or pass it to a helper.
+
+## Write a fake model
+
+A fake model is just a model action whose function returns whatever you tell it
+to. `genkit.DefineModelAction` registers it under a name your flow can resolve,
+and because the function closes over a struct, the same fake can also record
+every request it received.
+
+```go title="fake_test.go"
+type fake struct {
+	Requests []*ai.ModelRequest   // every request received, in order
+	Replies  []*ai.ModelResponse  // one per call; the last one repeats
+	Err      error                // when set, returned instead of a reply
+	Chunks   []string             // streamed before the reply
+}
+
+func (f *fake) register(t *testing.T, g *genkit.Genkit, name string) {
+	t.Helper()
+	genkit.DefineModelAction(g, name, &ai.ModelOptions{
+		// Claim the capabilities your test depends on. Genkit rewrites requests
+		// for models that do not claim them: with SystemRole false, the system
+		// prompt is folded into a user message prefixed "SYSTEM INSTRUCTIONS:",
+		// which will surprise you when you assert on it.
+		Supports: &ai.ModelSupports{Multiturn: true, Tools: true, SystemRole: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, _ struct{}, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		f.Requests = append(f.Requests, req)
+		if f.Err != nil {
+			return nil, f.Err
+		}
+		if cb != nil {
+			for _, c := range f.Chunks {
+				if err := cb(ctx, &ai.ModelResponseChunk{
+					Role:    ai.RoleModel,
+					Content: []*ai.Part{ai.NewTextPart(c)},
+				}); err != nil {
+					return nil, err
+				}
+			}
+		}
+		i := min(len(f.Requests)-1, len(f.Replies)-1)
+		return f.Replies[i], nil
+	})
+}
+
+func textReply(s string) *ai.ModelResponse {
+	return &ai.ModelResponse{FinishReason: ai.FinishReasonStop, Message: ai.NewModelTextMessage(s)}
+}
+```
+
+`genkit.Init(ctx)` with no plugins is enough for a test: it registers no
+providers, reads no credentials, and starts no reflection server, because
+`GENKIT_ENV` is unset and Genkit defaults to the production environment. Build a
+fresh instance per test so registrations cannot leak between them.
+
+## Test structured output
+
+The fake returns the JSON your schema expects, and the assertion is on the
+decoded Go value:
+
+```go
+func TestStructuredOutput(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+
+	want := Summary{Headline: "Go 1.24 lands", Bullets: []string{"a", "b", "c"}}
+	body, _ := json.Marshal(want)
+	f := &fake{Replies: []*ai.ModelResponse{textReply(string(body))}}
+	f.register(t, g, "fake/structured")
+
+	got, err := NewSummarizeFlow(g, "fake/structured").Run(ctx, "Go 1.24 was released today.")
+	if err != nil {
+		t.Fatalf("flow: %v", err)
+	}
+	if got.Headline != want.Headline || len(got.Bullets) != 3 {
+		t.Fatalf("got %+v", got)
+	}
+}
+```
+
+Returning JSON that does not satisfy the schema is also worth a test: Genkit
+validates the model's output and the flow returns an error rather than a
+half-filled struct.
+
+## Assert what the model received
+
+`f.Requests` is the whole point of recording. Use it to pin prompt assembly, so
+a careless edit to a system prompt fails a test instead of shipping:
+
+```go
+func TestPromptAssembly(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	body, _ := json.Marshal(Summary{Headline: "x", Bullets: []string{"a"}})
+	f := &fake{Replies: []*ai.ModelResponse{textReply(string(body))}}
+	f.register(t, g, "fake/prompt")
+
+	if _, err := NewSummarizeFlow(g, "fake/prompt").Run(ctx, "an article about badgers"); err != nil {
+		t.Fatalf("flow: %v", err)
+	}
+
+	var system, user string
+	for _, m := range f.Requests[0].Messages {
+		switch m.Role {
+		case ai.RoleSystem:
+			system = m.Text()
+		case ai.RoleUser:
+			user = m.Text()
+		}
+	}
+	if !strings.Contains(system, "Three bullets") {
+		t.Errorf("system prompt = %q", system)
+	}
+	if !strings.Contains(user, "badgers") {
+		t.Errorf("user prompt = %q", user)
+	}
+}
+```
+
+The request also carries the output schema Genkit derived from your Go type, in
+a user-role part tagged `metadata["purpose"] == "output"`. Assert on it when the
+schema itself is the thing you care about.
+
+## Test tool calling
+
+Script two replies: the first asks for the tool, the second answers using its
+result. Genkit runs the loop, so the test proves your tool was called with the
+input you expect and that its output reached the second request.
+
+```go
+func TestToolCalling(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+
+	var called int
+	wordCount := genkit.DefineTool(g, "wordCount", "Counts words in a string.",
+		func(_ *ai.ToolContext, in struct {
+			Text string `json:"text"`
+		}) (int, error) {
+			called++
+			return len(strings.Fields(in.Text)), nil
+		})
+
+	f := &fake{Replies: []*ai.ModelResponse{
+		{
+			FinishReason: ai.FinishReasonStop,
+			Message: ai.NewModelMessage(ai.NewToolRequestPart(&ai.ToolRequest{
+				Name: "wordCount", Input: map[string]any{"text": "one two three"}, Ref: "call-1",
+			})),
+		},
+		textReply("There are 3 words."),
+	}}
+	f.register(t, g, "fake/tools")
+
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithModelName("fake/tools"),
+		ai.WithPrompt("How many words?"),
+		ai.WithTools(wordCount),
+	)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("tool called %d times, want 1", called)
+	}
+	if len(f.Requests) != 2 {
+		t.Fatalf("model calls = %d, want 2", len(f.Requests))
+	}
+	if resp.Text() != "There are 3 words." {
+		t.Fatalf("text = %q", resp.Text())
+	}
+}
+```
+
+## Test streaming
+
+The fake's callback is the model's stream. Drive it from the test and assert on
+what a client would have seen:
+
+```go
+func TestStreaming(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	f := &fake{
+		Chunks:  []string{"Hello", ", ", "world"},
+		Replies: []*ai.ModelResponse{textReply("Hello, world")},
+	}
+	f.register(t, g, "fake/stream")
+
+	var seen []string
+	for chunk, err := range genkit.GenerateStream(ctx, g,
+		ai.WithModelName("fake/stream"),
+		ai.WithPrompt("greet"),
+	) {
+		if err != nil {
+			t.Fatalf("stream: %v", err)
+		}
+		if chunk.Done {
+			break
+		}
+		seen = append(seen, chunk.Chunk.Text())
+	}
+	if strings.Join(seen, "") != "Hello, world" {
+		t.Fatalf("chunks = %q", seen)
+	}
+}
+```
+
+To test a streaming flow rather than a bare generation, call `flow.Stream`. It
+returns a range-over-func yielding `*core.StreamingFlowValue[Out, Stream]`: while
+`Done` is false the value is in `Stream`, and the single final iteration carries
+the flow's return value in `Output`.
+
+```go
+func TestStreamingFlow(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	f := &fake{
+		Chunks:  []string{"Hello", ", ", "world"},
+		Replies: []*ai.ModelResponse{textReply("Hello, world")},
+	}
+	f.register(t, g, "fake/flowstream")
+
+	// The flow relays the model's chunks and returns the assembled text.
+	flow := genkit.DefineStreamingFlow(g, "greet",
+		func(ctx context.Context, name string, stream core.StreamCallback[string]) (string, error) {
+			resp, err := genkit.Generate(ctx, g,
+				ai.WithModelName("fake/flowstream"),
+				ai.WithPrompt("Greet %s.", name),
+				ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
+					if stream == nil {
+						return nil
+					}
+					return stream(ctx, chunk.Text())
+				}),
+			)
+			if err != nil {
+				return "", err
+			}
+			return resp.Text(), nil
+		})
+
+	var chunks []string
+	var final string
+	for v, err := range flow.Stream(ctx, "world") {
+		if err != nil {
+			t.Fatalf("stream: %v", err)
+		}
+		if v.Done {
+			final = v.Output
+			break
+		}
+		chunks = append(chunks, v.Stream)
+	}
+	if strings.Join(chunks, "") != "Hello, world" || final != "Hello, world" {
+		t.Fatalf("chunks = %q, final = %q", chunks, final)
+	}
+}
+```
+
+## Test the HTTP layer
+
+`genkit.Handler` turns a flow into an `http.HandlerFunc`, and `httptest.Server`
+serves it in-process. This is where you pin the wire contract: the success
+envelope, the status code on failure, and the redacted body.
+
+```go
+func TestHTTPBoundary(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	f := &fake{Err: status.Errorf(status.ErrResourceExhausted, "quota exceeded")}
+	f.register(t, g, "fake/http")
+
+	flow := NewSummarizeFlow(g, "fake/http")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /summarize", genkit.Handler(flow))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/summarize", "application/json",
+		strings.NewReader(`{"data":"an article"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "quota exceeded") {
+		t.Fatalf("internal message leaked: %q", body)
+	}
+}
+```
+
+The request body is `{"data": <flow input>}` and a successful response is
+`{"result": <flow output>}`. A failure body is plain text, and only a message
+built with `status.PublicErrorf` appears in it. See
+[Error types](/docs/error-types) for the rules the handler applies.
+
+## Test failure handling
+
+Set `Err` to a classified error and assert that the classification survives to
+your handler. This is how you pin the mapping your HTTP boundary depends on
+without provoking a real quota error.
+
+```go
+func TestProviderFailureIsClassified(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+	f := &fake{Err: status.Errorf(status.ErrResourceExhausted, "quota exceeded")}
+	f.register(t, g, "fake/broken")
+
+	_, err := genkit.Generate(ctx, g,
+		ai.WithModelName("fake/broken"),
+		ai.WithPrompt("anything"),
+	)
+	if !errors.Is(err, status.ErrResourceExhausted) {
+		t.Fatalf("error %v is not classified ResourceExhausted", err)
+	}
+}
+```
+
+See [Error types](/docs/error-types) for the full status set and how each one
+reaches a client.
+
+## Test a plugin
+
+Three facts about `genkit.Init` shape how plugin tests are written:
+
+- Each call builds an independent `*Genkit` with its own registry, so a per-test
+  `Init` is safe and two tests cannot collide on the same action name.
+- The reflection server starts only under `GENKIT_ENV=dev`. Leave that variable
+  unset in tests and nothing listens on port 3100, so tests can run in parallel
+  and in CI without a port conflict.
+- There is no `Close` or `Shutdown`. Background work is released by cancelling
+  the context you passed to `Init`, so use `t.Context()` or a
+  `context.WithCancel` you defer.
+
+The parts of a plugin worth unit-testing directly are its conversion functions:
+Genkit request to provider request, provider response back to
+`*ai.ModelResponse`. Those are ordinary functions and need no Genkit instance at
+all.
+
+For everything that goes over the wire, point the plugin at an `httptest.Server`
+through its own endpoint field, and let the handler produce the failure you want
+to test. That covers the cases a live provider will not reproduce on demand:
+
+```go
+func TestProviderDown(t *testing.T) {
+	// "Server down": a listener that is already closed.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	addr := srv.URL
+	srv.Close()
+
+	g := genkit.Init(t.Context(), genkit.WithPlugins(&ollama.Ollama{ServerAddress: addr}))
+	// ... assert the plugin's error is classified Unavailable ...
+	_ = g
+}
+
+func TestProviderDiesMidRequest(t *testing.T) {
+	// "Dies mid-request": headers and a partial body, then the connection is
+	// dropped without the rest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"response":"partia`))
+		w.(http.Flusher).Flush()
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	g := genkit.Init(t.Context(), genkit.WithPlugins(&ollama.Ollama{ServerAddress: srv.URL}))
+	// ... assert the truncated response surfaces as an error, not a partial value ...
+	_ = g
+}
+```
+
+`ollama.Ollama{ServerAddress: ...}` is the example here because its endpoint is a
+plain field. Other plugins expose the same hook under a different name, such as
+`compat_oai.OpenAICompatible{BaseURL: ...}`.
+
+## Imports
+
+Every snippet above uses these:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/ollama"
+)
+```
+
+## Learn more
+
+- [Flows](/docs/flows) — defining the units you'll be testing
+- [Tool calling](/docs/tool-calling) — how tool round-trips work
+- [Error types](/docs/error-types) — the status codes your tests assert on
+- [Writing plugins](/docs/plugin-authoring/overview) — `ai.ModelOptions` and
+  `ai.ModelSupports`, which the fake above uses
+- [Evaluation](/docs/evaluation) — assessing real model output quality
 
 </Lang>

--- a/src/content/docs/docs/testing.mdx
+++ b/src/content/docs/docs/testing.mdx
@@ -555,36 +555,99 @@ func NewSummarizeFlow(g *genkit.Genkit, model string) *core.Flow[string, Summary
 `github.com/firebase/genkit/go/core`. That is the type to name when you store a
 flow in a struct field or pass it to a helper.
 
-## Write a fake model
+## Write a test model stub
 
-A fake model is just a model action whose function returns whatever you tell it
-to. `genkit.DefineModelAction` registers it under a name your flow can resolve,
-and because the function closes over a struct, the same fake can also record
-every request it received.
+A test model is a model action registered on a test `*genkit.Genkit` instance that returns a predetermined response or error. `genkit.DefineModelAction` registers it under a name your flow can resolve, so your tests run deterministically with no network calls or API keys.
 
-```go title="fake_test.go"
-type fake struct {
-	Requests []*ai.ModelRequest   // every request received, in order
-	Replies  []*ai.ModelResponse  // one per call; the last one repeats
-	Err      error                // when set, returned instead of a reply
-	Chunks   []string             // streamed before the reply
-}
-
-func (f *fake) register(t *testing.T, g *genkit.Genkit, name string) {
-	t.Helper()
+```go title="mock_model_test.go"
+// defineTestModel registers a model action that returns a fixed response.
+func defineTestModel(g *genkit.Genkit, name string, response *ai.ModelResponse) {
 	genkit.DefineModelAction(g, name, &ai.ModelOptions{
-		// Claim the capabilities your test depends on. Genkit rewrites requests
-		// for models that do not claim them: with SystemRole false, the system
-		// prompt is folded into a user message prefixed "SYSTEM INSTRUCTIONS:",
-		// which will surprise you when you assert on it.
 		Supports: &ai.ModelSupports{Multiturn: true, Tools: true, SystemRole: true},
 	}, func(ctx context.Context, req *ai.ModelRequest, _ struct{}, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
-		f.Requests = append(f.Requests, req)
-		if f.Err != nil {
-			return nil, f.Err
-		}
+		return response, nil
+	})
+}
+
+// defineErrorModel registers a model action that returns a designated error.
+func defineErrorModel(g *genkit.Genkit, name string, err error) {
+	genkit.DefineModelAction(g, name, &ai.ModelOptions{
+		Supports: &ai.ModelSupports{Multiturn: true, Tools: true, SystemRole: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, _ struct{}, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		return nil, err
+	})
+}
+```
+
+`genkit.Init(ctx)` with no plugins initializes a test-friendly instance: it registers no external providers, reads no credentials, and starts no reflection server. Build a fresh instance per test to isolate registrations.
+
+## Test structured output
+
+Configure the test model to return JSON conforming to your output schema, and assert on the decoded Go value:
+
+```go
+func TestStructuredOutput(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+
+	want := Summary{Headline: "Release notes", Bullets: []string{"a", "b", "c"}}
+	body, _ := json.Marshal(want)
+	defineTestModel(g, "mock/model", &ai.ModelResponse{
+		FinishReason: ai.FinishReasonStop,
+		Message:      ai.NewModelTextMessage(string(body)),
+	})
+
+	flow := NewSummarizeFlow(g, "mock/model")
+	got, err := flow.Run(ctx, "Sample release notes text.")
+	if err != nil {
+		t.Fatalf("flow failed: %v", err)
+	}
+	if got.Headline != want.Headline || len(got.Bullets) != 3 {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+```
+
+## Test tools directly
+
+Because tools in Genkit wrap plain Go functions, you can unit-test tool business logic directly without running a model loop:
+
+```go
+func TestWordCountTool(t *testing.T) {
+	ctx := context.Background()
+
+	type wordCountInput struct {
+		Text string `json:"text"`
+	}
+	toolFn := func(_ *ai.ToolContext, in wordCountInput) (int, error) {
+		return len(strings.Fields(in.Text)), nil
+	}
+
+	got, err := toolFn(&ai.ToolContext{Context: ctx}, wordCountInput{Text: "one two three"})
+	if err != nil {
+		t.Fatalf("tool error: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+```
+
+## Test streaming
+
+To test streaming flows, pass chunks to the `ModelStreamCallback` inside a custom model action:
+
+```go
+func TestStreaming(t *testing.T) {
+	ctx := context.Background()
+	g := genkit.Init(ctx)
+
+	genkit.DefineModelAction(g, "mock/stream", &ai.ModelOptions{
+		Supports: &ai.ModelSupports{Multiturn: true},
+	}, func(ctx context.Context, req *ai.ModelRequest, _ struct{}, cb ai.ModelStreamCallback) (*ai.ModelResponse, error) {
+		chunks := []string{"Hello", ", ", "world"}
 		if cb != nil {
-			for _, c := range f.Chunks {
+			for _, c := range chunks {
 				if err := cb(ctx, &ai.ModelResponseChunk{
 					Role:    ai.RoleModel,
 					Content: []*ai.Part{ai.NewTextPart(c)},
@@ -593,158 +656,15 @@ func (f *fake) register(t *testing.T, g *genkit.Genkit, name string) {
 				}
 			}
 		}
-		i := min(len(f.Requests)-1, len(f.Replies)-1)
-		return f.Replies[i], nil
-	})
-}
-
-func textReply(s string) *ai.ModelResponse {
-	return &ai.ModelResponse{FinishReason: ai.FinishReasonStop, Message: ai.NewModelTextMessage(s)}
-}
-```
-
-`genkit.Init(ctx)` with no plugins is enough for a test: it registers no
-providers, reads no credentials, and starts no reflection server, because
-`GENKIT_ENV` is unset and Genkit defaults to the production environment. Build a
-fresh instance per test so registrations cannot leak between them.
-
-## Test structured output
-
-The fake returns the JSON your schema expects, and the assertion is on the
-decoded Go value:
-
-```go
-func TestStructuredOutput(t *testing.T) {
-	ctx := context.Background()
-	g := genkit.Init(ctx)
-
-	want := Summary{Headline: "Go 1.24 lands", Bullets: []string{"a", "b", "c"}}
-	body, _ := json.Marshal(want)
-	f := &fake{Replies: []*ai.ModelResponse{textReply(string(body))}}
-	f.register(t, g, "fake/structured")
-
-	got, err := NewSummarizeFlow(g, "fake/structured").Run(ctx, "Go 1.24 was released today.")
-	if err != nil {
-		t.Fatalf("flow: %v", err)
-	}
-	if got.Headline != want.Headline || len(got.Bullets) != 3 {
-		t.Fatalf("got %+v", got)
-	}
-}
-```
-
-Returning JSON that does not satisfy the schema is also worth a test: Genkit
-validates the model's output and the flow returns an error rather than a
-half-filled struct.
-
-## Assert what the model received
-
-`f.Requests` is the whole point of recording. Use it to pin prompt assembly, so
-a careless edit to a system prompt fails a test instead of shipping:
-
-```go
-func TestPromptAssembly(t *testing.T) {
-	ctx := context.Background()
-	g := genkit.Init(ctx)
-	body, _ := json.Marshal(Summary{Headline: "x", Bullets: []string{"a"}})
-	f := &fake{Replies: []*ai.ModelResponse{textReply(string(body))}}
-	f.register(t, g, "fake/prompt")
-
-	if _, err := NewSummarizeFlow(g, "fake/prompt").Run(ctx, "an article about badgers"); err != nil {
-		t.Fatalf("flow: %v", err)
-	}
-
-	var system, user string
-	for _, m := range f.Requests[0].Messages {
-		switch m.Role {
-		case ai.RoleSystem:
-			system = m.Text()
-		case ai.RoleUser:
-			user = m.Text()
-		}
-	}
-	if !strings.Contains(system, "Three bullets") {
-		t.Errorf("system prompt = %q", system)
-	}
-	if !strings.Contains(user, "badgers") {
-		t.Errorf("user prompt = %q", user)
-	}
-}
-```
-
-The request also carries the output schema Genkit derived from your Go type, in
-a user-role part tagged `metadata["purpose"] == "output"`. Assert on it when the
-schema itself is the thing you care about.
-
-## Test tool calling
-
-Script two replies: the first asks for the tool, the second answers using its
-result. Genkit runs the loop, so the test proves your tool was called with the
-input you expect and that its output reached the second request.
-
-```go
-func TestToolCalling(t *testing.T) {
-	ctx := context.Background()
-	g := genkit.Init(ctx)
-
-	var called int
-	wordCount := genkit.DefineTool(g, "wordCount", "Counts words in a string.",
-		func(_ *ai.ToolContext, in struct {
-			Text string `json:"text"`
-		}) (int, error) {
-			called++
-			return len(strings.Fields(in.Text)), nil
-		})
-
-	f := &fake{Replies: []*ai.ModelResponse{
-		{
+		return &ai.ModelResponse{
 			FinishReason: ai.FinishReasonStop,
-			Message: ai.NewModelMessage(ai.NewToolRequestPart(&ai.ToolRequest{
-				Name: "wordCount", Input: map[string]any{"text": "one two three"}, Ref: "call-1",
-			})),
-		},
-		textReply("There are 3 words."),
-	}}
-	f.register(t, g, "fake/tools")
-
-	resp, err := genkit.Generate(ctx, g,
-		ai.WithModelName("fake/tools"),
-		ai.WithPrompt("How many words?"),
-		ai.WithTools(wordCount),
-	)
-	if err != nil {
-		t.Fatalf("generate: %v", err)
-	}
-	if called != 1 {
-		t.Fatalf("tool called %d times, want 1", called)
-	}
-	if len(f.Requests) != 2 {
-		t.Fatalf("model calls = %d, want 2", len(f.Requests))
-	}
-	if resp.Text() != "There are 3 words." {
-		t.Fatalf("text = %q", resp.Text())
-	}
-}
-```
-
-## Test streaming
-
-The fake's callback is the model's stream. Drive it from the test and assert on
-what a client would have seen:
-
-```go
-func TestStreaming(t *testing.T) {
-	ctx := context.Background()
-	g := genkit.Init(ctx)
-	f := &fake{
-		Chunks:  []string{"Hello", ", ", "world"},
-		Replies: []*ai.ModelResponse{textReply("Hello, world")},
-	}
-	f.register(t, g, "fake/stream")
+			Message:      ai.NewModelTextMessage("Hello, world"),
+		}, nil
+	})
 
 	var seen []string
 	for chunk, err := range genkit.GenerateStream(ctx, g,
-		ai.WithModelName("fake/stream"),
+		ai.WithModelName("mock/stream"),
 		ai.WithPrompt("greet"),
 	) {
 		if err != nil {
@@ -761,72 +681,17 @@ func TestStreaming(t *testing.T) {
 }
 ```
 
-To test a streaming flow rather than a bare generation, call `flow.Stream`. It
-returns a range-over-func yielding `*core.StreamingFlowValue[Out, Stream]`: while
-`Done` is false the value is in `Stream`, and the single final iteration carries
-the flow's return value in `Output`.
-
-```go
-func TestStreamingFlow(t *testing.T) {
-	ctx := context.Background()
-	g := genkit.Init(ctx)
-	f := &fake{
-		Chunks:  []string{"Hello", ", ", "world"},
-		Replies: []*ai.ModelResponse{textReply("Hello, world")},
-	}
-	f.register(t, g, "fake/flowstream")
-
-	// The flow relays the model's chunks and returns the assembled text.
-	flow := genkit.DefineStreamingFlow(g, "greet",
-		func(ctx context.Context, name string, stream core.StreamCallback[string]) (string, error) {
-			resp, err := genkit.Generate(ctx, g,
-				ai.WithModelName("fake/flowstream"),
-				ai.WithPrompt("Greet %s.", name),
-				ai.WithStreaming(func(ctx context.Context, chunk *ai.ModelResponseChunk) error {
-					if stream == nil {
-						return nil
-					}
-					return stream(ctx, chunk.Text())
-				}),
-			)
-			if err != nil {
-				return "", err
-			}
-			return resp.Text(), nil
-		})
-
-	var chunks []string
-	var final string
-	for v, err := range flow.Stream(ctx, "world") {
-		if err != nil {
-			t.Fatalf("stream: %v", err)
-		}
-		if v.Done {
-			final = v.Output
-			break
-		}
-		chunks = append(chunks, v.Stream)
-	}
-	if strings.Join(chunks, "") != "Hello, world" || final != "Hello, world" {
-		t.Fatalf("chunks = %q, final = %q", chunks, final)
-	}
-}
-```
-
 ## Test the HTTP layer
 
-`genkit.Handler` turns a flow into an `http.HandlerFunc`, and `httptest.Server`
-serves it in-process. This is where you pin the wire contract: the success
-envelope, the status code on failure, and the redacted body.
+`genkit.Handler` turns a flow into an `http.HandlerFunc`, and `httptest.Server` serves it in-process. This verifies the wire contract: the success envelope, status codes, and error formatting.
 
 ```go
 func TestHTTPBoundary(t *testing.T) {
 	ctx := context.Background()
 	g := genkit.Init(ctx)
-	f := &fake{Err: status.Errorf(status.ErrResourceExhausted, "quota exceeded")}
-	f.register(t, g, "fake/http")
+	defineErrorModel(g, "mock/http", status.Errorf(status.ErrResourceExhausted, "quota exceeded"))
 
-	flow := NewSummarizeFlow(g, "fake/http")
+	flow := NewSummarizeFlow(g, "mock/http")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /summarize", genkit.Handler(flow))
@@ -850,26 +715,20 @@ func TestHTTPBoundary(t *testing.T) {
 }
 ```
 
-The request body is `{"data": <flow input>}` and a successful response is
-`{"result": <flow output>}`. A failure body is plain text, and only a message
-built with `status.PublicErrorf` appears in it. See
-[Error types](/docs/error-types) for the rules the handler applies.
+The request body is `{"data": <flow input>}` and a successful response is `{"result": <flow output>}`. A failure body is plain text, and only a message built with `status.PublicErrorf` appears in it. See [Error types](/docs/error-types) for the rules the handler applies.
 
 ## Test failure handling
 
-Set `Err` to a classified error and assert that the classification survives to
-your handler. This is how you pin the mapping your HTTP boundary depends on
-without provoking a real quota error.
+Use `defineErrorModel` with a classified error to verify that the classification propagates to your handler without needing a live provider error:
 
 ```go
 func TestProviderFailureIsClassified(t *testing.T) {
 	ctx := context.Background()
 	g := genkit.Init(ctx)
-	f := &fake{Err: status.Errorf(status.ErrResourceExhausted, "quota exceeded")}
-	f.register(t, g, "fake/broken")
+	defineErrorModel(g, "mock/broken", status.Errorf(status.ErrResourceExhausted, "quota exceeded"))
 
 	_, err := genkit.Generate(ctx, g,
-		ai.WithModelName("fake/broken"),
+		ai.WithModelName("mock/broken"),
 		ai.WithPrompt("anything"),
 	)
 	if !errors.Is(err, status.ErrResourceExhausted) {
@@ -878,8 +737,7 @@ func TestProviderFailureIsClassified(t *testing.T) {
 }
 ```
 
-See [Error types](/docs/error-types) for the full status set and how each one
-reaches a client.
+See [Error types](/docs/error-types) for the full status set and how each one reaches a client.
 
 ## Test a plugin
 
@@ -970,7 +828,7 @@ import (
 - [Tool calling](/docs/tool-calling) — how tool round-trips work
 - [Error types](/docs/error-types) — the status codes your tests assert on
 - [Writing plugins](/docs/plugin-authoring/overview) — `ai.ModelOptions` and
-  `ai.ModelSupports`, which the fake above uses
+  `ai.ModelSupports`, used when defining test models
 - [Evaluation](/docs/evaluation) — assessing real model output quality
 
 </Lang>

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -547,12 +547,71 @@ description. The name and the description are all the model knows about a tool
 besides the schemas inferred from the input and output types, so both are prompt
 and are worth writing as carefully as one.
 
-If the input shape is only known at runtime, declare the input parameter as
-`any` and pass the schema instead:
+#### The tool context
+
+`*ai.ToolContext` embeds `context.Context`, so it satisfies `context.Context`
+directly. Pass it unchanged to a flow, an HTTP client, or a database handle, and
+it carries the caller's cancellation and deadline with it. This one needs
+`time` on top of the imports above:
 
 ```go
+type RevenueInput struct {
+	Region string `json:"region"`
+}
+
+reportRevenue := genkit.DefineFlow(g, "reportRevenue",
+	func(ctx context.Context, region string) (string, error) {
+		// ... look up the numbers ...
+		return "revenue for " + region, nil
+	})
+
+getRevenue := genkit.DefineTool(g, "getRevenue",
+	"Reports revenue for a region over the last quarter.",
+	func(ctx *ai.ToolContext, input RevenueInput) (string, error) {
+		// ctx is a context.Context, so it goes straight into anything that
+		// takes one. Give a slow dependency a deadline of its own.
+		callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		return reportRevenue.Run(callCtx, input.Region)
+	})
+```
+
+The struct also carries `Resumed map[string]any` and `OriginalInput any`, both
+set only after an interrupt, plus the methods `Interrupt(*ai.InterruptOptions)`
+and `IsResumed()`. The [interrupts guide](/docs/interrupts) covers that half.
+
+#### Tools run concurrently
+
+When a model asks for several tools in one turn, Genkit runs them concurrently,
+one goroutine per request. A tool function must be safe to call from several
+goroutines at once: guard shared state with a mutex, and copy a slice or map
+before returning it. The registry is mutex-protected, so `genkit.DefineTool` and
+the other `Define*` calls are safe from any goroutine, but defining tools during
+startup is still the pattern to follow.
+
+#### Schemas known only at runtime
+
+If the input shape is only known at runtime, declare the input parameter as
+`any` and pass the schema instead. `ai.WithInputSchema(schema map[string]any)`
+takes a plain JSON Schema document as a `map[string]any`, not a
+`*jsonschema.Schema`, not `[]byte`, and not a struct:
+
+```go
+schema := map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"location": map[string]any{
+			"type":        "string",
+			"description": "The location to get the current weather for",
+		},
+	},
+	"required": []string{"location"},
+}
+
 genkit.DefineTool(g, "getWeather", "Gets the current weather in a given location",
 	func(ctx *ai.ToolContext, input any) (string, error) {
+		// input arrives as a map[string]any shaped by the schema above.
 		return "sunny", nil
 	},
 	ai.WithInputSchema(schema),
@@ -560,7 +619,7 @@ genkit.DefineTool(g, "getWeather", "Gets the current weather in a given location
 ```
 
 `ai.WithInputSchemaName` references a schema registered with
-`genkit.DefineSchemasFor`, and `ai.WithOutputSchema` and
+`genkit.DefineSchemasFor`, and `ai.WithOutputSchema(schema map[string]any)` and
 `ai.WithOutputSchemaName` do the same for the output. An explicit schema stands
 in for a type parameter, so the parameter it describes must be `any`.
 
@@ -578,6 +637,21 @@ Include defined tools in your prompts to generate content.
 resp, err := genkit.Generate(ctx, g,
 	ai.WithPrompt("What is the weather in San Francisco?"),
 	ai.WithTools(getWeather),
+)
+```
+
+`ai.WithTools(tools ...ai.ToolRef)` accepts anything with a `Name() string`
+method: `*ai.ToolAction` from `genkit.DefineTool`, `*aix.Tool` from the
+in-preview API below, and `ai.ToolName("getWeather")` when all you have is the
+name. So a per-request tool set is just a slice you spread. Repeating the option
+appends, and duplicate names are rejected when the request runs:
+
+```go
+adminTools := []ai.ToolRef{getWeather, getRevenue, ai.ToolName("auditLog")}
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("Who looked at the San Francisco forecast today?"),
+	ai.WithTools(adminTools...),
 )
 ```
 
@@ -626,6 +700,31 @@ resp, err := weatherPrompt.Execute(ctx,
 
 Genkit handles the tool call automatically if the LLM needs to use the
 `getWeather` tool to answer the prompt.
+
+### Controlling tool choice
+
+`ai.WithToolChoice()` decides whether the model may call a tool, must call one,
+or must not. `ai.ToolChoice` is a string type with three values:
+
+| Value | Meaning |
+| --- | --- |
+| `ai.ToolChoiceAuto` | The model decides whether to call a tool. |
+| `ai.ToolChoiceRequired` | The model must call at least one tool this turn. |
+| `ai.ToolChoiceNone` | The model must answer without calling a tool. |
+
+```go
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("What is the weather in San Francisco?"),
+	ai.WithTools(getWeather),
+	ai.WithToolChoice(ai.ToolChoiceRequired),
+)
+```
+
+Omitting the option leaves the zero value, the empty string, which means unset:
+Genkit sends nothing and the provider's own default applies. A model whose
+`ModelInfo.Supports.ToolChoice` is false accepts only the unset value and
+`ai.ToolChoiceAuto`; anything else fails the request with
+`ai.ErrUnsupportedByModel`.
 
 ### Returning more than one value from a tool
 
@@ -684,9 +783,22 @@ the `Output` shape instead.
 
 A tool call takes several turns, so a stream carries the tool's traffic as well
 as the model's text. Use `genkit.GenerateStream()` when the caller needs to act
-on that traffic, and switch on the part kind:
+on that traffic, and switch on the part kind. `core.StreamCallback` and
+`genkit.DefineStreamingFlow` come from the [flows](/docs/flows) API, and
+`status` here is `github.com/firebase/genkit/go/core/status`, not
+`google.golang.org/grpc/status`; see [Error types](/docs/error-types):
 
 ```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/firebase/genkit/go/ai"
+	"github.com/firebase/genkit/go/core"
+	"github.com/firebase/genkit/go/core/status"
+	"github.com/firebase/genkit/go/genkit"
+)
+
 genkit.DefineStreamingFlow(g, "deployFlow",
 	func(ctx context.Context, input string, sendChunk core.StreamCallback[string]) (string, error) {
 		for val, err := range genkit.GenerateStream(ctx, g,
@@ -744,6 +856,87 @@ When the limit is reached, Genkit stops the loop and returns an error matching
 `ai.ErrMaxTurnsExceeded`, whose status is `ABORTED`. Either raise the limit or
 look for a tool the model keeps retrying.
 
+### When a tool fails
+
+A tool that returns a non-nil error is fail-fast. Genkit stops the tool loop and
+`genkit.Generate()` returns the error wrapped as `ai.ErrToolFailed`, a subtype
+of `status.ErrInternal` (HTTP 500). The model never sees it and never retries.
+Output that does not match the tool's declared schema reports the same sentinel,
+and so does input the model sent that fails the declared input schema: the tool
+function never runs and the call aborts with `ai.ErrToolFailed` wrapping
+`status.ErrInvalidInput`.
+
+The tool's own error is wrapped with `%w`, so both the framework sentinel and
+your own cause still match:
+
+```go
+// errStationOffline is the tool's own sentinel, returned from its body.
+var errStationOffline = errors.New("weather station offline")
+
+resp, err := genkit.Generate(ctx, g,
+	ai.WithPrompt("What is the weather in San Francisco?"),
+	ai.WithTools(getWeather),
+)
+if err != nil {
+	if errors.Is(err, ai.ErrToolFailed) && errors.Is(err, errStationOffline) {
+		return fmt.Errorf("retry later: %w", err)
+	}
+	return err
+}
+```
+
+There is no soft-fail flag and no `ai.ToolError`. To let the model recover from
+a failure instead of aborting the call, return a nil error and put the failure
+in the tool's own output type, then say in the description how the model should
+react:
+
+```go
+type Forecast struct {
+	Summary     string `json:"summary,omitempty"`
+	Unavailable bool   `json:"unavailable" jsonschema:"description=True when the forecast could not be read; say so and do not retry"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+getWeather := genkit.DefineTool(g, "getWeather",
+	"Gets the current weather in a given location. If unavailable is true, tell the user rather than guessing.",
+	func(ctx *ai.ToolContext, input WeatherInput) (Forecast, error) {
+		// readStation is your own call to the weather service.
+		summary, err := readStation(ctx, input.Location)
+		if err != nil {
+			// A nil error, so the loop continues and the model can react.
+			return Forecast{Unavailable: true, Reason: err.Error()}, nil
+		}
+		return Forecast{Summary: summary}, nil
+	})
+```
+
+See [Error types](/docs/error-types) for the rest of the sentinels generation
+reports.
+
+### Inspecting which tools ran
+
+There is no `resp.ToolCalls()`. `resp.ToolRequests()` returns only the requests
+left unfulfilled by the final turn, which is empty unless
+`ai.WithReturnToolRequests(true)` is set or an interrupt fired. The full record
+of the loop is `resp.History()`: the request's messages plus the response, which
+includes each model message carrying tool requests and each `ai.RoleTool`
+message carrying their responses. Pair the two on `Ref`:
+
+```go
+calls := map[string]*ai.ToolRequest{}
+for _, msg := range resp.History() {
+	for _, part := range msg.Content {
+		switch {
+		case part.IsToolRequest():
+			calls[part.ToolRequest.Ref] = part.ToolRequest
+		case part.IsToolResponse():
+			req := calls[part.ToolResponse.Ref]
+			fmt.Printf("%s(%v) -> %v\n", part.ToolResponse.Name, req.Input, part.ToolResponse.Output)
+		}
+	}
+}
+```
+
 ### Tools that come from middleware
 
 Not every tool is one you write. Middleware attached with `ai.WithUse()` can
@@ -788,7 +981,10 @@ to your code so that you can handle more advanced scenarios. Visit the
 
 If you want full control over this tool-calling loop, for example to apply more
 complicated logic, set the `WithReturnToolRequests()` option to `true`. Now it's
-your responsibility to ensure all of the tool requests are fulfilled:
+your responsibility to ensure all of the tool requests are fulfilled, to carry
+the tools and the option onto every call, and to stop. One round is not enough:
+after you answer a tool request the model usually has more to say, and it may
+ask for another tool:
 
 ```go
 getWeather := genkit.DefineTool(g, "getWeather",
@@ -798,46 +994,64 @@ getWeather := genkit.DefineTool(g, "getWeather",
 		return "sunny", nil
 	})
 
-resp, err := genkit.Generate(ctx, g,
-	ai.WithPrompt("What is the weather in San Francisco?"),
-	ai.WithTools(getWeather),
-	ai.WithReturnToolRequests(true),
-)
-if err != nil {
-	log.Fatal(err)
+const maxTurns = 5
+
+messages := []*ai.Message{
+	ai.NewUserTextMessage("What is the weather in San Francisco?"),
 }
 
-// ToolRequests returns the request parts, so the call itself is on
-// part.ToolRequest.
-parts := []*ai.Part{}
-for _, part := range resp.ToolRequests() {
-	req := part.ToolRequest
-
-	tool := genkit.LookupTool(g, req.Name)
-	if tool == nil {
-		log.Fatalf("tool %q not found", req.Name)
-	}
-
-	output, err := tool.RunRaw(ctx, req.Input)
+for turn := 0; turn < maxTurns; turn++ {
+	resp, err := genkit.Generate(ctx, g,
+		ai.WithMessages(messages...),
+		// Both options belong on every call, not just the first: without
+		// them the model has no tools on the second turn.
+		ai.WithTools(getWeather),
+		ai.WithReturnToolRequests(true),
+	)
 	if err != nil {
-		log.Fatalf("tool %q failed: %v", tool.Name(), err)
+		log.Fatal(err)
 	}
 
-	parts = append(parts,
-		ai.NewToolResponsePart(&ai.ToolResponse{
-			Name:   req.Name,
-			Ref:    req.Ref,
-			Output: output,
-		}))
+	requests := resp.ToolRequests()
+	if len(requests) == 0 {
+		fmt.Println(resp.Text())
+		return
+	}
+
+	// ToolRequests returns the request parts, so the call itself is on
+	// part.ToolRequest.
+	var parts []*ai.Part
+	for _, part := range requests {
+		req := part.ToolRequest
+
+		tool := genkit.LookupTool(g, req.Name)
+		if tool == nil {
+			log.Fatalf("tool %q not found", req.Name)
+		}
+
+		output, err := tool.RunRaw(ctx, req.Input)
+		if err != nil {
+			log.Fatalf("tool %q failed: %v", tool.Name(), err)
+		}
+
+		parts = append(parts,
+			ai.NewToolResponsePart(&ai.ToolResponse{
+				Name:   req.Name,
+				Ref:    req.Ref,
+				Output: output,
+			}))
+	}
+
+	// Carry the whole turn forward: the model's request message, then the
+	// tool message answering it.
+	messages = append(resp.History(), ai.NewMessage(ai.RoleTool, nil, parts...))
 }
 
-resp, err = genkit.Generate(ctx, g,
-	ai.WithMessages(append(resp.History(), ai.NewMessage(ai.RoleTool, nil, parts...))...),
-)
-if err != nil {
-	log.Fatal(err)
-}
+log.Fatalf("gave up after %d turns", maxTurns)
 ```
+
+`ai.WithMaxTurns()` has nothing to bound in this mode, since Genkit is no longer
+running the loop, so the turn cap is yours to enforce.
 
 `RunRaw` returns the tool's output value. For a multipart tool, use
 `RunRawMultipart` instead when you also need the attached content parts.
@@ -867,6 +1081,7 @@ The package names collide, so import them deliberately:
 ```go
 import (
 	"github.com/firebase/genkit/go/ai"
+	aix "github.com/firebase/genkit/go/ai/exp"
 	"github.com/firebase/genkit/go/ai/exp/tool"
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
@@ -928,6 +1143,48 @@ The exact signatures are:
 func AttachParts(ctx context.Context, parts ...*ai.Part)
 func SendPartial(ctx context.Context, output any)
 func SendChunk(ctx context.Context, chunk *ai.ModelResponseChunk)
+```
+
+There is no in-preview generate entry point, and none is needed.
+`genkitx.DefineTool[In, Out]` returns `*aix.Tool[In, Out]`, the stable
+`genkit.DefineTool[In, Out]` returns `*ai.ToolAction[In, Out]`, and both have a
+`Name() string` method, so both satisfy `ai.ToolRef`. Write the type out when a
+helper hands a tool back, and pass it to the ordinary `ai.WithTools()` on a
+stable `genkit.Generate()`:
+
+```go
+func newDeployTool(g *genkit.Genkit) *aix.Tool[Deploy, *Rollout] {
+	return genkitx.DefineTool(g, "deployService",
+		"Deploys a service to an environment and reports how the rollout went.",
+		func(ctx context.Context, input Deploy) (*Rollout, error) {
+			tool.SendPartial(ctx, Progress{Step: "shifting traffic", Percent: 50})
+			// ... roll out, then return the answer ...
+			return &Rollout{Service: input.Service, Healthy: true}, nil
+		})
+}
+
+deployService := newDeployTool(g)
+
+for val, err := range genkit.GenerateStream(ctx, g,
+	ai.WithPrompt("Deploy checkout to staging."),
+	ai.WithTools(deployService),
+) {
+	if err != nil {
+		log.Fatal(err)
+	}
+	if val.Done {
+		fmt.Println(val.Response.Text())
+		break
+	}
+	for _, part := range val.Chunk.Content {
+		// A value from tool.SendPartial lands here as a tool response part
+		// flagged partial, named and ref'd like the call it is reporting on.
+		// It is progress, not the answer, and never reaches history.
+		if part.IsToolResponse() && part.IsPartial() {
+			fmt.Printf("[%s] %v\n", part.ToolResponse.Name, part.ToolResponse.Output)
+		}
+	}
+}
 ```
 
 `genkitx.DefineInterruptibleTool` is the interruptible counterpart, which takes

--- a/src/generate-llms-direct.ts
+++ b/src/generate-llms-direct.ts
@@ -54,99 +54,107 @@ function getDocsSidebar(): SidebarItem[] {
   return sidebar.filter(item => item.label !== "Introduction");
 }
 
+// Thematic bundles, defined against the section labels in src/sidebar.ts.
+//
+// `sections` are matched against sidebar section labels exactly. A theme that
+// names a section which no longer exists is a build error rather than a silently
+// empty bundle: an empty bundle still gets advertised in llms.txt, so the failure
+// mode is a 404 or a near-empty file for whoever fetches it.
+const THEMES: Array<{
+  label: string;
+  description: string;
+  sections?: string[];
+  slugs?: string[];
+}> = [
+  {
+    label: "Building AI Workflows",
+    description:
+      "Generating content, flows, tools, prompts, RAG, and the rest of the core Genkit API.",
+    sections: ["Get started", "Core concepts"],
+  },
+  {
+    label: "Full-Stack Agents",
+    description:
+      "Defining agents, running and streaming them, sessions and state, interrupts, background execution, and delegation.",
+    sections: ["Full-stack agents"],
+  },
+  {
+    label: "Deploying AI Workflows",
+    description:
+      "Serving flows from a web framework, connecting a frontend, and deploying to Cloud Run or any other platform.",
+    sections: ["Backend frameworks", "App frameworks", "Deployment", "Authorization"],
+  },
+  {
+    label: "Observing AI Workflows",
+    description: "Tracing, metrics, logging, and production monitoring.",
+    sections: ["Observability and monitoring"],
+  },
+  {
+    label: "Writing Plugins",
+    description: "Authoring Genkit plugins: models, retrievers, embedders, and evaluators.",
+    sections: ["Writing plugins"],
+  },
+  {
+    label: "AI Providers",
+    description: "Provider-specific setup and configuration for every supported model provider.",
+    sections: ["Model providers"],
+  },
+  {
+    label: "Vector Databases",
+    description: "Vector store and retriever integrations.",
+    sections: ["Database providers"],
+  },
+  {
+    label: "Developer Tools",
+    description: "The Genkit CLI, the Developer UI, the Genkit MCP server, and AI-assisted development.",
+    sections: ["Build with AI"],
+    slugs: ["docs/devtools"],
+  },
+];
+
 // Create language sets based on sidebar structure
 function createLanguageSetsFromSidebar(): LanguageSet[] {
   const docsSidebar = getDocsSidebar();
-  const languageSets: LanguageSet[] = [];
+  const known = new Set(docsSidebar.map((item) => item.label));
 
-  // Find specific sections in the sidebar and map them to language sets
-  const sectionMappings = [
-    {
-      sidebarLabel: "Building AI workflows",
-      setLabel: "Building AI Workflows",
-      description: "Guidance on how to generate content and interact with LLM and image models using Genkit.",
-      includeToplevel: ["docs/get-started"] // Include top-level items
-    },
-    {
-      sidebarLabel: "Deployment",
-      setLabel: "Deploying AI Workflows",
-      description: "Guidance on how to deploy Genkit code to various environments including Firebase and Cloud Run or use within a Next.js app.",
-      additionalSections: ["Web Framework Integrations"] // Include related sections
-    },
-    {
-      sidebarLabel: "Observability and Monitoring",
-      setLabel: "Observing AI Workflows",
-      description: "Guidance about Genkit's various observability features and how to use them."
-    },
-    {
-      sidebarLabel: "Writing Plugins",
-      setLabel: "Writing Plugins",
-      description: "Guidance about how to author plugins for Genkit."
-    },
-    {
-      sidebarLabel: "AI Providers",
-      setLabel: "AI Providers",
-      description: "Provider-specific documentation for AI model providers and integrations."
-    },
-    {
-      sidebarLabel: "Vector Databases",
-      setLabel: "Vector Databases",
-      description: "Documentation for vector database integrations and retrieval systems."
-    }
-  ];
+  return THEMES.map((theme) => {
+    const paths: string[] = [...(theme.slugs ?? [])];
 
-  for (const mapping of sectionMappings) {
-    const paths: string[] = [];
-    
-    // Add top-level items if specified
-    if (mapping.includeToplevel) {
-      paths.push(...mapping.includeToplevel);
-    }
-    
-    // Find the main section
-    const section = docsSidebar.find(item => item.label === mapping.sidebarLabel);
-    if (section?.items) {
-      paths.push(...extractPathsFromSidebar(section.items));
-    }
-    
-    // Add additional sections if specified
-    if (mapping.additionalSections) {
-      for (const additionalLabel of mapping.additionalSections) {
-        const additionalSection = docsSidebar.find(item => item.label === additionalLabel);
-        if (additionalSection?.items) {
-          paths.push(...extractPathsFromSidebar(additionalSection.items));
-        }
+    for (const label of theme.sections ?? []) {
+      if (!known.has(label)) {
+        throw new Error(
+          `generate-llms-direct: theme "${theme.label}" references sidebar section "${label}", ` +
+            `which does not exist. Known sections: ${[...known].join(", ")}. ` +
+            `Update THEMES in src/generate-llms-direct.ts when the sidebar is reorganized.`,
+        );
+      }
+      const section = docsSidebar.find((item) => item.label === label);
+      if (section?.items) {
+        paths.push(...extractPathsFromSidebar(section.items));
       }
     }
-    
-    if (paths.length > 0) {
-      languageSets.push({
-        label: mapping.setLabel,
-        description: mapping.description,
-        paths
-      });
-    }
-  }
 
-  // Add Developer Tools as a special case (top-level items)
-  const devToolsPaths = docsSidebar
-    .filter(item => ["Developer tools", "MCP Server"].includes(item.label))
-    .map(item => item.slug)
-    .filter((slug): slug is string => !!slug);
-    
-  if (devToolsPaths.length > 0) {
-    languageSets.push({
-      label: "Developer Tools",
-      description: "Documentation for development tools, MCP server, and local development.",
-      paths: devToolsPaths
-    });
-  }
-
-  return languageSets;
+    return {
+      label: theme.label,
+      description: theme.description,
+      paths: [...new Set(paths)],
+    };
+  });
 }
 
 // Generate language sets from sidebar
 const LANGUAGE_SETS = createLanguageSetsFromSidebar();
+
+// Every page in the sidebar, in sidebar order. The per-language bundles are
+// built from this, not from the thematic sets, so a page that no theme happens
+// to cover still reaches an agent that fetches llms-<lang>.txt.
+const ALL_SIDEBAR_PATHS: string[] = [
+  ...new Set(extractPathsFromSidebar(getDocsSidebar() as SidebarItem[])),
+];
+
+function setFilename(label: string, lang: Language): string {
+  return `${label.toLowerCase().replace(/\s+/g, '-')}-${lang}.txt`;
+}
 
 type Language = 'js' | 'go' | 'dart' | 'python';
 
@@ -160,10 +168,11 @@ function generateLanguageSpecificContent(docs: ProcessedDocument[], language: La
 
   let content = `# Genkit Documentation - ${languageNames[language]}\n\n`;
   content += `> Open-source GenAI toolkit for ${languageNames[language]}.\n\n`;
+  content += `> This file is every ${languageNames[language]} documentation page, in sidebar order.\n\n`;
 
-  // Get all unique paths from all language sets
-  const allPaths = [...new Set(LANGUAGE_SETS.flatMap(set => set.paths))];
-  
+  // Every page that supports this language, in sidebar order.
+  const allPaths = ALL_SIDEBAR_PATHS;
+
   for (const docPath of allPaths) {
     const doc = docs.find(d => d.slug === docPath);
     if (doc && doc.content[language] && doc.supportedLanguages.includes(language)) {
@@ -208,9 +217,8 @@ function generateFullDocumentation(docs: ProcessedDocument[]): string {
   content += `> Open-source GenAI toolkit for JS, Go, Dart, and Python.\n`;
   content += `> This is the complete unfiltered documentation (primarily for internal use).\n\n`;
 
-  // Get all unique paths from all language sets and sort them
-  const allPaths = [...new Set(LANGUAGE_SETS.flatMap(set => set.paths))].sort();
-  
+  const allPaths = [...ALL_SIDEBAR_PATHS].sort();
+
   for (const docPath of allPaths) {
     const doc = docs.find(d => d.slug === docPath);
     if (doc) {
@@ -232,56 +240,73 @@ function generateFullDocumentation(docs: ProcessedDocument[]): string {
   return content;
 }
 
-function generateMainLlmsTxt(): string {
-  const content = `# Genkit
+const LANGUAGE_NAMES: Record<Language, string> = {
+  js: 'JavaScript/TypeScript',
+  go: 'Go',
+  dart: 'Dart',
+  python: 'Python',
+};
+
+/**
+ * Builds llms.txt from the bundles that were actually written, so the index can
+ * never advertise a file that does not exist. `written` maps each language to
+ * the thematic sets that produced content for it.
+ */
+function generateMainLlmsTxt(written: Map<Language, LanguageSet[]>): string {
+  const languages: Language[] = ['js', 'go', 'dart', 'python'];
+
+  let content = `# Genkit
 
 > Open-source GenAI toolkit for JS, Go, Dart, and Python.
 
 ## Documentation Sets
 
-- [JavaScript documentation](https://genkit.dev/llms-js.txt): Genkit documentation focused on JavaScript/TypeScript
-- [Go documentation](https://genkit.dev/llms-go.txt): Genkit documentation focused on Go
-- [Python documentation](https://genkit.dev/llms-python.txt): Genkit documentation focused on Python
-- [Dart documentation](https://genkit.dev/llms-dart.txt): Genkit documentation focused on Dart
+Each of these is the complete documentation for one language, in sidebar order.
+
+`;
+
+  for (const lang of languages) {
+    content += `- [${LANGUAGE_NAMES[lang]} documentation](https://genkit.dev/llms-${lang}.txt): every Genkit ${LANGUAGE_NAMES[lang]} page in one file\n`;
+  }
+
+  content += `
+## Single Pages
+
+Every documentation page is also served as markdown. Append \`.md\` to any docs
+URL to fetch just that page:
+
+- \`https://genkit.dev/docs/go/flows.md\` — the Go rendering of the Flows page
+- \`https://genkit.dev/docs/js/flows.md\` — the JavaScript rendering of the same page
+
+Use these when you know which page you need; use the language bundles above when
+you do not.
+
+## API Rules For Coding Agents
+
+Condensed, opinionated rules for writing Genkit code, suitable for dropping into
+an agent's system prompt or rules file:
+
+- [Genkit Go API rules](https://genkit.dev/GENKIT.go.md)
+- [Genkit JavaScript API rules](https://genkit.dev/GENKIT.js.md)
 
 ### Language-Specific Thematic Sets
 
-#### JavaScript
-- [Building AI Workflows - JS](https://genkit.dev/_llms-txt/building-ai-workflows-js.txt): Guidance on how to generate content and interact with LLM and image models using Genkit in JavaScript.
-- [Deploying AI Workflows - JS](https://genkit.dev/_llms-txt/deploying-ai-workflows-js.txt): Guidance on how to deploy Genkit code to various environments using JavaScript.
-- [Observing AI Workflows - JS](https://genkit.dev/_llms-txt/observing-ai-workflows-js.txt): Guidance about Genkit's various observability features in JavaScript.
-- [Writing Plugins - JS](https://genkit.dev/_llms-txt/writing-plugins-js.txt): Guidance about how to author plugins for Genkit in JavaScript.
-- [AI Providers - JS](https://genkit.dev/_llms-txt/ai-providers-js.txt): Provider-specific documentation for AI model providers in JavaScript.
-- [Vector Databases - JS](https://genkit.dev/_llms-txt/vector-databases-js.txt): Documentation for vector database integrations in JavaScript.
+Smaller bundles for one topic in one language. Only the combinations that have
+content are listed.
 
-#### Go
-- [Building AI Workflows - Go](https://genkit.dev/_llms-txt/building-ai-workflows-go.txt): Guidance on how to generate content and interact with LLM and image models using Genkit in Go.
-- [Deploying AI Workflows - Go](https://genkit.dev/_llms-txt/deploying-ai-workflows-go.txt): Guidance on how to deploy Genkit code to various environments using Go.
-- [Observing AI Workflows - Go](https://genkit.dev/_llms-txt/observing-ai-workflows-go.txt): Guidance about Genkit's various observability features in Go.
-- [Writing Plugins - Go](https://genkit.dev/_llms-txt/writing-plugins-go.txt): Guidance about how to author plugins for Genkit in Go.
-- [AI Providers - Go](https://genkit.dev/_llms-txt/ai-providers-go.txt): Provider-specific documentation for AI model providers in Go.
-- [Vector Databases - Go](https://genkit.dev/_llms-txt/vector-databases-go.txt): Documentation for vector database integrations in Go.
+`;
 
-#### Python
-- [Building AI Workflows - Python](https://genkit.dev/_llms-txt/building-ai-workflows-python.txt): Guidance on how to generate content and interact with LLM and image models using Genkit in Python.
-- [Deploying AI Workflows - Python](https://genkit.dev/_llms-txt/deploying-ai-workflows-python.txt): Guidance on how to deploy Genkit code to various environments using Python.
-- [Observing AI Workflows - Python](https://genkit.dev/_llms-txt/observing-ai-workflows-python.txt): Guidance about Genkit's various observability features in Python.
-- [Writing Plugins - Python](https://genkit.dev/_llms-txt/writing-plugins-python.txt): Guidance about how to author plugins for Genkit in Python.
-- [AI Providers - Python](https://genkit.dev/_llms-txt/ai-providers-python.txt): Provider-specific documentation for AI model providers in Python.
-- [Vector Databases - Python](https://genkit.dev/_llms-txt/vector-databases-python.txt): Documentation for vector database integrations in Python.
+  for (const lang of languages) {
+    const sets = written.get(lang) ?? [];
+    if (sets.length === 0) continue;
+    content += `#### ${LANGUAGE_NAMES[lang]}\n`;
+    for (const set of sets) {
+      content += `- [${set.label} - ${LANGUAGE_NAMES[lang]}](https://genkit.dev/_llms-txt/${setFilename(set.label, lang)}): ${set.description}\n`;
+    }
+    content += `\n`;
+  }
 
-#### Dart
-- [Building AI Workflows - Dart](https://genkit.dev/_llms-txt/building-ai-workflows-dart.txt): Guidance on how to generate content and interact with LLM and image models using Genkit in Dart.
-- [Deploying AI Workflows - Dart](https://genkit.dev/_llms-txt/deploying-ai-workflows-dart.txt): Guidance on how to deploy Genkit code to various environments using Dart.
-- [Observing AI Workflows - Dart](https://genkit.dev/_llms-txt/observing-ai-workflows-dart.txt): Guidance about Genkit's various observability features in Dart.
-- [Writing Plugins - Dart](https://genkit.dev/_llms-txt/writing-plugins-dart.txt): Guidance about how to author plugins for Genkit in Dart.
-- [AI Providers - Dart](https://genkit.dev/_llms-txt/ai-providers-dart.txt): Provider-specific documentation for AI model providers in Dart.
-- [Vector Databases - Dart](https://genkit.dev/_llms-txt/vector-databases-dart.txt): Documentation for vector database integrations in Dart.
-
-### Developer Tools
-- [Developer Tools](https://genkit.dev/_llms-txt/devtools.txt): Documentation for development tools, MCP server, and local development.
-
-## Notes
+  content += `## Notes
 
 - Language-specific versions filter content to show only relevant examples and instructions for that language
 - The content is automatically generated from the same source as the official documentation
@@ -305,11 +330,6 @@ export async function generateLlmsDirectly(): Promise<void> {
   const docs = await getAllProcessedDocuments();
   console.log(`Processed ${docs.length} documents`);
   
-  // Generate main llms.txt
-  const mainContent = generateMainLlmsTxt();
-  await writeFile(path.join(outputDir, 'llms.txt'), mainContent);
-  console.log('Generated main llms.txt');
-  
   // Generate complete unfiltered documentation (llms-full.txt)
   console.log('Generating complete unfiltered documentation...');
   const fullContent = generateFullDocumentation(docs);
@@ -326,26 +346,33 @@ export async function generateLlmsDirectly(): Promise<void> {
     console.log(`Generated llms-${lang}.txt`);
   }
   
-  // Generate language-specific thematic sets
+  // Generate language-specific thematic sets. A set with no pages for a language
+  // is skipped rather than written empty, and only the sets actually written are
+  // advertised in llms.txt.
+  const written = new Map<Language, LanguageSet[]>();
   for (const lang of languages) {
-    console.log(`Generating thematic sets for ${lang}...`);
+    const producedForLang: LanguageSet[] = [];
     for (const set of LANGUAGE_SETS) {
+      const pageCount = set.paths.filter((p) => {
+        const doc = docs.find((d) => d.slug === p);
+        return !!doc && !!doc.content[lang] && doc.supportedLanguages.includes(lang);
+      }).length;
+      if (pageCount === 0) {
+        console.log(`  skipping ${setFilename(set.label, lang)} (no ${lang} pages)`);
+        continue;
+      }
       const content = generateLanguageSpecificSet(docs, set, lang);
-      const filename = `${set.label.toLowerCase().replace(/\s+/g, '-')}-${lang}.txt`;
-      await writeFile(path.join(llmsTxtDir, filename), content);
+      await writeFile(path.join(llmsTxtDir, setFilename(set.label, lang)), content);
+      producedForLang.push(set);
     }
-    console.log(`Generated thematic sets for ${lang}`);
+    written.set(lang, producedForLang);
+    console.log(`Generated ${producedForLang.length} thematic sets for ${lang}`);
   }
-  
-  // Generate developer tools (language-agnostic, use js as base)
-  const devToolsSet = LANGUAGE_SETS.find(s => s.label === 'Developer Tools');
-  if (devToolsSet) {
-    console.log('Generating developer tools documentation...');
-    const content = generateLanguageSpecificSet(docs, devToolsSet, 'js');
-    await writeFile(path.join(llmsTxtDir, 'devtools.txt'), content);
-    console.log('Generated devtools.txt');
-  }
-  
+
+  // llms.txt is written last so it can list exactly what exists.
+  await writeFile(path.join(outputDir, 'llms.txt'), generateMainLlmsTxt(written));
+  console.log('Generated main llms.txt');
+
   console.log('LLMs.txt generation from source files complete!');
 }
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -124,6 +124,10 @@ const DOCS_SIDEBAR = [
       { label: "Tool calling", slug: "docs/tool-calling" },
       { label: "Prompt templating", slug: "docs/dotprompt" },
       { label: "Runtime context", slug: "docs/context" },
+      {
+        label: "Concurrency and lifecycle",
+        slug: "docs/concurrency",
+      },
       { label: "Middleware", slug: "docs/middleware" },
       { label: "Agentic patterns", slug: "docs/agentic-patterns" },
       { label: "Interrupts", slug: "docs/interrupts" },

--- a/src/utils/docs-link-routing.ts
+++ b/src/utils/docs-link-routing.ts
@@ -327,6 +327,11 @@ type RewriteOptions = {
   context?: string;
   warnOnUnresolved?: boolean;
   warnOnCrossLanguageTargets?: boolean;
+  /**
+   * Rewrite links that carry a fragment (`/docs/models#structured-output`).
+   * Defaults to true: `resolveDocsTarget` preserves the fragment, so skipping
+   * these left anchored neutral links unresolved on every language page.
+   */
   rewriteHashLinks?: boolean;
 };
 
@@ -340,7 +345,7 @@ export function rewriteInternalDocsLinks(
   const crossLanguageWarnings: string[] = [];
   const warnUnresolved = Boolean(options.warnOnUnresolved);
   const warnOnCrossLanguageTargets = Boolean(options.warnOnCrossLanguageTargets);
-  const rewriteHashLinks = Boolean(options.rewriteHashLinks);
+  const rewriteHashLinks = options.rewriteHashLinks !== false;
 
   const rewriteIfNeeded = (originalUrl: string): string => {
     const parsed = parseDocsUrl(originalUrl);


### PR DESCRIPTION
Fixes defects found by reading the Go documentation as a new user would, with no access to the SDK source, then building applications from it. Every finding was afterwards checked against the real API with `go doc` and a compiler harness; every Go snippet added or changed here type-checks against the local module, and the testing and authorization examples were run.

## Four sidebar sections were empty for Go

The sidebar advertised Runtime context, Testing, and Authorization. A Go reader clicked and got a JavaScript page. All three were documentation gaps, not feature gaps: `core.WithActionContext`, `genkit.WithContextProviders`, and fake models via `genkit.DefineModelAction` already shipped and were described nowhere.

- `context.mdx`, `testing.mdx`, `deployment/authorization.mdx` gain Go sections.
- New `concurrency.mdx` states the contract nothing stated: one instance per process is safe to share, **tool calls in a turn run concurrently**, deadlines reach the provider, abandoned streams leak nothing, `server.Start` already drains on SIGTERM, and `googlecloud.FlushMetrics` exists.

## Code that does not compile

`integrations/cloud-firestore.mdx` used `EmbedderName` and `TopK` on `firebase.RetrieverOptions`; neither field exists, and the page's own reference section listed the real ones. `dotprompt.mdx` typed `TopK` and `MaxOutputTokens` as `*int32`; they are `*float32` and `int32`. `model-context-protocol.mdx` called `client.GetTool`, which does not exist, and documented two of the three transports, omitting the Streamable HTTP one that MCP servers actually speak. Ten of eleven agents pages showed `genkit.Init` without `genkit.WithExperimental()`, so every snippet panicked at startup. `deployment/cloud-run.mdx` ran `go mod get`. `deployment/any-platform.mdx` bound `127.0.0.1` inside a container.

Snippets failing to type-check for a real reason: 21 before, 2 after.

## One inverted security statement

`integrations/google-cloud.mdx` said `DisableLoggingInputAndOutput: true` "disables PII redaction and preserves inputs/outputs". The source says `logInputAndOutput: !opts.DisableLoggingInputAndOutput`. A reader wanting prompts kept out of Cloud Logging would have left the flag alone.

## The machine-readable layer was broken

`llms.txt` advertised 25 bundles and 17 returned 404. `llms-go.txt` held five pages, all deployment: no flows, models, tools, prompts, or agents. `generate-llms-direct.ts` matched sidebar labels that no longer exist ("AI Providers" against "Model providers"), so six of eight themes produced nothing while a hardcoded index advertised them.

The generator now names real sections and **fails the build** on a stale reference, adds a Full-stack agents theme, builds per-language bundles from the whole sidebar, and emits `llms.txt` from the files actually written. `llms-go.txt` goes from 17 KB to 1.2 MB; advertised 404s go from 17 to 0.

Separately, `rewriteInternalDocsLinks` skipped any URL containing `#`, so anchored neutral links were never resolved to the reader's language. Fixed for all four languages; broken internal links in the Go rendering go from 7 to 0.

## Not addressed

- **The fragment style stands.** 67% of Go fences use a Genkit package they never import, and that ratio did not move: new snippets follow the same house style. The thirteen pages that showed no import block at all now have one, which helps a reader scrolling but not an assistant retrieving a single fence. That needs a convention, not more point edits.
- **No cookbook, migration guide, architecture page, or safety page.** All four are things peer SDKs treat as mandatory, and all four are new work rather than fixes.
- **`plugins/weaviate` is still undocumented**, with zero mentions across 83 Go pages.
- **`public/GENKIT.js.md` still claims v1.20.0** against a 1.41.0 SDK. I corrected the Go file's stamp and left the JavaScript one alone as out of scope.

Sibling PR in `genkit-ai/genkit` fixes the godoc examples this documentation points readers at.
