### PR TITLE
docs: update Gemini model references to Gemini 3.8 Flash and prune older models

### DIFF
--- a/src/content/docs/docs/integrations/google-genai.mdx
+++ b/src/content/docs/docs/integrations/google-genai.mdx
@@ -72,23 +72,13 @@ You can create models that call the Google Generative AI API. The models support
 
 ### Available Models
 
-**Gemini 3+ Series** - Latest experimental models with state-of-the-art reasoning:
+**Gemini 3 Series** - Latest models with state-of-the-art reasoning and multimodal capabilities:
 
-- `gemini-3.5-flash` - Fast and efficient for most use cases
-- `gemini-3.1-pro-preview` - Preview of the most capable model for complex tasks
-- `gemini-3.1-pro-preview-customtools` - Model tuned for best custom tools support
-- `gemini-3.1-flash-image` - Fast and efficient image generation
-- `gemini-3.1-flash-lite` - Lightweight version for simple tasks
-- `gemini-3.1-flash-lite-preview` - Preview of the lightweight model
-- `gemini-3-flash-preview` - Fast and intelligent model for high-volume tasks
-- `gemini-3-pro-image` - Supports image generation outputs
-
-**Gemini 2.5 Series** - Latest stable models with advanced reasoning and multimodal capabilities:
-
-- `gemini-2.5-pro` - Most capable stable model for complex tasks
-- `gemini-2.5-flash` - Fast and efficient for most use cases
-- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
-- `gemini-2.5-flash-image` - Supports image generation outputs
+- `gemini-3.8-flash` - Most intelligent Flash model, engineered for complex reasoning, coding, and agentic workflows
+- `gemini-3.1-pro-preview` - Preview of the most capable model for complex reasoning and problem solving
+- `gemini-3.5-flash-lite` - Fastest, most cost-effective model for high-throughput execution
+- `gemini-3.1-flash-image` - Fast and efficient image generation and editing
+- `gemini-3-pro-image` - State-of-the-art image generation and editing for complex visual tasks
 
 **Gemma 4 Series** - Open models for various use cases:
 
@@ -487,7 +477,7 @@ while Genkit tools are provided in the top-level `tools` property.
 // const getWeather = ai.defineTool(...);
 
 const response = await ai.generate({
-  model: googleAI.model('gemini-3-flash-preview'),
+  model: googleAI.model('gemini-flash-latest'),
   prompt:
     'What is the southernmost city in Canada? What is the weather like there today?',
   config: {
@@ -523,7 +513,7 @@ The following configuration options are available for code execution:
 
 ### Generating Text and Images (Nano Banana)
 
-Some Gemini models (like `gemini-3.1-flash-image`, `gemini-3-pro-image`, `gemini-2.5-flash-image`) can output images natively alongside text:
+Some Gemini models (like `gemini-3.1-flash-image`, `gemini-3-pro-image`) can output images natively alongside text:
 
 ```typescript
 const response = await ai.generate({
@@ -1205,6 +1195,7 @@ The plugin registers no models at initialization. A model ID resolves when a req
 - `gemini-2.5-pro`
 - `gemini-omni-flash`
 - `gemini-3-flash-preview`
+- `gemini-3.8-flash`
 - `gemini-3.7-flash`
 - `gemini-3.6-flash`
 - `gemini-3.5-flash`
@@ -1680,17 +1671,13 @@ You can create models that call the Google Generative AI API. The models support
 
 ### Available Models
 
-**Gemini 3 Series** - Latest experimental models with state-of-the-art reasoning:
+**Gemini 3 Series** - Latest models with state-of-the-art reasoning:
 
-- `gemini-3-pro-preview`
-- `gemini-3-flash-preview`
+- `gemini-3.8-flash`
+- `gemini-3.1-pro-preview`
+- `gemini-3.5-flash-lite`
+- `gemini-3.1-flash-image`
 - `gemini-3-pro-image`
-
-**Gemini 2.5 Series** - Latest stable models:
-
-- `gemini-2.5-pro`
-- `gemini-2.5-flash`
-- `gemini-2.5-flash-lite`
 
 **Gemma 3 Series** - Open models:
 
@@ -1999,22 +1986,13 @@ This is useful for multi-tenant apps or routing requests to different keys. Mode
 
 ### Available Models
 
-**Gemini 3 Series** - Latest experimental models:
+**Gemini 3 Series** - Latest models with state-of-the-art reasoning and multimodal capabilities:
 
-- `gemini-3-pro-preview` - Most capable model for complex tasks
-- `gemini-3-flash-preview` - Fast and intelligent for high-volume tasks
+- `gemini-3.8-flash` - Most intelligent Flash model, engineered for complex reasoning, coding, and agentic workflows
 - `gemini-3.1-pro-preview` - Preview of the most capable model for complex tasks
-- `gemini-3.1-pro-preview-customtools` - Tuned for best custom tools support
-- `gemini-3.1-flash-lite-preview` - Preview of the lightweight model
-- `gemini-3.1-flash-image` - Fast and efficient image generation
-- `gemini-3.1-flash-image-preview` - Preview of the flash image model
-- `gemini-3-pro-image` - Supports image generation outputs
-
-**Gemini 2.5 Series** - Stable models with advanced reasoning:
-
-- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
-- `gemini-2.5-flash` - Fast and efficient for most use cases
-- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
+- `gemini-3.5-flash-lite` - Fastest, most cost-effective model for high-throughput execution
+- `gemini-3.1-flash-image` - Fast and efficient image generation and editing
+- `gemini-3-pro-image` - State-of-the-art image generation and editing for complex visual tasks
 
 ### Basic Usage
 

--- a/src/content/docs/docs/integrations/vertex-ai.mdx
+++ b/src/content/docs/docs/integrations/vertex-ai.mdx
@@ -174,17 +174,13 @@ _Note: When using Express Mode, you do not provide `projectId` and `location` in
 
 The following Gemini models are registered for use with the Vertex AI plugin:
 
-**Gemini 3+ Series:**
-- `gemini-3.5-flash`
-- `gemini-3.1-pro-preview`
-- `gemini-3.1-flash-lite-preview`
-- `gemini-3-flash-preview`
-- `gemini-3.1-flash-image`
+**Gemini 3 Series** - Latest models with state-of-the-art reasoning and multimodal capabilities:
 
-**Gemini 2.5 Series:**
-- `gemini-2.5-pro`
-- `gemini-2.5-flash`
-- `gemini-2.5-flash-lite`
+- `gemini-3.8-flash` - Most intelligent Flash model, engineered for complex reasoning, coding, and agentic workflows
+- `gemini-3.1-pro-preview` - Preview of the most capable model for complex reasoning and problem solving
+- `gemini-3.5-flash-lite` - Fastest, most cost-effective model for high-throughput execution
+- `gemini-3.1-flash-image` - Fast and efficient image generation and editing
+- `gemini-3-pro-image` - State-of-the-art image generation and editing for complex visual tasks
 
 ### Basic Usage
 
@@ -831,6 +827,7 @@ The plugin registers no models at initialization. A model ID resolves when a req
 - `gemini-2.5-pro`
 - `gemini-omni-flash-preview`
 - `gemini-3-flash-preview`
+- `gemini-3.8-flash`
 - `gemini-3.7-flash`
 - `gemini-3.6-flash`
 - `gemini-3.5-flash`
@@ -1094,20 +1091,13 @@ _Note: When using Express Mode, you typically omit `project` and `location` on `
 
 ### Available Models
 
-**Gemini 3+ Series** - Latest models with state-of-the-art reasoning:
+**Gemini 3 Series** - Latest models with state-of-the-art reasoning and multimodal capabilities:
 
-- `gemini-3.5-flash` - Fast and efficient for most use cases
-- `gemini-3.1-pro-preview` - Preview of the most capable model for complex tasks
-- `gemini-3.1-flash-lite` - Lightweight version for simple tasks
-- `gemini-3.1-flash-image` - Fast and efficient image generation
-- `gemini-3-pro-image` - Supports image generation outputs
-- `gemini-3-flash-preview` - Fast and intelligent for high-volume tasks
-
-**Gemini 2.5 Series** - Stable models with advanced reasoning:
-
-- `gemini-2.5-pro` - Most advanced stable model for complex tasks, with deep reasoning and coding
-- `gemini-2.5-flash` - Fast and efficient for most use cases
-- `gemini-2.5-flash-lite` - Lightweight version for simple tasks
+- `gemini-3.8-flash` - Most intelligent Flash model, engineered for complex reasoning, coding, and agentic workflows
+- `gemini-3.1-pro-preview` - Preview of the most capable model for complex reasoning and problem solving
+- `gemini-3.5-flash-lite` - Fastest, most cost-effective model for high-throughput execution
+- `gemini-3.1-flash-image` - Fast and efficient image generation and editing
+- `gemini-3-pro-image` - State-of-the-art image generation and editing for complex visual tasks
 
 ### Basic Usage
 
@@ -1271,7 +1261,7 @@ The Vertex AI Genkit plugin supports **Context Caching**, which allows models to
 
 #### How to Use Context Caching
 
-To enable context caching, ensure your model supports it. For example, `gemini-3-flash-preview` is a generation 3 model that supports context caching. Note that context caching cannot be combined with tool calls or system prompts in the same request.
+To enable context caching, ensure your model supports it. For example, `gemini-3.8-flash` is a generation 3 model that supports context caching. Note that context caching cannot be combined with tool calls or system prompts in the same request.
 
 You can define a caching mechanism in your application like this:
 
@@ -1300,7 +1290,7 @@ llm_response = await ai.generate(
             },
         ),
     ],
-    model='vertexai/gemini-3-flash-preview',
+    model='vertexai/gemini-3.8-flash',
     prompt="Describe Pierre's transformation throughout the novel.",
 )
 ```
@@ -1338,12 +1328,12 @@ llm_response = await ai.generate(
             },
         ),
     ],
-    model='vertexai/gemini-3-flash-preview',
+    model='vertexai/gemini-3.8-flash',
     prompt='Analyze the relationship between Pierre and Natasha.',
 )
 ```
 
-**Supported models**: `gemini-3-flash-preview`
+**Supported models**: `gemini-3.8-flash`
 
 ### Model Garden Integration
 

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1095,6 +1095,7 @@ For production workloads where consistent behavior is desired, you can specify a
 ```go
 resp, err := genkit.Generate(ctx, g,
 	ai.WithModelName("googleai/gemini-3.7-flash"),
+	ai.WithModelName("googleai/gemini-3.8-flash"),
 	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
 )
 ```

--- a/src/content/docs/docs/models.mdx
+++ b/src/content/docs/docs/models.mdx
@@ -1094,7 +1094,6 @@ For production workloads where consistent behavior is desired, you can specify a
 
 ```go
 resp, err := genkit.Generate(ctx, g,
-	ai.WithModelName("googleai/gemini-3.7-flash"),
 	ai.WithModelName("googleai/gemini-3.8-flash"),
 	ai.WithPrompt("Invent a menu item for a pirate themed restaurant."),
 )

--- a/src/content/docs/docs/tutorials/chat-with-pdf.mdx
+++ b/src/content/docs/docs/tutorials/chat-with-pdf.mdx
@@ -105,6 +105,7 @@ import { createInterface } from 'node:readline/promises';
 ### 3. Configure Genkit and the default model
 
 Add the following lines to configure Genkit and set Gemini 2.5 Flash as the
+Add the following lines to configure Genkit and set the latest Gemini Flash model as the
 default model.
 
 ```typescript

--- a/src/content/docs/docs/tutorials/chat-with-pdf.mdx
+++ b/src/content/docs/docs/tutorials/chat-with-pdf.mdx
@@ -104,7 +104,6 @@ import { createInterface } from 'node:readline/promises';
 
 ### 3. Configure Genkit and the default model
 
-Add the following lines to configure Genkit and set Gemini 2.5 Flash as the
 Add the following lines to configure Genkit and set the latest Gemini Flash model as the
 default model.
 

--- a/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
+++ b/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
@@ -90,6 +90,7 @@ import { genkit } from 'genkit';
 ### 3. Configure Genkit and the default model
 
 Add the following lines to configure Genkit and set Gemini 2.0 Flash as the
+Add the following lines to configure Genkit and set the latest Gemini Flash model as the
 default model.
 
 ```typescript

--- a/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
+++ b/src/content/docs/docs/tutorials/summarize-youtube-videos.mdx
@@ -89,7 +89,6 @@ import { genkit } from 'genkit';
 
 ### 3. Configure Genkit and the default model
 
-Add the following lines to configure Genkit and set Gemini 2.0 Flash as the
 Add the following lines to configure Genkit and set the latest Gemini Flash model as the
 default model.
 


### PR DESCRIPTION
## Summary

- Updates version-specific references of Gemini Flash to **Gemini 3.8 Flash** (`gemini-3.8-flash`) across the documentation.
- Updates the **Google Gen AI** (`google-genai.mdx`) and **Vertex AI** (`vertex-ai.mdx`) integration guides against current official models catalogs:
  - Prunes deprecated Gemini 2.5 series models.
  - Prunes outdated intermediate models (e.g. `gemini-3.5-flash`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`).
  - Retains the active, curated Gemini 3 series (`gemini-3.8-flash`, `gemini-3.1-pro-preview`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-image`, `gemini-3-pro-image`).
- Updates tutorial prose in `chat-with-pdf.mdx` and `summarize-youtube-videos.mdx` to reflect setting the latest Gemini Flash model matching the code snippets.
- Updates context caching sample snippets in `vertex-ai.mdx` to `gemini-3.8-flash`.