### PR TITLE
docs(go): move A2UI to the `a2ui/exp` import path

### DIFF
--- a/src/content/docs/docs/agents/a2ui.mdx
+++ b/src/content/docs/docs/agents/a2ui.mdx
@@ -135,12 +135,14 @@ The `a2ui()` middleware accepts the following options:
 Add the A2UI plugin to your Go module:
 
 ```bash
-go get github.com/firebase/genkit/go/plugins/a2ui
+go get github.com/firebase/genkit/go/plugins/a2ui/exp
 ```
+
+The package declares itself `exp`, so these examples import it as `a2uix`, the same convention as `aix` and `genkitx`.
 
 ### Configure the agent
 
-Attach `&a2ui.Surfaces{}` with `ai.WithUse` to an agent's prompt or a generate call. When called without options, it defaults to the bundled **basic catalog**.
+Attach `&a2uix.Surfaces{}` with `ai.WithUse` to an agent's prompt or a generate call. When called without options, it defaults to the bundled **basic catalog**.
 
 The [`basic-middleware/a2ui`](https://github.com/genkit-ai/genkit/tree/main/go/samples/basic-middleware/a2ui) sample serves an agent configured with the middleware:
 
@@ -157,20 +159,17 @@ import (
 	"github.com/firebase/genkit/go/ai/exp/localstore"
 	"github.com/firebase/genkit/go/genkit"
 	genkitx "github.com/firebase/genkit/go/genkit/exp"
-	"github.com/firebase/genkit/go/plugins/a2ui"
+	a2uix "github.com/firebase/genkit/go/plugins/a2ui/exp"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
 	"github.com/firebase/genkit/go/plugins/middleware"
 )
 
 func main() {
 	ctx := context.Background()
-	g, err := genkit.Init(ctx,
+	g := genkit.Init(ctx,
 		genkit.WithExperimental(),
 		genkit.WithPlugins(&googlegenai.GoogleAI{}),
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	type WeatherInput struct {
 		City string `json:"city"`
@@ -200,7 +199,7 @@ func main() {
 			ai.WithModelName("googleai/gemini-flash-latest"),
 			ai.WithSystem("You are a helpful assistant that can render rich UI. Prefer a surface whenever a result is clearer shown than told."),
 			ai.WithTools(getWeather),
-			ai.WithUse(&middleware.Retry{MaxRetries: 5}, &a2ui.Surfaces{}),
+			ai.WithUse(&middleware.Retry{MaxRetries: 5}, &a2uix.Surfaces{}),
 		},
 		aix.WithSessionStore(localstore.NewInMemorySessionStore[any]()),
 	)
@@ -224,24 +223,24 @@ resp, err := genkit.Generate(ctx, g,
 	ai.WithModelName("googleai/gemini-flash-latest"),
 	ai.WithSystem("You help users. Render UI when it is clearer than prose."),
 	ai.WithPrompt("Show me the weather in Tokyo."),
-	ai.WithUse(&a2ui.Surfaces{}),
+	ai.WithUse(&a2uix.Surfaces{}),
 )
 if err != nil {
 	return err
 }
 
-for _, envelope := range a2ui.EnvelopesFromParts(resp.Message.Content) {
+for _, envelope := range a2uix.EnvelopesFromParts(resp.Message.Content) {
 	log.Println(envelope)
 }
 ```
 
-The middleware maintains streaming turn state. When pairing with middleware that re-invokes the model (such as `Retry` or `Fallback`), place them outside `Surfaces`: `ai.WithUse(&middleware.Retry{}, &a2ui.Surfaces{})` ensures each retry attempt gets a fresh A2UI turn.
+The middleware maintains streaming turn state. When pairing with middleware that re-invokes the model (such as `Retry` or `Fallback`), place them outside `Surfaces`: `ai.WithUse(&middleware.Retry{}, &a2uix.Surfaces{})` ensures each retry attempt gets a fresh A2UI turn.
 
-`a2ui.EnvelopesFromParts` extracts envelopes from any message or chunk content, while `a2ui.IsPart` reports whether a given part carries A2UI data.
+`a2uix.EnvelopesFromParts` extracts envelopes from any message or chunk content, while `a2uix.IsPart` reports whether a given part carries A2UI data.
 
 ### Options
 
-Every field of `a2ui.Surfaces` is per-call configuration:
+Every field of `a2uix.Surfaces` is per-call configuration:
 
 | Field          | Default      | Description                                                                                                                                                                            |
 | -------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -250,16 +249,16 @@ Every field of `a2ui.Surfaces` is per-call configuration:
 | `Instructions` | `"system"`   | Where the catalog's capabilities are injected. Set to `"none"` to omit prompt injection when managing instructions manually.                                                           |
 | `Validate`     | `"warn"`     | How malformed envelopes are handled: `"warn"` logs and drops the block; `"strict"` fails the call; `"off"` passes everything through. See [The trust boundary and security](#the-trust-boundary-and-security). |
 | `SurfaceID`    | a fresh UUID | A fixed surface ID to reuse for every surface, for a client that maintains a single live surface.                                                                                      |
-| `Version`      | `"v0.9"`     | The protocol version stamped on envelopes. Must be one of `a2ui.SupportedVersions`.                                                                                                    |
+| `Version`      | `"v0.9"`     | The protocol version stamped on envelopes. Must be one of `a2uix.SupportedVersions`.                                                                                                |
 
 ### Register as a plugin
 
-Passing `&a2ui.Surfaces{}` directly to `ai.WithUse` does not require registering a plugin. However, registering `&a2ui.A2UI{}` makes the middleware discoverable by name in the Developer UI and in `.prompt` files (`use: [a2ui]`):
+Passing `&a2uix.Surfaces{}` directly to `ai.WithUse` does not require registering a plugin. However, registering `&a2uix.A2UI{}` makes the middleware discoverable by name in the Developer UI and in `.prompt` files (`use: [a2ui]`):
 
 ```go
 g := genkit.Init(ctx,
 	genkit.WithExperimental(),
-	genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2ui.A2UI{}),
+	genkit.WithPlugins(&googlegenai.GoogleAI{}, &a2uix.A2UI{}),
 )
 ```
 
@@ -770,9 +769,9 @@ export const dashboardAgent = ai.defineAgent({
 Load a catalog from a JSON file with `LoadCatalogFile`, or construct a `Catalog` struct in memory and register it with `LoadCatalog`:
 
 ```go
-myCatalog := &a2ui.Catalog{
+myCatalog := &a2uix.Catalog{
 	ID: "https://example.com/catalogs/dashboard.json",
-	Components: []a2ui.CatalogComponent{
+	Components: []a2uix.CatalogComponent{
 		{
 			Name:        "MetricCard",
 			Description: "Displays a key metric with a title, numeric value, and trend indicator.",
@@ -780,7 +779,7 @@ myCatalog := &a2ui.Catalog{
 		},
 	},
 }
-if err := a2ui.LoadCatalog(g, myCatalog); err != nil {
+if err := a2uix.LoadCatalog(g, myCatalog); err != nil {
 	return err
 }
 ```
@@ -788,18 +787,21 @@ if err := a2ui.LoadCatalog(g, myCatalog); err != nil {
 Or from a file:
 
 ```go
-if err := a2ui.LoadCatalogFile(g, "./catalogs/dashboard.json"); err != nil {
+catalog, err := a2uix.LoadCatalogFile(g, "./catalogs/dashboard.json")
+if err != nil {
 	return err
 }
 ```
 
-Reference the registered catalog by ID in `a2ui.Surfaces`:
+`LoadCatalogFile` returns the parsed catalog, so `catalog.ID` is the key to reference it by.
+
+Reference the registered catalog by ID in `a2uix.Surfaces`:
 
 ```go
 resp, err := genkit.Generate(ctx, g,
 	ai.WithModelName("googleai/gemini-flash-latest"),
 	ai.WithPrompt("Show dashboard metrics."),
-	ai.WithUse(&a2ui.Surfaces{CatalogID: "https://example.com/catalogs/dashboard.json"}),
+	ai.WithUse(&a2uix.Surfaces{CatalogID: "https://example.com/catalogs/dashboard.json"}),
 )
 ```
 

--- a/src/content/docs/docs/api-stability.mdx
+++ b/src/content/docs/docs/api-stability.mdx
@@ -82,11 +82,11 @@ Running `go get github.com/firebase/genkit/go` records the dependency version in
 
 A few features ship ahead of that guarantee so you can build on them and send feedback while their shape is still settling. **Preview** is the name for this channel throughout the docs, and a page that carries a `:::caution[Preview]` admonition is in it. In code, the channel shows up two ways: the package suffix `exp` (or `x`), and the `genkit.WithExperimental()` opt-in. Each preview API may experience breaking changes in minor releases while its shape is stabilizing.
 
-Throughout these docs `genkitx` is an import alias for `github.com/firebase/genkit/go/genkit/exp`, and `aix` for `github.com/firebase/genkit/go/ai/exp`. Both packages declare themselves `exp`, so the aliases keep the two apart.
+Throughout these docs `genkitx` is an import alias for `github.com/firebase/genkit/go/genkit/exp`, `aix` for `github.com/firebase/genkit/go/ai/exp`, and `a2uix` for `github.com/firebase/genkit/go/plugins/a2ui/exp`. All three packages declare themselves `exp`, so the aliases keep them apart.
 
 - **Tools with a plain `context.Context` signature** (`github.com/firebase/genkit/go/ai/exp`, `.../ai/exp/tool`, `.../genkit/exp`): `genkitx.DefineTool` and `genkitx.DefineInterruptibleTool`, whose functions take a `context.Context` rather than an `*ai.ToolContext`, and whose interrupt payload is a typed value rather than a metadata map. They complement the stable [tool APIs](/docs/tool-calling) rather than replacing them.
 - **Agents** (`github.com/firebase/genkit/go/ai/exp`, `.../ai/exp/localstore`, `.../genkit/exp`, `.../plugins/middleware/exp`): the [agent](/docs/agents/overview) constructors, session stores, HTTP route builders, and the multi-agent, background-delegation, and artifact middleware.
-- **A2UI** (`github.com/firebase/genkit/go/plugins/a2ui`): the [generative UI](/docs/agents/a2ui) middleware that streams A2UI surfaces from a model to a browser.
+- **A2UI** (`github.com/firebase/genkit/go/plugins/a2ui/exp`): the [generative UI](/docs/agents/a2ui) middleware that streams A2UI surfaces from a model to a browser.
 - **[Durable streaming](/docs/durable-streaming)** (`github.com/firebase/genkit/go/core/x/streaming`, `.../plugins/firebase/exp`): the `StreamManager` API that lets a client reconnect to a stream by ID.
 
 The `genkit/exp` constructors require opting in. Pass `genkit.WithExperimental()` to `genkit.Init`, or they panic with a message pointing back to that option.

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -567,7 +567,7 @@ g := genkit.Init(ctx, genkit.WithPlugins(
 
 A `.prompt` reference such as `genkit-middleware/retry` resolves to the stable plugin; the experimental ones are named `genkit-middleware-exp/agents` and `genkit-middleware-exp/artifacts`. Being in preview, they may change in any minor release.
 
-A third package, `github.com/firebase/genkit/go/plugins/a2ui`, ships one middleware of its own: `a2ui.Surfaces` lets the model stream generative UI to a browser over the A2UI protocol, and `a2ui.A2UI` is the plugin that registers it by name. It is in preview too. See [Generative UI (A2UI)](/docs/agents/a2ui).
+A third package, `github.com/firebase/genkit/go/plugins/a2ui/exp`, ships one middleware of its own: `a2uix.Surfaces` lets the model stream generative UI to a browser over the A2UI protocol, and `a2uix.A2UI` is the plugin that registers it by name. It is in preview too. See [Generative UI (A2UI)](/docs/agents/a2ui).
 
 ## Building your own custom middleware
 


### PR DESCRIPTION
Follows [genkit-ai/genkit#6275](https://github.com/genkit-ai/genkit/pull/6275), which moves the Go A2UI plugin to `github.com/firebase/genkit/go/plugins/a2ui/exp` while it is in preview. Updates the path and the `a2uix` alias in the Go blocks of `agents/a2ui.mdx`, the preview list in `api-stability.mdx`, and the middleware page.

Fixes two snippets on the A2UI page that never compiled: `genkit.Init` returns one value rather than `(g, err)`, and `LoadCatalogFile` returns `(*Catalog, error)`. Every Go block on the page now vets against the SDK.