### PR TITLE
docs: update tool API to use return-based responses and interrupts

### DIFF
--- a/src/content/docs/docs/agentic-patterns.mdx
+++ b/src/content/docs/docs/agentic-patterns.mdx
@@ -785,7 +785,7 @@ final getWeather = ai.defineTool(
   outputSchema: .string(),
   fn: (input, _) async {
     // In a real app, you would call a weather API here.
-    return 'The weather in ${input.location} is 75°F and sunny.';
+    return .response('The weather in ${input.location} is 75°F and sunny.');
   },
 );
 
@@ -975,7 +975,7 @@ final menuRagTool = ai.defineTool(
       return w;
     }).toList();
 
-    if (queryWords.isEmpty) return [];
+    if (queryWords.isEmpty) return .response([]);
 
     final docs = menuItems.where((item) {
       final lowerItem = item.toLowerCase();
@@ -983,7 +983,7 @@ final menuRagTool = ai.defineTool(
       return queryWords.any((word) => lowerItem.contains(word));
     }).map((item) => DocumentData(content: [TextPart(text: item)])).toList();
 
-    return docs;
+    return .response(docs);
   },
 );
 
@@ -1442,7 +1442,7 @@ final webSearch = ai.defineTool(
   outputSchema: .string(),
   fn: (input, _) async {
     // In a real app, you would implement a web search API call here.
-    return 'You found search results for: ${input.query}';
+    return .response('You found search results for: ${input.query}');
   },
 );
 
@@ -1454,8 +1454,7 @@ final askUser = ai.defineTool(
   outputSchema: .string(),
   fn: (input, context) async {
     // This tool interrupts the flow to ask the user a question.
-    context.interrupt(input.question);
-    return ''; // Will not be reached after interrupt
+    return .interrupt(input.question);
   },
 );
 

--- a/src/content/docs/docs/agents/interrupts.mdx
+++ b/src/content/docs/docs/agents/interrupts.mdx
@@ -431,7 +431,7 @@ if input.Resume != nil {
 
 ## Define an interrupt
 
-In Genkit Dart, interrupts are modeled as tools that invoke `ctx.interrupt()` to pause execution and prompt the client for external validation or missing inputs.
+In Genkit Dart, interrupts are modeled as tools that return `.interrupt()` to pause execution and prompt the client for external validation or missing inputs.
 
 ```dart
 import 'package:genkit/genkit.dart';
@@ -452,7 +452,7 @@ final userApproval = ai.defineTool(
   description: 'Ask the user for approval before proceeding with a sensitive action.',
   inputSchema: UserApprovalInput.$schema,
   // No outputSchema needed: the output is provided by the client on resume
-  fn: (input, ctx) async => ctx.interrupt(),
+  fn: (input, ctx) async => .interrupt(),
 );
 
 final bankingAgent = ai.defineAgent(

--- a/src/content/docs/docs/agents/overview.mdx
+++ b/src/content/docs/docs/agents/overview.mdx
@@ -250,7 +250,7 @@ This makes the Dev UI a fast way to test conversational behavior, debug tool tur
 - [Serve over HTTP](/docs/agents/http) covers shelf route serving and `remoteAgent()`.
 - [Sessions and state](/docs/agents/state) covers stores, custom state, and functional state updates.
 - [Session stores](/docs/agents/session-stores) covers `InMemorySessionStore` and `FileSessionStore`.
-- [Interrupts](/docs/agents/interrupts) covers tool-based interrupts calling `ctx.interrupt()`.
+- [Interrupts](/docs/agents/interrupts) covers tool-based interrupts that return `.interrupt()`.
 - [Background execution](/docs/agents/background) covers detached background work (`detach`), polling, and aborting.
 - [Multi-agent delegation](/docs/agents/multi-agent) covers agent coordination using the `agents()` middleware.
 - [Custom orchestration](/docs/agents/custom-orchestration) covers `defineCustomAgent` and custom turn loops.

--- a/src/content/docs/docs/interrupts.mdx
+++ b/src/content/docs/docs/interrupts.mdx
@@ -1023,7 +1023,7 @@ interacting with an LLM:
 The most common kind of interrupt allows the LLM to request clarification from
 the user, for example by asking a multiple-choice question.
 
-For this use case, use the `ai.defineTool()` method and call `ctx.interrupt()`:
+For this use case, use the `ai.defineTool()` method and return `.interrupt()` from the tool function:
 
 ```dart
 import 'package:genkit/genkit.dart';
@@ -1042,10 +1042,8 @@ final askQuestion = ai.defineTool(
   description: 'Use this to ask the user a clarifying question',
   inputSchema: QuestionInput.$schema,
   outputSchema: .string(), // The expected user answer type
-  fn: (input, ctx) {
-    // Trigger an interrupt with the input data as metadata
-    ctx.interrupt(input);
-  },
+  // Trigger an interrupt with the input data as metadata.
+  fn: (input, ctx) => .interrupt(input),
 );
 ```
 
@@ -1136,6 +1134,7 @@ ai.defineTool(
   name: 'transfer_funds',
   description: 'transfer funds, requires user approval',
   inputSchema: ApprovalRequest.$schema,
+  outputSchema: .string(),
   fn: (input, ctx) async {
     // `ctx.resumed` is null on the first call and carries the client's
     // approval metadata when the tool is restarted.
@@ -1143,9 +1142,9 @@ ai.defineTool(
     final approved = resumed is Map && resumed['approved'] == true;
 
     if (!approved) {
-      ctx.interrupt(input);
+      return .interrupt(input);
     }
-    return 'Successfully transferred funds! Details: ${input.details}';
+    return .response('Successfully transferred funds! Details: ${input.details}');
   },
 );
 ```

--- a/src/content/docs/docs/middleware.mdx
+++ b/src/content/docs/docs/middleware.mdx
@@ -1411,7 +1411,7 @@ class LoggerMiddleware extends GenerateMiddleware {
 
 ### 3. Define the middleware and plugin
 
-Use `defineMiddleware` to link your schema and implementation, and expose it via a `GenkitPlugin`.
+Use `defineMiddleware` to link your schema and implementation, and expose it via a `GenkitPlugin`. The `create` callback receives the resolved `config` and a `GenerateMiddlewareContext` (`ctx`).
 
 ```dart
 class LoggerPlugin extends GenkitPlugin {
@@ -1419,14 +1419,59 @@ class LoggerPlugin extends GenkitPlugin {
   String get name => 'logger';
 
   @override
-  List middleware() => [
-    defineMiddleware(
+  List<GenerateMiddlewareDef> middleware() => [
+    defineMiddleware<LoggerOptions>(
       name: 'logger',
-      configSchema: LoggerOptions.schema,
-      create: ([LoggerOptions? config]) => LoggerMiddleware(
+      configSchema: LoggerOptions.$schema,
+      create: (config, ctx) => LoggerMiddleware(
         enableColor: config?.enableColor ?? false,
         maxLogLength: config?.maxLogLength ?? 1000,
       ),
+    ),
+  ];
+}
+```
+
+The `ctx` argument carries an ephemeral `GenkitAI` instance (`ctx.ai`) backed by the active registry. This lets a middleware run its own AI operations (`generate`, `generateStream`, `embed`) and resolve other registered actions at request time, which is useful for building guardrails, classifiers, or routers. For example, a safety middleware can screen a request with the model before letting it proceed:
+
+```dart
+class SafetyMiddleware extends GenerateMiddleware {
+  final GenkitAI ai;
+
+  SafetyMiddleware(this.ai);
+
+  @override
+  Future<GenerateResponseHelper> generate(
+    GenerateTurnState envelope,
+    ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    Future<GenerateResponseHelper> Function(
+      GenerateTurnState envelope,
+      ActionFnArg<ModelResponseChunk, GenerateActionOptions, void> ctx,
+    ) next,
+  ) async {
+    // Use the ephemeral GenkitAI to classify the request before proceeding.
+    final verdict = await ai.generate(
+      prompt: 'Reply "block" if this request is unsafe, otherwise "allow": '
+          '${envelope.request.messages.last.text}',
+    );
+    if (verdict.text.trim().toLowerCase().startsWith('block')) {
+      throw GenkitException('Request blocked by safety middleware.');
+    }
+    return next(envelope, ctx);
+  }
+}
+
+class SafetyPlugin extends GenkitPlugin {
+  @override
+  String get name => 'safety';
+
+  @override
+  List<GenerateMiddlewareDef> middleware() => [
+    defineMiddleware(
+      name: 'safety',
+      // `ctx.ai` is an ephemeral GenkitAI the middleware can use for its own
+      // generate/embed calls at request time.
+      create: (config, ctx) => SafetyMiddleware(ctx.ai),
     ),
   ];
 }

--- a/src/content/docs/docs/tool-calling.mdx
+++ b/src/content/docs/docs/tool-calling.mdx
@@ -1283,9 +1283,10 @@ void main() async {
     name: 'getWeather',
     description: 'Gets the current weather in a given location',
     inputSchema: WeatherInput.$schema,
+    outputSchema: .string(),
     fn: (input, _) async {
       // Simulate API call
-      return 'The current weather in ${input.location} is 63°F and sunny.';
+      return .response('The current weather in ${input.location} is 63°F and sunny.');
     },
   );
 }


### PR DESCRIPTION
Replace direct return values with `.response()` wrappers and change interrupt handling from `ctx.interrupt()` calls to returning `.interrupt()` from tool functions across Dart documentation examples.